### PR TITLE
fix: update getFileUrl to use domain end index for URL construction

### DIFF
--- a/examples/elysia-resolver.ts
+++ b/examples/elysia-resolver.ts
@@ -2,7 +2,7 @@ import { Elysia } from 'elysia'
 import { resolveDID, AbstractCrypto } from 'didwebvh-ts';
 import type { DIDDoc, SigningInput, SigningOutput, Verifier } from 'didwebvh-ts/types';
 
-import { verify } from '@stablelib/ed25519';
+import { verify as ed25519Verify } from '@stablelib/ed25519';
 
 class ElysiaVerifier extends AbstractCrypto implements Verifier {
   constructor(public readonly verificationMethod: {
@@ -21,7 +21,7 @@ class ElysiaVerifier extends AbstractCrypto implements Verifier {
 
   async verify(signature: Uint8Array, message: Uint8Array, publicKey: Uint8Array): Promise<boolean> {
     try {
-      return verify(publicKey, message, signature);
+      return ed25519Verify(publicKey, message, signature);
     } catch (error) {
       console.error('Ed25519 verification error:', error);
       return false;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -108,8 +108,9 @@ export const getBaseUrl = (id: string) => {
 
 export const getFileUrl = (id: string) => {
   const baseUrl = getBaseUrl(id);
-  const url = new URL(baseUrl);
-  if (url.pathname !== '/') {
+  const domainEndIndex = baseUrl.indexOf('/', baseUrl.indexOf('://') + 3);
+  
+  if (domainEndIndex !== -1) {
     return `${baseUrl}/did.jsonl`;
   }
   return `${baseUrl}/.well-known/did.jsonl`;


### PR DESCRIPTION
The current implementation doesn't work with react native so this is the first of possibly a few changes required to get it to work in that environment