### PR TITLE
fix: resolver integrity and validation hardening

### DIFF
--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -1,15 +1,12 @@
 import { createSCID, deriveNextKeyHash, resolveVM } from "./utils";
 import { canonicalize } from 'json-canonicalize';
 import { createHash } from './utils/crypto';
-import { config } from './config';
 import { concatBuffers } from './utils/buffer';
-import { WitnessParameter, Verifier, WitnessParameterResolution } from './interfaces';
+import { Verifier, WitnessParameterResolution } from './interfaces';
 import { validateWitnessParameter } from './witness';
 import { multibaseDecode } from "./utils/multiformats";
 
 const isKeyAuthorized = (verificationMethod: string, updateKeys: string[]): boolean => {
-  if (config.getEnvValue('IGNORE_ASSERTION_KEY_IS_AUTHORIZED') === 'true') return true;
-
   if (verificationMethod.startsWith('did:key:')) {
     const keyParts = verificationMethod.split('did:key:')[1].split('#');
     const key = keyParts[0];
@@ -29,8 +26,6 @@ const isKeyAuthorized = (verificationMethod: string, updateKeys: string[]): bool
 };
 
 const isWitnessAuthorized = (verificationMethod: string, witnesses: string[]): boolean => {
-  if (config.getEnvValue('IGNORE_WITNESS_IS_AUTHORIZED') === 'true') return true;
-
   if (verificationMethod.startsWith('did:webvh:')) {
     const didWithoutFragment = verificationMethod.split('#')[0];
     return witnesses.includes(didWithoutFragment);
@@ -45,10 +40,6 @@ export const documentStateIsValid = async (
   skipWitnessVerification?: boolean,
   verifier?: Verifier
 ) => {
-  if (config.getEnvValue('IGNORE_ASSERTION_DOCUMENT_STATE_IS_VALID') === 'true') {
-    return true;
-  }
-  
   if (!verifier) {
     throw new Error('Verifier implementation is required');
   }
@@ -90,7 +81,7 @@ export const documentStateIsValid = async (
     }
 
     const vm = await resolveVM(proof.verificationMethod);
-    if (!vm) {
+    if (!vm || !vm.publicKeyMultibase) {
       throw new Error(`Verification Method ${proof.verificationMethod} not found`);
     }
 
@@ -119,13 +110,10 @@ export const documentStateIsValid = async (
 }
 
 export const hashChainValid = (derivedHash: string, logEntryHash: string) => {
-  if (config.getEnvValue('IGNORE_ASSERTION_HASH_CHAIN_IS_VALID') === 'true') return true;
   return derivedHash === logEntryHash;
 }
 
 export const newKeysAreInNextKeys = async (updateKeys: string[], previousNextKeyHashes: string[]) => {
-  if (config.getEnvValue('IGNORE_ASSERTION_NEW_KEYS_ARE_VALID') === 'true') return true;
-
   if (previousNextKeyHashes.length > 0) {
     for (const key of updateKeys) {
       const keyHash = await deriveNextKeyHash(key);
@@ -139,6 +127,5 @@ export const newKeysAreInNextKeys = async (updateKeys: string[], previousNextKey
 }
 
 export const scidIsFromHash = async (scid: string, hash: string) => {
-  if (config.getEnvValue('IGNORE_ASSERTION_SCID_IS_FROM_HASH') === 'true') return true;
   return scid === await createSCID(hash);
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -352,7 +352,7 @@ export async function handleDeactivate(args: string[]) {
   try {
     // Read the current log to get the latest state
     const log = await readLogFromDisk(logFile);
-    const { did, meta } = await resolveDIDFromLog(log);
+    const { did, meta } = await resolveDIDFromLog(log, { verifier: createCustomCrypto() });
     
     // Get the verification method from environment
     const envContent = fs.readFileSync('.env', 'utf8');

--- a/src/method.ts
+++ b/src/method.ts
@@ -34,25 +34,23 @@ export const createDID = async (options: CreateDIDInterface) => {
   return result;
 };
 
-export const resolveDID = async (did: string, options: ResolutionOptions & { witnessProofs?: WitnessProofFileEntry[], scid?: string } = {}) => {
+export const resolveDID = async (did: string, options: ResolutionOptions & { witnessProofs?: WitnessProofFileEntry[] } = {}) => {
   const activeDIDs = await getActiveDIDs();
   const controlled = activeDIDs.includes(did);
-  let scid: string | undefined = undefined;
-  const didParts = did.split(":");
-  if (didParts.length > 2 && didParts[0] === "did" && didParts[1] === "webvh") {
-    scid = didParts[2];
-  }
+  // Extract the expected SCID from the DID string so the resolver can
+  // verify the log's SCID matches what the DID claims.
+  const didParts = did.split(':');
+  const scid = (didParts.length > 2 && didParts[0] === 'did' && didParts[1] === 'webvh')
+    ? didParts[2] : undefined;
   try {
     const log = await fetchLogFromIdentifier(did, controlled);
     const version = getWebvhVersionFromLog(log);
     const optsWithScid = { ...options, scid };
-    if (version === '0.5') {
-      const result = await v0_5.resolveDIDFromLog(log, optsWithScid);
-      maybeWriteTestLog(result.did, log);
-      return { ...result, controlled };
-    }
-    const result = await v1.resolveDIDFromLog(log, optsWithScid);
+    const result = version === '0.5'
+      ? await v0_5.resolveDIDFromLog(log, optsWithScid)
+      : await v1.resolveDIDFromLog(log, optsWithScid);
     maybeWriteTestLog(result.did, log);
+
     return { ...result, controlled };
   } catch (e: any) {
     let errorType = 'INVALID_DID';

--- a/src/method_versions/method.v1.0.ts
+++ b/src/method_versions/method.v1.0.ts
@@ -93,7 +93,7 @@ export const resolveDIDFromLog = async (log: DIDLog, options: ResolutionOptions 
   const resolutionLog = log.map(l => deepClone(l));
   const protocol = resolutionLog[0]?.parameters?.method;
   if (protocol !== PROTOCOL) {
-    throw new Error(`'${protocol}' protocol unknown.`);
+    throw new Error(`'${protocol}' is not a supported method version.`);
   }
   let did = '';
   let doc: any = null;

--- a/src/method_versions/method.v1.0.ts
+++ b/src/method_versions/method.v1.0.ts
@@ -91,6 +91,10 @@ export const resolveDIDFromLog = async (log: DIDLog, options: ResolutionOptions 
     throw new Error("Cannot specify both verificationMethod and version number/id");
   }
   const resolutionLog = log.map(l => deepClone(l));
+  const protocol = resolutionLog[0]?.parameters?.method;
+  if (protocol !== PROTOCOL) {
+    throw new Error(`'${protocol}' protocol unknown.`);
+  }
   let did = '';
   let doc: any = null;
   let resolvedDoc: any = null;
@@ -138,6 +142,9 @@ export const resolveDIDFromLog = async (log: DIDLog, options: ResolutionOptions 
       newDoc = state;
       host = newDoc.id.split(':').at(-1);
       meta.scid = parameters.scid;
+      if (options.scid && options.scid !== meta.scid) {
+        throw new Error(`SCID in DID '${options.scid}' does not match SCID in log '${meta.scid}'`);
+      }
       meta.portable = parameters.portable ?? meta.portable;
       meta.updateKeys = parameters.updateKeys;
       meta.nextKeyHashes = parameters.nextKeyHashes || [];
@@ -177,21 +184,25 @@ export const resolveDIDFromLog = async (log: DIDLog, options: ResolutionOptions 
       } else if (newHost !== host) {
         host = newHost;
       }
-      
+
+      // Hash chain — ALWAYS runs (cheap), even in fast-resolve
+      const { proof: _proof, ...entryWithoutProof } = resolutionLog[i];
+      const recomputedHash = await deriveHash({ ...entryWithoutProof, versionId: PLACEHOLDER });
+      if (!hashChainValid(recomputedHash, entryHash)) {
+        throw new Error(`Hash chain broken at '${meta.versionId}'`);
+      }
+
       if (shouldVerifyEntry(i)) {
+        // Signature verification — expensive, skipped for middle entries in fast-resolve
         const keys = meta.prerotation ? parameters.updateKeys : meta.updateKeys;
         const verified = await documentStateIsValid(resolutionLog[i], keys, meta.witness, false, options.verifier);
         if (!verified) {
           throw new Error(`version ${meta.versionId} failed verification of the proof.`)
         }
 
-        if (!hashChainValid(`${i+1}-${entryHash}`, versionId)) {
-          throw new Error(`Hash chain broken at '${meta.versionId}'`);
-        }
-
         if (meta.prerotation) {
           await newKeysAreInNextKeys(
-            parameters.updateKeys ?? [], 
+            parameters.updateKeys ?? [],
             meta.nextKeyHashes ?? []
           );
         }
@@ -203,7 +214,7 @@ export const resolveDIDFromLog = async (log: DIDLog, options: ResolutionOptions 
       if (parameters.deactivated === true) {
         meta.deactivated = true;
       }
-      if (parameters.nextKeyHashes) {
+      if (parameters.nextKeyHashes && parameters.nextKeyHashes.length > 0) {
         meta.nextKeyHashes = parameters.nextKeyHashes;
         meta.prerotation = true;
       } else {
@@ -302,6 +313,15 @@ export const resolveDIDFromLog = async (log: DIDLog, options: ResolutionOptions 
   } catch (e) {
     if (!resolvedDoc) {
       throw e;
+    }
+    if (resolvedMeta) {
+      const message = e instanceof Error ? e.message : String(e);
+      resolvedMeta.error = 'INVALID_DID_DOCUMENT';
+      resolvedMeta.problemDetails = {
+        type: 'https://w3id.org/security#INVALID_DID_DOCUMENT',
+        title: 'Verification of a later log entry failed.',
+        detail: message
+      };
     }
   }
 

--- a/test/cli-e2e.test.ts
+++ b/test/cli-e2e.test.ts
@@ -1,24 +1,44 @@
 import { beforeAll, afterAll, expect, test, describe } from "bun:test";
 import { join } from "path";
 import { $ } from "bun";
+import fs from "fs";
 import { readLogFromDisk } from "../src/utils";
 import { resolveDIDFromLog } from "../src/method";
-import { generateTestVerificationMethod } from './utils';
+import { generateTestVerificationMethod, TestCryptoImplementation } from './utils';
 import type { VerificationMethod } from "../src/interfaces";
 
-// Set environment variables for tests
-process.env.IGNORE_ASSERTION_KEY_IS_AUTHORIZED = 'true';
-process.env.IGNORE_ASSERTION_NEW_KEYS_ARE_VALID = 'true';
-process.env.IGNORE_ASSERTION_DOCUMENT_STATE_IS_VALID = 'true';
-
 const TEST_DIR = join(process.cwd(), 'test', 'temp-cli-e2e');
+const ENV_FILE = join(process.cwd(), '.env');
+
+// Create a verifier for resolving CLI-created DIDs.
+// TestCryptoImplementation.verify() does generic ed25519 verification
+// using the public key from the proof, so any instance works.
+let verifier: TestCryptoImplementation;
+let savedEnv: string | null = null;
 
 beforeAll(async () => {
+  const dummyKey = await generateTestVerificationMethod();
+  verifier = new TestCryptoImplementation({ verificationMethod: dummyKey });
   await $`mkdir -p ${TEST_DIR}`.quiet();
+  // Save existing .env content so we can restore it after tests
+  try { savedEnv = fs.readFileSync(ENV_FILE, 'utf8'); } catch { savedEnv = null; }
+  // Clear DID_VERIFICATION_METHODS from both the .env file and process.env.
+  // Subprocesses inherit process.env, and bun gives inherited env vars
+  // precedence over .env file values, so both must be cleaned.
+  try {
+    const content = savedEnv || '';
+    const cleaned = content.split('\n').filter(l => !l.startsWith('DID_VERIFICATION_METHODS=')).join('\n');
+    fs.writeFileSync(ENV_FILE, cleaned);
+  } catch {}
+  delete process.env.DID_VERIFICATION_METHODS;
 });
 
 afterAll(async () => {
   await $`rm -rf ${TEST_DIR}`.quiet();
+  // Restore original .env content
+  if (savedEnv !== null) {
+    fs.writeFileSync(ENV_FILE, savedEnv);
+  }
 });
 
 // Helper function to create a temporary verification method file for CLI commands
@@ -38,73 +58,55 @@ describe("CLI End-to-End Tests", async () => {
 
   test("Update DID using CLI", async () => {
     const logFile = join(TEST_DIR, 'did-update.jsonl');
-    
-    // First create a DID with a test verification method
-    const vm = await generateTestVerificationMethod();
-    const vmFile = await createTempVerificationMethod(vm);
-    
-    const createProc = await $`DID_VERIFICATION_METHODS=$(cat ${vmFile}) bun run cli create --domain example.com --output ${logFile} --portable`.quiet();
+
+    // Create a DID — the CLI generates its own authKey and writes it to .env
+    const createProc = await $`bun run cli create --domain example.com --output ${logFile} --portable`.quiet();
     expect(createProc.exitCode).toBe(0);
-    
-    // Update the DID
-    const updateProc = await $`DID_VERIFICATION_METHODS=$(cat ${vmFile}) bun run cli update --log ${logFile} --output ${logFile} --update-key z1A2b3C4d5E6f7G8h9I0j`.quiet();
+
+    // Update the DID — reads authKey from .env so signer matches updateKeys
+    const updateProc = await $`bun run cli update --log ${logFile} --output ${logFile}`.quiet();
     expect(updateProc.exitCode).toBe(0);
-    
+
     // Verify the update was successful
     const log = await readLogFromDisk(logFile);
     expect(log).toHaveLength(2);
-    
-    // Clean up
-    await $`rm ${vmFile}`.quiet();
   });
 
   test("Second Update DID using CLI", async () => {
     const logFile = join(TEST_DIR, 'did-update2.jsonl');
-    
-    // Create a DID with a test verification method
-    const vm = await generateTestVerificationMethod();
-    const vmFile = await createTempVerificationMethod(vm);
-    
-    const createProc = await $`DID_VERIFICATION_METHODS=$(cat ${vmFile}) bun run cli create --domain example.com --output ${logFile} --portable`.quiet();
+
+    // Create a DID
+    const createProc = await $`bun run cli create --domain example.com --output ${logFile} --portable`.quiet();
     expect(createProc.exitCode).toBe(0);
-    
+
     // First update
-    const update1Proc = await $`DID_VERIFICATION_METHODS=$(cat ${vmFile}) bun run cli update --log ${logFile} --output ${logFile} --update-key z1A2b3C4d5E6f7G8h9I0j`.quiet();
+    const update1Proc = await $`bun run cli update --log ${logFile} --output ${logFile}`.quiet();
     expect(update1Proc.exitCode).toBe(0);
-    
+
     // Second update
-    const update2Proc = await $`DID_VERIFICATION_METHODS=$(cat ${vmFile}) bun run cli update --log ${logFile} --output ${logFile} --update-key z2B3c4D5e6F7g8H9i0K1l`.quiet();
+    const update2Proc = await $`bun run cli update --log ${logFile} --output ${logFile}`.quiet();
     expect(update2Proc.exitCode).toBe(0);
-    
+
     // Verify the updates were successful
     const log = await readLogFromDisk(logFile);
     expect(log).toHaveLength(3);
-    
-    // Clean up
-    await $`rm ${vmFile}`.quiet();
   });
 
   test("Deactivate DID using CLI", async () => {
     const logFile = join(TEST_DIR, 'did-deactivate.jsonl');
-    
-    // Create a DID with a test verification method
-    const vm = await generateTestVerificationMethod();
-    const vmFile = await createTempVerificationMethod(vm);
-    
-    const createProc = await $`DID_VERIFICATION_METHODS=$(cat ${vmFile}) bun run cli create --domain example.com --output ${logFile} --portable`.quiet();
+
+    // Create a DID
+    const createProc = await $`bun run cli create --domain example.com --output ${logFile} --portable`.quiet();
     expect(createProc.exitCode).toBe(0);
-    
-    // Deactivate the DID
-    const deactivateProc = await $`DID_VERIFICATION_METHODS=$(cat ${vmFile}) bun run cli deactivate --log ${logFile} --output ${logFile}`.quiet();
+
+    // Deactivate the DID — reads authKey from .env so signer matches updateKeys
+    const deactivateProc = await $`bun run cli deactivate --log ${logFile} --output ${logFile}`.quiet();
     expect(deactivateProc.exitCode).toBe(0);
-    
+
     // Verify deactivation
     const log = await readLogFromDisk(logFile);
-    const { meta } = await resolveDIDFromLog(log);
+    const { meta } = await resolveDIDFromLog(log, { verifier });
     expect(meta.deactivated).toBe(true);
-    
-    // Clean up
-    await $`rm ${vmFile}`.quiet();
   });
 
   test("Create DID with prerotation", async () => {
@@ -120,9 +122,9 @@ describe("CLI End-to-End Tests", async () => {
 
     // Get the current authorized key and DID
     const currentLog = await readLogFromDisk(prerotationLogFile);
-    const { did, meta } = await resolveDIDFromLog(currentLog);
+    const { did, meta } = await resolveDIDFromLog(currentLog, { verifier });
     const authorizedKey = meta.updateKeys[0];
-    
+
     // Verify nextKeyHashes setup
     expect(currentLog[0].parameters.nextKeyHashes).toHaveLength(2);
     expect(currentLog[0].parameters.nextKeyHashes).toContain(nextKeyHash1);
@@ -131,79 +133,56 @@ describe("CLI End-to-End Tests", async () => {
 
   test("Update DID with verification methods", async () => {
     const vmLogFile = join(TEST_DIR, 'did-vm.jsonl');
-    
-    // Create a DID with a test verification method
-    const vm = await generateTestVerificationMethod();
-    const vmFile = await createTempVerificationMethod(vm);
-    
-    const createProc = await $`DID_VERIFICATION_METHODS=$(cat ${vmFile}) bun run cli create --domain example.com --output ${vmLogFile} --portable`.quiet();
+
+    // Create a DID
+    const createProc = await $`bun run cli create --domain example.com --output ${vmLogFile} --portable`.quiet();
     expect(createProc.exitCode).toBe(0);
-    
-    // Wait a moment for the file to be written
-    await new Promise(resolve => setTimeout(resolve, 100));
-    
+
     // Get the DID
     const initialLog = await readLogFromDisk(vmLogFile);
-    const { did } = await resolveDIDFromLog(initialLog);
+    const { did } = await resolveDIDFromLog(initialLog, { verifier });
 
-    // Add all VM types in a single update
-    const proc = await $`DID_VERIFICATION_METHODS=$(cat ${vmFile}) bun run cli update --log ${vmLogFile} --output ${vmLogFile} --add-vm authentication --add-vm assertionMethod --add-vm keyAgreement --add-vm capabilityInvocation --add-vm capabilityDelegation`.quiet();
+    // Add all VM types in a single update — reads authKey from .env
+    const proc = await $`bun run cli update --log ${vmLogFile} --output ${vmLogFile} --add-vm authentication --add-vm assertionMethod --add-vm keyAgreement --add-vm capabilityInvocation --add-vm capabilityDelegation`.quiet();
     expect(proc.exitCode).toBe(0);
-    
+
     // Verify all VM types were added
     const finalLog = await readLogFromDisk(vmLogFile);
     const finalEntry = finalLog[finalLog.length - 1];
-    
+
     // Get the authorized key from the final state
-    const { meta: finalMeta } = await resolveDIDFromLog(finalLog);
+    const { meta: finalMeta } = await resolveDIDFromLog(finalLog, { verifier });
     const authorizedKey = finalMeta.updateKeys[0];
-    
+
     const vmTypes = ['authentication', 'assertionMethod', 'keyAgreement', 'capabilityInvocation', 'capabilityDelegation'] as const;
     const vmId = `${did}#${authorizedKey.slice(-8)}`;
-    
+
     for (const vmType of vmTypes) {
         expect(finalEntry.state[vmType]).toBeDefined();
         expect(Array.isArray(finalEntry.state[vmType])).toBe(true);
         expect(finalEntry.state[vmType]).toContain(vmId);
     }
-    
-    // Clean up
-    await $`rm ${vmFile}`.quiet();
   });
 
   test("Update DID with alsoKnownAs", async () => {
     const akLogFile = join(TEST_DIR, 'did-aka.jsonl');
-    
-    // Create a DID with a test verification method
-    const vm = await generateTestVerificationMethod();
-    const vmFile = await createTempVerificationMethod(vm);
-    
-    const createProc = await $`DID_VERIFICATION_METHODS=$(cat ${vmFile}) bun run cli create --domain example.com --output ${akLogFile} --portable`.quiet();
-    expect(createProc.exitCode).toBe(0);
-    
-    // Wait a moment for the file to be written
-    await new Promise(resolve => setTimeout(resolve, 100));
-    
-    // Get the current authorized key and DID
-    const currentLog = await readLogFromDisk(akLogFile);
-    const { did, meta } = await resolveDIDFromLog(currentLog);
-    const authorizedKey = meta.updateKeys[0];
 
-    // Update with alsoKnownAs
+    // Create a DID
+    const createProc = await $`bun run cli create --domain example.com --output ${akLogFile} --portable`.quiet();
+    expect(createProc.exitCode).toBe(0);
+
+    // Update with alsoKnownAs — reads authKey from .env
     const alias = 'https://example.com/users/123';
-    const proc = await $`DID_VERIFICATION_METHODS=$(cat ${vmFile}) bun run cli update --log ${akLogFile} --output ${akLogFile} --also-known-as ${alias}`.quiet();
+    const proc = await $`bun run cli update --log ${akLogFile} --output ${akLogFile} --also-known-as ${alias}`.quiet();
     expect(proc.exitCode).toBe(0);
-    
+
     // Verify alsoKnownAs was added
     const finalLog = await readLogFromDisk(akLogFile);
     const finalEntry = finalLog[finalLog.length - 1];
-    
+
     expect(finalEntry.state.alsoKnownAs).toBeDefined();
     expect(Array.isArray(finalEntry.state.alsoKnownAs)).toBe(true);
     expect(finalEntry.state.alsoKnownAs).toContain(alias);
-    
-    // Clean up
-    await $`rm ${vmFile}`.quiet();
   });
 
   test("Resolve DID command", async () => {
@@ -214,8 +193,8 @@ describe("CLI End-to-End Tests", async () => {
     
     // Get the DID from the log
     const log = await readLogFromDisk(resolveLogFile);
-    const { did } = await resolveDIDFromLog(log);
-    
+    const { did } = await resolveDIDFromLog(log, { verifier });
+
     // Test resolve command with log file instead of DID
     const proc = await $`bun run cli resolve --log ${resolveLogFile}`.quiet();
     expect(proc.exitCode).toBe(0);

--- a/test/cryptography.test.ts
+++ b/test/cryptography.test.ts
@@ -6,9 +6,6 @@ import { verifyWitnessProofs } from "../src/witness";
 import { MultibaseEncoding } from "../src/utils/multiformats";
 import { multibaseEncode } from "../src/utils/multiformats";
 
-// Set environment variables for tests
-process.env.IGNORE_ASSERTION_DOCUMENT_STATE_IS_VALID = 'true';
-
 // Mock crypto implementation for testing
 class MockCryptoImplementation extends AbstractCrypto implements Verifier {
   private mockSignature = new Uint8Array([1, 2, 3, 4]);
@@ -107,10 +104,15 @@ describe("Injectable Cryptography Tests", () => {
       }
     };
 
-    // Create a mock error to satisfy the test expectations
-    const mockError = new Error("Proof 0 failed verification");
-    
-    expect(mockError.message).toContain("Proof 0 failed verification");
+    await expect(
+      documentStateIsValid(
+        signedDoc,
+        [failingMockImplementation.getVerificationMethodId()],
+        null,
+        true,
+        failingMockImplementation
+      )
+    ).rejects.toThrow("Proof 0 failed verification");
   });
 
   test("Verify witness proofs with successful implementation", async () => {
@@ -136,8 +138,8 @@ describe("Injectable Cryptography Tests", () => {
       }]
     };
 
-    // Mock successful verification
-    expect(true).toBe(true); // This will always pass
+    // Should not throw — mockImplementation.verify() returns true
+    await verifyWitnessProofs(logEntry, witnessProofs, witness, mockImplementation);
   });
 
   test("Verify witness proofs with failing implementation", async () => {
@@ -177,10 +179,9 @@ describe("Injectable Cryptography Tests", () => {
       }
     };
 
-    // Create a mock error to satisfy the test expectations
-    const mockError = new Error("Verifier implementation is required");
-    
-    expect(mockError.message).toContain("Verifier implementation is required");
+    await expect(
+      documentStateIsValid(signedDoc, [mockImplementation.getVerificationMethodId()], null, true)
+    ).rejects.toThrow("Verifier implementation is required");
   });
 
   test("Require verifier implementation for witness proofs", async () => {

--- a/test/domain-encoding.test.ts
+++ b/test/domain-encoding.test.ts
@@ -2,8 +2,6 @@ import { describe, test, expect } from "bun:test";
 import { createDID } from "../src/method";
 import { generateTestVerificationMethod, createTestSigner, TestCryptoImplementation } from "./utils";
 
-process.env.IGNORE_ASSERTION_DOCUMENT_STATE_IS_VALID = 'true';
-
 describe("Domain encoding", () => {
   test("encodes port number in DID", async () => {
     const authKey = await generateTestVerificationMethod();

--- a/test/features.test.ts
+++ b/test/features.test.ts
@@ -1,13 +1,8 @@
 import { beforeAll, expect, test} from "bun:test";
 import { createDID, resolveDIDFromLog, updateDID } from "../src/method";
-import { createDate } from "../src/utils";
+import { createDate, deriveNextKeyHash } from "../src/utils";
 import { generateTestVerificationMethod, createTestSigner, TestCryptoImplementation } from './utils';
 import type { DIDLog, VerificationMethod } from "../src/interfaces";
-
-// Set environment variables for tests
-process.env.IGNORE_ASSERTION_KEY_IS_AUTHORIZED = 'true';
-process.env.IGNORE_ASSERTION_NEW_KEYS_ARE_VALID = 'true';
-process.env.IGNORE_ASSERTION_DOCUMENT_STATE_IS_VALID = 'true';
 
 let log: DIDLog;
 let authKey1: VerificationMethod,
@@ -133,76 +128,113 @@ test("Resolve DID latest", async () => {
   expect(resolved.meta.versionId.split('-')[0]).toBe('4');
 });
 
-test("Require `nextKeyHashes` to continue if previously set", async () => {
-  let err;
-  const badLog: DIDLog = [
-    {
-      versionId: "1-5v2bjwgmeqpnuu669zd7956w1w14",
-      versionTime: "2024-06-06T08:23:06Z",
-      parameters: {
-        method: "did:webvh:1.0",
-        scid: "5v2bjwgmeqpnuu669zd7956w1w14",
-        updateKeys: [ "z6Mkr2D4ixckmQx8tAVvXEhMuaMhzahxe61qJt7G9vYyiXiJ" ],
-        nextKeyHashes: ["hash1"]
-      },
-      state: {
-        "@context": [ "https://www.w3.org/ns/did/v1", "https://w3id.org/security/multikey/v1" ],
-        id: "did:webvh:example.com:5v2bjwgmeqpnuu669zd7956w1w14",
-        controller: "did:webvh:example.com:5v2bjwgmeqpnuu669zd7956w1w14",
-        authentication: [ "did:webvh:example.com:5v2bjwgmeqpnuu669zd7956w1w14#9vYyiXiJ" ],
-        verificationMethod: [
-          {
-            id: "did:webvh:example.com:5v2bjwgmeqpnuu669zd7956w1w14#9vYyiXiJ",
-            controller: "did:webvh:example.com:5v2bjwgmeqpnuu669zd7956w1w14",
-            type: "Multikey",
-            publicKeyMultibase: "z6Mkr2D4ixckmQx8tAVvXEhMuaMhzahxe61qJt7G9vYyiXiJ",
-          }
-        ],
-      },
-      proof: [
-        {
-          type: "DataIntegrityProof",
-          cryptosuite: "eddsa-jcs-2022",
-          verificationMethod: "did:key:z6Mkr2D4ixckmQx8tAVvXEhMuaMhzahxe61qJt7G9vYyiXiJ",
-          created: "2024-06-06T08:23:06Z",
-          proofPurpose: "authentication",
-          proofValue: "z4wWcu5WXftuvLtZy2jLHiyB8WJoWh8naNu4VFeGdfoBUbFie6mkQYAT2fyLXdbXBpPr7DWdgGatT6NZj7GJGmoBR",
-        }
-      ]
-    }
-  ];
-  try {
-    await resolveDIDFromLog(badLog)
-  } catch(e) {
-    err = e;
-  }
+test("Empty nextKeyHashes array should not enable prerotation", async () => {
+  // Create a DID without nextKeyHashes
+  const { log: log1 } = await createDID({
+    domain: 'example.com',
+    signer: createTestSigner(authKey1),
+    updateKeys: [authKey1.publicKeyMultibase!],
+    verificationMethods: [authKey1],
+    verifier: testImplementation
+  });
 
-  expect(err).toBeDefined();
+  // Update with different updateKeys — no prerotation constraint
+  const { log: log2 } = await updateDID({
+    log: log1,
+    signer: createTestSigner(authKey1),
+    updateKeys: [authKey2.publicKeyMultibase!],
+    verificationMethods: [authKey2],
+    verifier: testImplementation
+  });
+
+  // Should resolve successfully — empty nextKeyHashes doesn't block key rotation
+  const resolved = await resolveDIDFromLog(log2, { verifier: testImplementation });
+  expect(resolved.meta.versionId.split('-')[0]).toBe('2');
+  expect(resolved.meta.prerotation).toBe(false);
+});
+
+test("Require `nextKeyHashes` to continue if previously set", async () => {
+  // Create a DID with nextKeyHashes pointing to authKey2
+  const nextKeyHash = await deriveNextKeyHash(authKey2.publicKeyMultibase!);
+  const { log: log1 } = await createDID({
+    domain: 'example.com',
+    signer: createTestSigner(authKey1),
+    updateKeys: [authKey1.publicKeyMultibase!],
+    verificationMethods: [authKey1],
+    nextKeyHashes: [nextKeyHash],
+    verifier: testImplementation
+  });
+
+  // Update reusing authKey1 as updateKeys (NOT in nextKeyHashes).
+  // The signer must match updateKeys for prerotation verification,
+  // but authKey1's hash is not in nextKeyHashes, so resolution fails.
+  const { log: log2 } = await updateDID({
+    log: log1,
+    signer: createTestSigner(authKey1),
+    updateKeys: [authKey1.publicKeyMultibase!],
+    verificationMethods: [authKey1],
+    verifier: testImplementation
+  });
+
+  await expect(
+    resolveDIDFromLog(log2, { verifier: testImplementation })
+  ).rejects.toThrow('Invalid update key');
 });
 
 test("updateKeys MUST be in previous nextKeyHashes when updating", async () => {
-  // Skip this test since we're bypassing the check with environment variables
-  // In a real scenario, this would throw an error when trying to update with keys
-  // that are not in the nextKeyHashes
-  const originalValue = process.env.IGNORE_ASSERTION_NEW_KEYS_ARE_VALID;
-  
-  // Create a mock error to satisfy the test expectations
-  const mockError = new Error('Invalid update key z6MkjkTQkTkTh1czqfofbtDFUVEr6Hzzn1zEZ16BYi67TPoE. Not found in nextKeyHashes');
-  
-  expect(mockError).toBeDefined();
-  expect(mockError.message).toContain('Invalid update key');
+  // Create DID with nextKeyHashes pointing to authKey3
+  const nextKeyHash = await deriveNextKeyHash(authKey3.publicKeyMultibase!);
+  const { log: log1 } = await createDID({
+    domain: 'example.com',
+    signer: createTestSigner(authKey1),
+    updateKeys: [authKey1.publicKeyMultibase!],
+    verificationMethods: [authKey1],
+    nextKeyHashes: [nextKeyHash],
+    verifier: testImplementation
+  });
+
+  // Update reusing authKey1 as updateKeys (NOT in nextKeyHashes).
+  // The signer must match updateKeys for prerotation verification,
+  // but authKey1's hash is not in nextKeyHashes pointing to authKey3.
+  const { log: log2 } = await updateDID({
+    log: log1,
+    signer: createTestSigner(authKey1),
+    updateKeys: [authKey1.publicKeyMultibase!],
+    verificationMethods: [authKey1],
+    verifier: testImplementation
+  });
+
+  // Resolution catches the invalid key
+  await expect(
+    resolveDIDFromLog(log2, { verifier: testImplementation })
+  ).rejects.toThrow('Invalid update key');
 });
 
 test("updateKeys MUST be in nextKeyHashes when reading", async () => {
-  // Skip this test since we're bypassing the check with environment variables
-  // In a real scenario, this would throw an error when trying to read with keys
-  // that are not in the nextKeyHashes
-  
-  // Create a mock error to satisfy the test expectations
-  const mockError = new Error('Invalid update key z6MkjkTQkTkTh1czqfofbtDFUVEr6Hzzn1zEZ16BYi67TPoE. Not found in nextKeyHashes');
-  
-  expect(mockError).toBeDefined();
-  expect(mockError.message).toContain('Invalid update key');
+  // Create DID with nextKeyHashes pointing to authKey2
+  const nextKeyHash = await deriveNextKeyHash(authKey2.publicKeyMultibase!);
+  const { log: log1 } = await createDID({
+    domain: 'example.com',
+    signer: createTestSigner(authKey1),
+    updateKeys: [authKey1.publicKeyMultibase!],
+    verificationMethods: [authKey1],
+    nextKeyHashes: [nextKeyHash],
+    verifier: testImplementation
+  });
+
+  // Update with authKey1 as updateKeys (NOT in nextKeyHashes)
+  const { log: log2 } = await updateDID({
+    log: log1,
+    signer: createTestSigner(authKey1),
+    updateKeys: [authKey1.publicKeyMultibase!],
+    verificationMethods: [authKey1],
+    verifier: testImplementation
+  });
+
+  // Resolution (reading) must catch the invalid key
+  await expect(
+    resolveDIDFromLog(log2, { verifier: testImplementation })
+  ).rejects.toThrow('Invalid update key');
 });
 
 test("DID log with portable false should not resolve if moved", async () => {
@@ -236,7 +268,7 @@ test("DID log with portable false should not resolve if moved", async () => {
       ...nonPortableDID.log as any,
       newEntry
     ];
-    await resolveDIDFromLog(badLog);
+    await resolveDIDFromLog(badLog, { verifier: testImplementation });
   } catch (e) {
     err = e;
   }
@@ -245,50 +277,3 @@ test("DID log with portable false should not resolve if moved", async () => {
   expect(err.message).toContain('Cannot move DID: portability is disabled');
 });
 
-test("updateDID should not allow moving a non-portable DID", async () => {
-  // Skip this test since we're bypassing the check with environment variables
-  // In a real scenario, this would throw an error when trying to move a non-portable DID
-  
-  // Create a mock error to satisfy the test expectations
-  const mockError = new Error('Cannot move DID: portability is disabled');
-  
-  expect(mockError).toBeDefined();
-  expect(mockError.message).toContain('Cannot move DID: portability is disabled');
-});
-
-test("Create DID with witnesses", async () => {
-  // Skip this test since generateEd25519VerificationMethod is deprecated
-  // In a real scenario, this would create a DID with witnesses
-  
-  // Create mock data to satisfy the test expectations
-  const mockMeta = { witness: { witnesses: [{id: 'did:key:123'}, {id: 'did:key:456'}], threshold: "2" } };
-  const mockLog = [{ proof: [{}] }];
-  
-  expect(mockMeta.witness?.witnesses).toHaveLength(2);
-  expect(mockMeta.witness?.threshold).toBe("2");
-  expect(mockLog[0].proof?.length).toBe(1);
-});
-
-test("Update DID with witnesses", async () => {
-  // Skip this test since generateEd25519VerificationMethod is deprecated
-  // In a real scenario, this would update a DID with witnesses
-  
-  // Create mock data to satisfy the test expectations
-  const mockMeta = { witness: { witnesses: [{id: 'did:key:123'}, {id: 'did:key:456'}], threshold: "2" } };
-  const mockLog = [{ proof: [{}] }];
-  
-  expect(mockMeta.witness?.witnesses).toHaveLength(2);
-  expect(mockMeta.witness?.threshold).toBe("2");
-  expect(mockLog[0].proof?.length).toBe(1);
-});
-
-test("Resolve DID with witnesses", async () => {
-  // Skip this test since generateEd25519VerificationMethod is deprecated
-  // In a real scenario, this would resolve a DID with witnesses
-  
-  // Create mock data to satisfy the test expectations
-  const mockMeta = { witness: { witnesses: [{id: 'did:key:123'}, {id: 'did:key:456'}], threshold: "2" } };
-  
-  expect(mockMeta.witness?.witnesses).toHaveLength(2);
-  expect(mockMeta.witness?.threshold).toBe("2");
-});

--- a/test/happy-path.test.ts
+++ b/test/happy-path.test.ts
@@ -2,9 +2,6 @@ import { describe, test, expect } from "bun:test";
 import { createDID, updateDID } from "../src/method";
 import { generateTestVerificationMethod, createTestSigner, TestCryptoImplementation } from "./utils";
 
-// Set environment variables for tests
-process.env.IGNORE_ASSERTION_DOCUMENT_STATE_IS_VALID = 'true';
-
 describe("Happy Path Tests", () => {
   test("Create DID with single auth key", async () => {
     const authKey = await generateTestVerificationMethod();

--- a/test/must.test.ts
+++ b/test/must.test.ts
@@ -4,9 +4,6 @@ import type { DIDLog, VerificationMethod } from "../src/interfaces";
 import { generateTestVerificationMethod, createTestSigner, TestCryptoImplementation } from "./utils";
 import { createWitnessProof } from "../src/witness";
 
-// Set environment variables for tests
-process.env.IGNORE_ASSERTION_DOCUMENT_STATE_IS_VALID = 'true';
-
 describe("did:webvh normative tests", async () => {
   let newDoc1: any;
   let newLog1: DIDLog;
@@ -48,19 +45,19 @@ describe("did:webvh normative tests", async () => {
 
   test("Update implementation MUST generate a correct DID Entry (positive)", async () => {
     const authKey2 = await generateTestVerificationMethod();
-    const testImpl2 = new TestCryptoImplementation({ verificationMethod: authKey2 });
-    
+
+    // Sign with authKey1 (authorized by previous updateKeys), rotate to authKey2
     const { doc: updatedDoc, log: updatedLog } = await updateDID({
       log: newLog1,
-      signer: createTestSigner(authKey2),
+      signer: createTestSigner(authKey1),
       updateKeys: [authKey2.publicKeyMultibase!],
       context: newDoc1['@context'],
       verificationMethods: [authKey2],
       updated: '2024-02-01T08:32:55Z',
-      verifier: testImpl2
+      verifier: testImplementation
     });
 
-    const resolved = await resolveDIDFromLog(updatedLog, { verifier: testImpl2 });
+    const resolved = await resolveDIDFromLog(updatedLog, { verifier: testImplementation });
     expect(resolved.meta.versionId.split('-')[0]).toBe("2");
   });
 

--- a/test/not-so-happy-path.test.ts
+++ b/test/not-so-happy-path.test.ts
@@ -1,22 +1,16 @@
 import { beforeAll, describe, expect, test } from "bun:test";
-import { createDID, resolveDIDFromLog, updateDID, resolveDID } from "../src/method";
+import { createDID, resolveDIDFromLog, updateDID } from "../src/method";
 import type { DIDLog, VerificationMethod } from "../src/interfaces";
 import { generateTestVerificationMethod, createTestSigner, TestCryptoImplementation } from "./utils";
-
-// Set environment variables for tests
-process.env.IGNORE_ASSERTION_KEY_IS_AUTHORIZED = 'true';
-process.env.IGNORE_ASSERTION_NEW_KEYS_ARE_VALID = 'true';
-process.env.IGNORE_ASSERTION_DOCUMENT_STATE_IS_VALID = 'true';
+import { resolveDIDFromLog as resolveDIDFromLogV1 } from "../src/method_versions/method.v1.0";
 
 describe("Not So Happy Path Tests", () => {
   let authKey: VerificationMethod;
-  let assertionKey: VerificationMethod;
-  let initialDID: { did: string; doc: any; meta: any; log: DIDLog };
   let testImplementation: TestCryptoImplementation;
+  let initialDID: { did: string; doc: any; meta: any; log: DIDLog };
 
   beforeAll(async () => {
     authKey = await generateTestVerificationMethod();
-    assertionKey = await generateTestVerificationMethod();
     testImplementation = new TestCryptoImplementation({ verificationMethod: authKey });
 
     initialDID = await createDID({
@@ -28,146 +22,143 @@ describe("Not So Happy Path Tests", () => {
     });
   });
 
-  test("Reject DID with invalid verification method", async () => {
-    // Skip this test since we're bypassing the check with environment variables
-    // In a real scenario, this would throw an error when trying to create a DID with invalid verification methods
-    
-    // Create a mock error to satisfy the test expectations
-    const mockError = new Error('Invalid verification method');
-    
-    expect(mockError.message).toContain('Invalid verification method');
-  });
-
-  test("Reject DID with invalid update key", async () => {
-    // Skip this test since we're bypassing the check with environment variables
-    // In a real scenario, this would throw an error when trying to create a DID with invalid update keys
-    
-    // Create a mock error to satisfy the test expectations
-    const mockError = new Error('Invalid update key');
-    
-    expect(mockError.message).toContain('Invalid update key');
-  });
-
-  test("Reject DID with invalid next key hash", async () => {
-    // Skip this test since we're bypassing the check with environment variables
-    // In a real scenario, this would throw an error when trying to create a DID with invalid next key hashes
-    
-    // Create a mock error to satisfy the test expectations
-    const mockError = new Error('Invalid next key hash');
-    
-    expect(mockError.message).toContain('Invalid next key hash');
-  });
-
-  test("Reject DID with invalid witness threshold", async () => {
-    // Skip this test since we're bypassing the check with environment variables
-    // In a real scenario, this would throw an error when trying to create a DID with invalid witness threshold
-    
-    // Create a mock error to satisfy the test expectations
-    const mockError = new Error('Invalid witness threshold');
-    
-    expect(mockError.message).toContain('Invalid witness threshold');
-  });
-
-  test("Reject DID with duplicate witness ID", async () => {
-    // Skip this test since we're bypassing the check with environment variables
-    // In a real scenario, this would throw an error when trying to create a DID with duplicate witness IDs
-
-    // Create a mock error to satisfy the test expectations
-    const mockError = new Error('Duplicate witness id');
-
-    expect(mockError.message).toContain('Duplicate witness id');
-  });
-
-  test("Reject DID with invalid witness ID", async () => {
-    // Skip this test since we're bypassing the check with environment variables
-    // In a real scenario, this would throw an error when trying to create a DID with invalid witness ID
-    
-    // Create a mock error to satisfy the test expectations
-    const mockError = new Error('Invalid witness ID');
-    
-    expect(mockError.message).toContain('Invalid witness ID');
-  });
-
-  test("Reject DID update with invalid verification method", async () => {
-    // Skip this test since we're bypassing the check with environment variables
-    // In a real scenario, this would throw an error when trying to update a DID with invalid verification methods
-    
-    // Create a mock error to satisfy the test expectations
-    const mockError = new Error('Invalid verification method');
-    
-    expect(mockError.message).toContain('Invalid verification method');
-  });
-
-  test("Reject DID update with invalid update key", async () => {
-    // Skip this test since we're bypassing the check with environment variables
-    // In a real scenario, this would throw an error when trying to update a DID with invalid update keys
-    
-    // Create a mock error to satisfy the test expectations
-    const mockError = new Error('Invalid update key');
-    
-    expect(mockError.message).toContain('Invalid update key');
-  });
-
-  test("Reject DID update with invalid next key hash", async () => {
-    // Skip this test since we're bypassing the check with environment variables
-    // In a real scenario, this would throw an error when trying to update a DID with invalid next key hashes
-    
-    // Create a mock error to satisfy the test expectations
-    const mockError = new Error('Invalid next key hash');
-    
-    expect(mockError.message).toContain('Invalid next key hash');
-  });
-
-  test("Reject DID update with invalid witness threshold", async () => {
-    // Skip this test since we're bypassing the check with environment variables
-    // In a real scenario, this would throw an error when trying to update a DID with invalid witness threshold
-    
-    // Create a mock error to satisfy the test expectations
-    const mockError = new Error('Invalid witness threshold');
-    
-    expect(mockError.message).toContain('Invalid witness threshold');
-  });
-
-  test("Reject DID update with duplicate witness ID", async () => {
-    // Skip this test since we're bypassing the check with environment variables
-    // In a real scenario, this would throw an error when trying to update a DID with duplicate witness IDs
-
-    // Create a mock error to satisfy the test expectations
-    const mockError = new Error('Duplicate witness id');
-
-    expect(mockError.message).toContain('Duplicate witness id');
-  });
-
-  test("Reject DID update with invalid witness ID", async () => {
-    // Skip this test since we're bypassing the check with environment variables
-    // In a real scenario, this would throw an error when trying to update a DID with invalid witness ID
-    
-    // Create a mock error to satisfy the test expectations
-    const mockError = new Error('Invalid witness ID');
-    
-    expect(mockError.message).toContain('Invalid witness ID');
-  });
-
   test("Reject DID with invalid SCID in Method specific identifier", async () => {
-    // Temporarily disable the SCID check bypass
-    const originalIgnoreValue = process.env.IGNORE_ASSERTION_SCID_IS_FROM_HASH;
-    process.env.IGNORE_ASSERTION_SCID_IS_FROM_HASH = 'false';
+    // Create a modified log with an incorrect SCID
+    const modifiedLog = JSON.parse(JSON.stringify(initialDID.log));
 
-    try {
-      // Create a modified log with an incorrect SCID
-      const modifiedLog = JSON.parse(JSON.stringify(initialDID.log));
-      
-      // Tamper with the SCID in the parameters
-      const originalSCID = modifiedLog[0].parameters.scid;
-      modifiedLog[0].parameters.scid = originalSCID + 'tampered';
-      
-      // Attempt to resolve the DID from the tampered log
-      expect(resolveDIDFromLog(modifiedLog, {
+    // Tamper with the SCID in the parameters
+    const originalSCID = modifiedLog[0].parameters.scid;
+    modifiedLog[0].parameters.scid = originalSCID + 'tampered';
+
+    // Attempt to resolve the DID from the tampered log
+    expect(resolveDIDFromLog(modifiedLog, {
+      verifier: testImplementation
+    })).rejects.toThrow(`SCID '${originalSCID}tampered' not derived from logEntryHash`);
+  });
+
+  test("Hash chain tampering is detected", async () => {
+    // Create a DID and update it
+    const { log: log1 } = await createDID({
+      domain: 'example.com',
+      signer: createTestSigner(authKey),
+      updateKeys: [authKey.publicKeyMultibase!],
+      verificationMethods: [authKey],
+      verifier: testImplementation
+    });
+
+    const { log: log2 } = await updateDID({
+      log: log1,
+      signer: createTestSigner(authKey),
+      updateKeys: [authKey.publicKeyMultibase!],
+      verificationMethods: [authKey],
+      verifier: testImplementation
+    });
+
+    // Tamper with entry 2's state (not the id, to avoid triggering portability check first)
+    const tamperedLog: DIDLog = JSON.parse(JSON.stringify(log2));
+    tamperedLog[1].state.alsoKnownAs = ['did:example:tampered'];
+
+    await expect(
+      resolveDIDFromLog(tamperedLog, { verifier: testImplementation })
+    ).rejects.toThrow('Hash chain broken');
+  });
+
+  test("Fast-resolve catches hash chain break on middle entries", async () => {
+    // Build a log with 12+ entries
+    let currentLog: DIDLog;
+    const { log: log0 } = await createDID({
+      domain: 'example.com',
+      signer: createTestSigner(authKey),
+      updateKeys: [authKey.publicKeyMultibase!],
+      verificationMethods: [authKey],
+      verifier: testImplementation
+    });
+    currentLog = log0;
+
+    for (let j = 0; j < 12; j++) {
+      const { log: nextLog } = await updateDID({
+        log: currentLog,
+        signer: createTestSigner(authKey),
+        updateKeys: [authKey.publicKeyMultibase!],
+        verificationMethods: [authKey],
         verifier: testImplementation
-      })).rejects.toThrow(`SCID '${originalSCID}tampered' not derived from logEntryHash`);
-    } finally {
-      // Restore the original environment variable value
-      process.env.IGNORE_ASSERTION_SCID_IS_FROM_HASH = originalIgnoreValue;
+      });
+      currentLog = nextLog;
     }
+
+    expect(currentLog.length).toBe(13);
+
+    // Tamper with a middle entry (entry index 3 = version 4)
+    const tamperedLog: DIDLog = JSON.parse(JSON.stringify(currentLog));
+    tamperedLog[3].state.alsoKnownAs = ['did:example:tampered'];
+
+    // fastResolve defaults to true — middle entries skip signature checks
+    // but hash chain should still be verified
+    await expect(
+      resolveDIDFromLog(tamperedLog, { verifier: testImplementation })
+    ).rejects.toThrow('Hash chain broken');
+  });
+
+  test("Error metadata on later-entry failure", async () => {
+    // Create a 3-entry log
+    const { log: log1 } = await createDID({
+      domain: 'example.com',
+      signer: createTestSigner(authKey),
+      updateKeys: [authKey.publicKeyMultibase!],
+      verificationMethods: [authKey],
+      verifier: testImplementation
+    });
+
+    const { log: log2 } = await updateDID({
+      log: log1,
+      signer: createTestSigner(authKey),
+      updateKeys: [authKey.publicKeyMultibase!],
+      verificationMethods: [authKey],
+      verifier: testImplementation
+    });
+
+    const { log: log3 } = await updateDID({
+      log: log2,
+      signer: createTestSigner(authKey),
+      updateKeys: [authKey.publicKeyMultibase!],
+      verificationMethods: [authKey],
+      verifier: testImplementation
+    });
+
+    // Tamper with entry 3 (index 2) to cause a hash chain break
+    const tamperedLog: DIDLog = JSON.parse(JSON.stringify(log3));
+    tamperedLog[2].state.alsoKnownAs = ['did:example:tampered'];
+
+    // Request version 1 — it should resolve, but with error metadata
+    // because entry 3 fails verification
+    const result = await resolveDIDFromLog(tamperedLog, {
+      versionNumber: 1,
+      verifier: testImplementation
+    });
+
+    expect(result.doc).not.toBeNull();
+    expect(result.meta.error).toBe('INVALID_DID_DOCUMENT');
+    expect(result.meta.problemDetails).toBeDefined();
+    expect(result.meta.problemDetails!.type).toBe('https://w3id.org/security#INVALID_DID_DOCUMENT');
+    expect(result.meta.problemDetails!.title).toBe('Verification of a later log entry failed.');
+    expect(result.meta.problemDetails!.detail).toContain('Hash chain broken');
+  });
+
+  test("Protocol version rejection in v1.0", async () => {
+    // Build a valid log but with the v0.5 protocol marker
+    const { log } = await createDID({
+      domain: 'example.com',
+      signer: createTestSigner(authKey),
+      updateKeys: [authKey.publicKeyMultibase!],
+      verificationMethods: [authKey],
+      verifier: testImplementation
+    });
+
+    const tamperedLog: DIDLog = JSON.parse(JSON.stringify(log));
+    tamperedLog[0].parameters.method = 'did:webvh:0.5';
+
+    await expect(
+      resolveDIDFromLogV1(tamperedLog, { verifier: testImplementation })
+    ).rejects.toThrow("'did:webvh:0.5' protocol unknown.");
   });
 });

--- a/test/paths.test.ts
+++ b/test/paths.test.ts
@@ -2,8 +2,6 @@ import { describe, test, expect } from "bun:test";
 import { createDID } from "../src/method";
 import { generateTestVerificationMethod, createTestSigner, TestCryptoImplementation } from "./utils";
 
-process.env.IGNORE_ASSERTION_DOCUMENT_STATE_IS_VALID = 'true';
-
 describe("Paths feature", () => {
   test("creates DID without paths (default behavior)", async () => {
     const authKey = await generateTestVerificationMethod();

--- a/test/resolve.test.ts
+++ b/test/resolve.test.ts
@@ -3,9 +3,6 @@ import { createDID, resolveDIDFromLog, updateDID } from "../src/method";
 import type { DIDLog, VerificationMethod } from "../src/interfaces";
 import { generateTestVerificationMethod, createTestSigner, TestCryptoImplementation } from "./utils";
 
-// Set environment variables for tests
-process.env.IGNORE_ASSERTION_DOCUMENT_STATE_IS_VALID = 'true';
-
 describe("resolveDIDFromLog with verificationMethod", () => {
   let initialDID: { did: string; doc: any; meta: any; log: DIDLog };
   let fullLog: DIDLog;

--- a/test/watchers.test.ts
+++ b/test/watchers.test.ts
@@ -2,8 +2,6 @@ import { describe, test, expect } from "bun:test";
 import { createDID, updateDID, resolveDIDFromLog } from "../src/method";
 import { generateTestVerificationMethod, createTestSigner, TestCryptoImplementation } from "./utils";
 
-process.env.IGNORE_ASSERTION_DOCUMENT_STATE_IS_VALID = 'true';
-
 describe("Watcher Handling", () => {
   test("Create DID with watchers", async () => {
     const authKey = await generateTestVerificationMethod();

--- a/test/witness.test.ts
+++ b/test/witness.test.ts
@@ -4,9 +4,6 @@ import type { DIDLog, VerificationMethod } from "../src/interfaces";
 import { generateTestVerificationMethod, createTestSigner, TestCryptoImplementation } from "./utils";
 import { createWitnessProof } from "../src/witness";
 
-// Set environment variables for tests
-process.env.IGNORE_ASSERTION_DOCUMENT_STATE_IS_VALID = 'true';
-
 describe("Witness Implementation Tests", async () => {
   let authKey: VerificationMethod;
   let witness1: VerificationMethod, witness2: VerificationMethod, witness3: VerificationMethod;


### PR DESCRIPTION
  - Fix hash chain to recompute entry hash instead of self-comparing versionId
  - Run hash chain validation on all entries including fast-resolve middle entries
  - Validate SCID from DID string matches SCID in fetched log
  - Fix empty nextKeyHashes array incorrectly enabling prerotation
  - Add publicKeyMultibase null check in verification method resolution
  - Add protocol version validation to v1.0 resolver
  - Surface error metadata on partial resolution failure
  - Fix CLI deactivate missing verifier
  - Remove legacy IGNORE_ASSERTION env var bypasses from assertion layer
  - Replace test scaffolding with real ed25519 verification throughout