### PR TITLE
feat: add paths support in DID creation and testing

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -119,6 +119,7 @@ export interface CreateDIDInterface {
   signer: Signer;
   updateKeys: string[];
   verificationMethods: VerificationMethod[];
+  paths?: string[];
   controller?: string;
   context?: string | string[] | object | object[];
   alsoKnownAs?: string[];

--- a/src/method_versions/method.v0.5.ts
+++ b/src/method_versions/method.v0.5.ts
@@ -17,7 +17,8 @@ export const createDID = async (options: CreateDIDInterface): Promise<{did: stri
   }
   
   const encodedDomain = encodeURIComponent(options.domain);
-  const controller = `did:${METHOD}:${PLACEHOLDER}:${encodedDomain}`;
+  const path = options.paths?.join(':');
+  const controller = `did:${METHOD}:${PLACEHOLDER}:${encodedDomain}${path ? `:${path}` : ''}`;
   const createdDate = createDate(options.created);
   let {doc} = await createDIDDoc({...options, controller});
   const params = {

--- a/src/method_versions/method.v1.0.ts
+++ b/src/method_versions/method.v1.0.ts
@@ -17,7 +17,8 @@ export const createDID = async (options: CreateDIDInterface): Promise<{did: stri
   }
   
   const encodedDomain = encodeURIComponent(options.domain);
-  const controller = `did:${METHOD}:${PLACEHOLDER}:${encodedDomain}`;
+  const path = options.paths?.join(':');
+  const controller = `did:${METHOD}:${PLACEHOLDER}:${encodedDomain}${path ? `:${path}` : ''}`;
   const createdDate = createDate(options.created);
   let {doc} = await createDIDDoc({...options, controller});
   const params = {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,13 +7,21 @@ import { createBuffer, bufferToString } from './utils/buffer';
 import { createMultihash, encodeBase58Btc, MultihashAlgorithm } from './utils/multiformats';
 import { createHash } from './utils/crypto';
 
+// Environment detection - treat React Native like a browser
+const isNodeEnvironment = typeof process !== 'undefined' && process.versions && process.versions.node && typeof window === 'undefined';
+
 let fsModule: typeof import('fs') | null = null;
-if (!config.isBrowser) {
-  fsModule = await import('node:fs');
+if (isNodeEnvironment) {
+  try {
+    fsModule = await import('node:fs');
+  } catch (error) {
+    console.warn('Failed to import node:fs, filesystem operations will not be available:', error);
+  }
 }
+
 const getFS = () => {
   if (!fsModule) {
-    throw new Error('Filesystem access is not available in this environment');
+    throw new Error('Filesystem access is not available in this environment (React Native, browser, or failed Node.js import)');
   }
   return fsModule;
 };
@@ -170,11 +178,11 @@ export async function fetchLogFromIdentifier(identifier: string, controlled: boo
         let text: string;
         if (typeof Bun !== 'undefined' && Bun.file) {
           text = (await Bun.file(logPath).text()).trim();
-        } else if (!config.isBrowser) {
+        } else if (isNodeEnvironment) {
           const fs = getFS();
           text = fs.readFileSync(logPath, 'utf8').trim();
         } else {
-          throw new Error('Local log retrieval not supported in browser');
+          throw new Error('Local log retrieval not supported in this environment');
         }
         if (!text) {
           return [];

--- a/test/paths.test.ts
+++ b/test/paths.test.ts
@@ -1,0 +1,158 @@
+import { describe, test, expect } from "bun:test";
+import { createDID } from "../src/method";
+import { generateTestVerificationMethod, createTestSigner, TestCryptoImplementation } from "./utils";
+
+process.env.IGNORE_ASSERTION_DOCUMENT_STATE_IS_VALID = 'true';
+
+describe("Paths feature", () => {
+  test("creates DID without paths (default behavior)", async () => {
+    const authKey = await generateTestVerificationMethod();
+    const verifier = new TestCryptoImplementation({ verificationMethod: authKey });
+    const { doc } = await createDID({
+      domain: 'example.com',
+      signer: createTestSigner(authKey),
+      updateKeys: [authKey.publicKeyMultibase!],
+      verificationMethods: [authKey],
+      verifier
+    });
+    
+    // Should only contain domain, no additional path components
+    const didParts = doc.id.split(':');
+    expect(didParts.length).toBe(4); // did:webvh:scid:domain
+    expect(didParts[3]).toBe('example.com');
+  });
+
+  test("creates DID with single path component", async () => {
+    const authKey = await generateTestVerificationMethod();
+    const verifier = new TestCryptoImplementation({ verificationMethod: authKey });
+    const { doc } = await createDID({
+      domain: 'example.com',
+      paths: ['api'],
+      signer: createTestSigner(authKey),
+      updateKeys: [authKey.publicKeyMultibase!],
+      verificationMethods: [authKey],
+      verifier
+    });
+    
+    // Should contain domain + single path component
+    const didParts = doc.id.split(':');
+    expect(didParts.length).toBe(5); // did:webvh:scid:domain:path
+    expect(didParts[3]).toBe('example.com');
+    expect(didParts[4]).toBe('api');
+  });
+
+  test("creates DID with multiple path components", async () => {
+    const authKey = await generateTestVerificationMethod();
+    const verifier = new TestCryptoImplementation({ verificationMethod: authKey });
+    const { doc } = await createDID({
+      domain: 'example.com',
+      paths: ['api', 'v1', 'users'],
+      signer: createTestSigner(authKey),
+      updateKeys: [authKey.publicKeyMultibase!],
+      verificationMethods: [authKey],
+      verifier
+    });
+    
+    // Should contain domain + multiple path components
+    const didParts = doc.id.split(':');
+    expect(didParts.length).toBe(7); // did:webvh:scid:domain:path1:path2:path3
+    expect(didParts[3]).toBe('example.com');
+    expect(didParts[4]).toBe('api');
+    expect(didParts[5]).toBe('v1');
+    expect(didParts[6]).toBe('users');
+  });
+
+  test("creates DID with empty paths array (should behave like no paths)", async () => {
+    const authKey = await generateTestVerificationMethod();
+    const verifier = new TestCryptoImplementation({ verificationMethod: authKey });
+    const { doc } = await createDID({
+      domain: 'example.com',
+      paths: [],
+      signer: createTestSigner(authKey),
+      updateKeys: [authKey.publicKeyMultibase!],
+      verificationMethods: [authKey],
+      verifier
+    });
+    
+    // Should only contain domain, no additional path components
+    const didParts = doc.id.split(':');
+    expect(didParts.length).toBe(4); // did:webvh:scid:domain
+    expect(didParts[3]).toBe('example.com');
+  });
+
+  test("creates DID with paths containing special characters", async () => {
+    const authKey = await generateTestVerificationMethod();
+    const verifier = new TestCryptoImplementation({ verificationMethod: authKey });
+    const { doc } = await createDID({
+      domain: 'example.com',
+      paths: ['path-with-dash', 'path_with_underscore', 'path.with.dots'],
+      signer: createTestSigner(authKey),
+      updateKeys: [authKey.publicKeyMultibase!],
+      verificationMethods: [authKey],
+      verifier
+    });
+    
+    // Should contain domain + path components with special characters
+    const didParts = doc.id.split(':');
+    expect(didParts.length).toBe(7); // did:webvh:scid:domain:path1:path2:path3
+    expect(didParts[3]).toBe('example.com');
+    expect(didParts[4]).toBe('path-with-dash');
+    expect(didParts[5]).toBe('path_with_underscore');
+    expect(didParts[6]).toBe('path.with.dots');
+  });
+
+  test("creates DID with domain requiring encoding and paths", async () => {
+    const authKey = await generateTestVerificationMethod();
+    const verifier = new TestCryptoImplementation({ verificationMethod: authKey });
+    const { doc } = await createDID({
+      domain: 'localhost:3000',
+      paths: ['api', 'health'],
+      signer: createTestSigner(authKey),
+      updateKeys: [authKey.publicKeyMultibase!],
+      verificationMethods: [authKey],
+      verifier
+    });
+    
+    // Should contain encoded domain + path components
+    const didParts = doc.id.split(':');
+    expect(didParts.length).toBe(6); // did:webvh:scid:domain:path1:path2
+    expect(didParts[3]).toBe('localhost%3A3000'); // domain should be encoded
+    expect(didParts[4]).toBe('api');
+    expect(didParts[5]).toBe('health');
+  });
+
+  test("controller field matches DID with paths", async () => {
+    const authKey = await generateTestVerificationMethod();
+    const verifier = new TestCryptoImplementation({ verificationMethod: authKey });
+    const { doc } = await createDID({
+      domain: 'example.com',
+      paths: ['api', 'v2'],
+      signer: createTestSigner(authKey),
+      updateKeys: [authKey.publicKeyMultibase!],
+      verificationMethods: [authKey],
+      verifier
+    });
+    
+    // Controller should match the DID ID
+    expect(doc.controller).toBe(doc.id);
+    expect(doc.controller).toContain('example.com:api:v2');
+  });
+
+  test("verification method IDs include paths", async () => {
+    const authKey = await generateTestVerificationMethod();
+    const verifier = new TestCryptoImplementation({ verificationMethod: authKey });
+    const { doc } = await createDID({
+      domain: 'example.com',
+      paths: ['secure', 'keys'],
+      signer: createTestSigner(authKey),
+      updateKeys: [authKey.publicKeyMultibase!],
+      verificationMethods: [authKey],
+      verifier
+    });
+    
+    // Verification method ID should include the paths in the DID
+    expect(doc.verificationMethod[0].id).toContain('example.com:secure:keys');
+    // Verify the ID starts with the correct DID prefix
+    expect(doc.verificationMethod[0].id).toStartWith(doc.id + '#');
+  });
+}); 


### PR DESCRIPTION
Updated the createDID function to construct the controller with the new paths, allowing for flexible DID structures. I was using the domain for paths before and it wasn't quite working correctly so this makes it more clear and easier to use.

I also updated some feature detection to be able to handle the lack of file system in react native.