### PR TITLE
Fix prerotation key verification logic in method.v1.0.ts

### DIFF
--- a/src/method_versions/method.v1.0.ts
+++ b/src/method_versions/method.v1.0.ts
@@ -407,11 +407,12 @@ export const updateDID = async (options: UpdateDIDInterface & { services?: any[]
   const signedProof = await options.signer.sign({ document: prelimEntry, proof: { type: 'DataIntegrityProof', cryptosuite: 'eddsa-jcs-2022', verificationMethod: options.signer.getVerificationMethodId(), created: createdDate, proofPurpose: 'assertionMethod' } });
   let allProofs = [{ type: 'DataIntegrityProof', cryptosuite: 'eddsa-jcs-2022', verificationMethod: options.signer.getVerificationMethodId(), created: createdDate, proofPurpose: 'assertionMethod', proofValue: signedProof.proofValue }];
   prelimEntry.proof = allProofs;
+  const keysToVerify = lastMeta.prerotation ? params.updateKeys : lastMeta.updateKeys;
   const verified = await documentStateIsValid(
     prelimEntry,
-    lastMeta.updateKeys,
+    keysToVerify,
     lastMeta.witness,
-    true, // skipWitnessVerification
+    true,
     options.verifier
   );
   if (!verified) {


### PR DESCRIPTION
Found a (possible?) bug when creating a compliance test suite via Claude. 

Fixes updateDID to validate the signer against params.updateKeys instead of lastMeta.updateKeys when pre-rotation is active, matching the existing resolver behaviour in resolveDIDFromLog.