### PR TITLE
fix: update DID without recalculating verification methods

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -402,30 +402,30 @@ export const normalizeVMs = (verificationMethod: VerificationMethod[] | undefine
   // First collect all VMs
   const vms = verificationMethod.map(vm => ({
     ...vm,
-    id: createVMID(vm, did)
+    id: vm.id ?? createVMID(vm, did)
   }));
   all.verificationMethod = vms;
 
   // Then handle relationships - default to authentication if no purpose is specified
   all.authentication = verificationMethod
     .filter(vm => !vm.purpose || vm.purpose === 'authentication')
-    .map(vm => createVMID(vm, did));
+    .map(vm => vm.id ?? createVMID(vm, did));
 
   all.assertionMethod = verificationMethod
     .filter(vm => vm.purpose === 'assertionMethod')
-    .map(vm => createVMID(vm, did));
+    .map(vm => vm.id ??createVMID(vm, did));
 
   all.keyAgreement = verificationMethod
     .filter(vm => vm.purpose === 'keyAgreement')
-    .map(vm => createVMID(vm, did));
+    .map(vm => vm.id ??createVMID(vm, did));
 
   all.capabilityDelegation = verificationMethod
     .filter(vm => vm.purpose === 'capabilityDelegation')
-    .map(vm => createVMID(vm, did));
+    .map(vm => vm.id ??createVMID(vm, did));
 
   all.capabilityInvocation = verificationMethod
     .filter(vm => vm.purpose === 'capabilityInvocation')
-    .map(vm => createVMID(vm, did));
+    .map(vm => vm.id ?? createVMID(vm, did));
 
   return all;
 };

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -70,7 +70,7 @@ export async function generateTestVerificationMethod(purpose: "authentication" |
     type: 'Multikey',
     publicKeyMultibase: publicKey,
     secretKeyMultibase: secretKey,
-    purpose,
+    purpose
   };
 }
 

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -61,15 +61,16 @@ export class MockFailingImplementation extends TestCryptoImplementation {
 }
 
 // Helper to generate verification method for tests
-export async function generateTestVerificationMethod(purpose: "authentication" | "assertionMethod" | "keyAgreement" | "capabilityInvocation" | "capabilityDelegation" = 'authentication'): Promise<VerificationMethod> {
+export async function generateTestVerificationMethod(purpose: "authentication" | "assertionMethod" | "keyAgreement" | "capabilityInvocation" | "capabilityDelegation" = 'authentication', id?: string): Promise<VerificationMethod> {
   const keyPair = crypto.generateKeyPair();
   const secretKey = multibaseEncode(new Uint8Array([0x80, 0x26, ...keyPair.secretKey]), MultibaseEncoding.BASE58_BTC);
   const publicKey = multibaseEncode(new Uint8Array([0xed, 0x01, ...keyPair.publicKey]), MultibaseEncoding.BASE58_BTC);
   return {
+    id,   
     type: 'Multikey',
     publicKeyMultibase: publicKey,
     secretKeyMultibase: secretKey,
-    purpose
+    purpose,
   };
 }
 


### PR DESCRIPTION
When developing a did:webvh registrar for credo-ts I've found that I couldn't make my DIDComm invitation services to work. Later I found that it was because, when updating the DID to add my custom services (including those for DID communication), this library was recalculating all verification method IDs. For multibase keys there was no problem, because it always generated the latest few chars of the public key. But for `Ed25519VerificationKey2018` and `X25519KeyAgreementKey2019` it was creating random values that made my services to lose the reference to them.

I guess this verification method normalization is necessary at the DID creation because we don't know the SCID beforehand, but when updating it we can allow passing verification methods as they are, we already know the full WebVH DID. But as I'm quite new to this spec, I'm not completely sure about that.

Comments and pointers to achieve my goal (add arbitrary defined verification methods in DID updates) are more than welcome!