### PR TITLE
fix: correct host normalization in toASCII for numeric domains

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -197,10 +197,7 @@ export const getBaseUrl = (id: string) => {
   const [hostPart, ...pathParts] = remainder.split('/');
   let [host, port] = decodeURIComponent(hostPart).split(':');
 
-  host = host
-    .split('.')
-    .map(label => toASCII(label.normalize('NFC')))
-    .join('.');
+  host = toASCII(host.normalize("NFC"));
 
   const normalizedHost = port ? `${host}:${port}` : host;
   const path = pathParts.join('/');


### PR DESCRIPTION
When a domain name such as 2060.io is processed, the current logic splits the host by dots and applies toASCII to each label individually. This causes numeric labels (like 2060) to be incorrectly decoded, resulting in an invalid hostname.

By applying toASCII directly to the entire normalized host string, numeric domains are handled correctly without unwanted transformations.