### PR TITLE
feat(dids): canonical did address encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ For complete examples, see the [examples](./examples/) directory.
 
 - `createDID(options: CreateDIDInterface): Promise<{did: string, doc: any, meta: DIDResolutionMeta, log: DIDLog}>`
   Creates a new DID.
+  Accepts `address` (`host`, `host:port`, `https://...`, or `did:webvh:...`) or legacy `domain`.
+  Resolver URL mapping uses `http://localhost` for local testing and `https://` for non-local hosts.
 
 - `updateDID(options: UpdateDIDInterface): Promise<{did: string, doc: any, meta: DIDResolutionMeta, log: DIDLog}>`
   Updates an existing DID.
@@ -165,4 +167,3 @@ For complete examples, see the [examples](./examples/) directory.
 ## License
 
 This project is licensed under the [MIT License](LICENSE).
-

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -32,7 +32,8 @@ Commands:
   generate-vm Generate a new verification method keypair
 
 Options:
-  --domain [domain]         Domain for the DID (required for create)
+  --address [address]       Address for the DID (host, host:port, http://localhost, https://url, or did:webvh form) (required for create)
+  --domain [domain]         DEPRECATED: Use --address instead. Domain for the DID (backwards compatibility).
   --log [file]              Path to the DID log file (required for resolve, update, deactivate)
   --output [file]           Path to save the updated DID log (optional for create, update, deactivate)
   --portable                Make the DID portable (optional for create)
@@ -51,7 +52,11 @@ Options:
   --witness-secret [secret] Witness secret key multibase (matches witness-did order)
 
 Examples:
-  bun run cli create --domain example.com --portable --witness did:example:witness1 --witness did:example:witness2
+  bun run cli create --address example.com --portable --witness did:example:witness1 --witness did:example:witness2
+  bun run cli create --address https://example.com --portable
+  bun run cli create --address "example.com:3000" --portable
+  bun run cli create --address "did:webvh:example.com:3000" --portable
+  bun run cli create --domain example.com --portable # DEPRECATED: use --address
   bun run cli resolve --did did:webvh:123456:example.com
   bun run cli resolve --log ./did.jsonl --witness-file ./did-witness.json
   bun run cli update --log ./did.jsonl --output ./updated-did.jsonl --add-vm keyAgreement --service LinkedDomains,https://example.com
@@ -116,10 +121,14 @@ function createCustomCrypto(verificationMethod?: VerificationMethod): Signer & V
 
 export async function handleCreate(args: string[]) {
   const options = parseOptions(args);
-  const domainInput = options['domain'] as string;
-  const parts = domainInput.split('/');
-  const domain = parts[0];
-  const paths = parts.length > 1 ? parts.slice(1) : undefined;
+  
+  // Support both --address (new) and --domain (deprecated) options
+  const addressInput = (options['address'] || options['domain']) as string;
+  
+  // Extract optional explicit paths (colon-delimited) from CLI args
+  // If provided, these override any paths parsed from address input
+  const explicitPaths = options['paths'] as string[] | undefined;
+  
   const output = options['output'] as string | undefined;
   const portable = options['portable'] !== undefined;
   const nextKeyHashes = options['next-key-hash'] as string[] | undefined;
@@ -127,8 +136,8 @@ export async function handleCreate(args: string[]) {
   const watchers = options['watcher'] as string[] | undefined;
   const witnessThreshold = options['witness-threshold'] ? parseInt(options['witness-threshold'] as string) : witnesses?.length ?? 0;
 
-  if (!domain) {
-    console.error('Domain is required for create command');
+  if (!addressInput) {
+    console.error('Address is required for create command (use --address or deprecated --domain)');
     process.exit(1);
   }
 
@@ -145,9 +154,10 @@ export async function handleCreate(args: string[]) {
       purpose: authKey.purpose
     };
     
+    // Use new address parameter for strict parsing and encoding
     const { did, doc, meta, log } = await createDID({
-      domain,
-      paths,
+      address: addressInput,
+      paths: explicitPaths,
       signer: crypto,
       verifier: crypto,
       updateKeys: [authKey.publicKeyMultibase!],

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -120,7 +120,8 @@ export interface ServiceEndpoint {
 }
 
 export interface CreateDIDInterface {
-  domain: string;
+  domain?: string;
+  address?: string;
   signer: Signer;
   updateKeys: string[];
   verificationMethods: VerificationMethod[];

--- a/src/method_versions/method.v0.5.ts
+++ b/src/method_versions/method.v0.5.ts
@@ -1,4 +1,4 @@
-import { createDate, createDIDDoc, createSCID, deriveHash, findVerificationMethod, getBaseUrl, replaceValueInObject, deepClone } from "../utils";
+import { createDate, createDIDDoc, createSCID, deriveHash, findVerificationMethod, getBaseUrl, replaceValueInObject, deepClone, parseCanonicalAddress } from "../utils";
 import {METHOD, PLACEHOLDER } from '../constants';
 import { documentStateIsValid, hashChainValid, newKeysAreInNextKeys, scidIsFromHash } from '../assertions';
 import type { CreateDIDInterface, DIDResolutionMeta, DIDLogEntry, DIDLog, UpdateDIDInterface, DeactivateDIDInterface, ResolutionOptions, WitnessProofFileEntry, WitnessParameterResolution } from '../interfaces';
@@ -16,9 +16,17 @@ export const createDID = async (options: CreateDIDInterface): Promise<{did: stri
     validateWitnessParameter(options.witness);
   }
   
-  const encodedDomain = encodeURIComponent(options.domain);
-  const path = options.paths?.join(':');
-  const controller = `did:${METHOD}:${PLACEHOLDER}:${encodedDomain}${path ? `:${path}` : ''}`;
+  // Parse address input with strict validation
+  const addressInput = options.address || options.domain;
+  if (!addressInput) {
+    throw new Error('Either address or domain must be provided');
+  }
+
+  const parsed = parseCanonicalAddress(addressInput);
+  const didDomainComponent = parsed.didDomainComponent;
+  const allPaths = [...(parsed.paths || []), ...(options.paths || [])];
+  const path = allPaths.length > 0 ? allPaths.join(':') : undefined;
+  const controller = `did:${METHOD}:${PLACEHOLDER}:${didDomainComponent}${path ? `:${path}` : ''}`;
   const createdDate = createDate(options.created);
   
   // Safety guard: Strip secret keys from verification methods before creating DID document

--- a/src/method_versions/method.v1.0.ts
+++ b/src/method_versions/method.v1.0.ts
@@ -1,4 +1,4 @@
-import { createDate, createDIDDoc, createSCID, deriveHash, findVerificationMethod, getActiveDIDs, getBaseUrl, replaceValueInObject, deepClone } from "../utils";
+import { createDate, createDIDDoc, createSCID, deriveHash, findVerificationMethod, getActiveDIDs, getBaseUrl, replaceValueInObject, deepClone, parseCanonicalAddress } from "../utils";
 import { METHOD, PLACEHOLDER } from '../constants';
 import { documentStateIsValid, hashChainValid, newKeysAreInNextKeys, scidIsFromHash } from '../assertions';
 import type { CreateDIDInterface, DIDResolutionMeta, DIDLogEntry, DIDLog, UpdateDIDInterface, DeactivateDIDInterface, ResolutionOptions, WitnessProofFileEntry, DataIntegrityProof } from '../interfaces';
@@ -15,9 +15,18 @@ export const createDID = async (options: CreateDIDInterface): Promise<{did: stri
   if (options.witness && options.witness.witnesses && options.witness.witnesses.length > 0) {
     validateWitnessParameter(options.witness);
   }
-  const encodedDomain = encodeURIComponent(options.domain);
-  const path = options.paths?.join(':');
-  const controller = `did:${METHOD}:${PLACEHOLDER}:${encodedDomain}${path ? `:${path}` : ''}`;
+
+  // Parse address input with strict validation
+  const addressInput = options.address || options.domain;
+  if (!addressInput) {
+    throw new Error('Either address or domain must be provided');
+  }
+
+  const parsed = parseCanonicalAddress(addressInput);
+  const didDomainComponent = parsed.didDomainComponent;
+  const allPaths = [...(parsed.paths || []), ...(options.paths || [])];
+  const path = allPaths.length > 0 ? allPaths.join(':') : undefined;
+  const controller = `did:${METHOD}:${PLACEHOLDER}:${didDomainComponent}${path ? `:${path}` : ''}`;
   const createdDate = createDate(options.created);
   
   // Safety guard: Strip secret keys from verification methods before creating DID document

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,6 +7,165 @@ import { bufferToString, createBuffer } from './utils/buffer';
 import { createHash } from './utils/crypto';
 import { createMultihash, encodeBase58Btc, MultihashAlgorithm } from './utils/multiformats';
 
+// Canonical address parser for strict parity with didwebvh-rs
+interface ParsedAddress {
+  canonicalHost: string;
+  canonicalPort?: number;
+  didDomainComponent: string;
+  paths?: string[];
+}
+
+function isIPAddress(host: string): boolean {
+  // Reject IPv4
+  if (/^\d+\.\d+\.\d+\.\d+$/.test(host)) return true;
+  // Reject IPv6 (with or without brackets)
+  const bare = host.replace(/^\[|\]$/g, '');
+  if (/^[0-9a-f:]+$/i.test(bare)) return true;
+  return false;
+}
+
+function isDoubleEncoded(value: string): boolean {
+  // Detect %25 (which is percent-encoded %)
+  return value.includes('%25');
+}
+
+export function parseCanonicalAddress(input: string): ParsedAddress {
+  if (!input || typeof input !== 'string') {
+    throw new Error('Address input must be a non-empty string');
+  }
+
+  // Parse did:webvh form
+  if (input.startsWith('did:webvh:')) {
+    const parts = input.substring(10).split(':');
+    if (parts.length < 2) {
+      throw new Error('Invalid did:webvh identifier: must contain SCID (or {SCID} placeholder) and domain');
+    }
+
+    const scid = parts[0];
+    let domainPart = parts[1];
+    const pathParts = parts.slice(2);
+
+    // Detect double encoding
+    if (isDoubleEncoded(domainPart)) {
+      throw new Error('Domain is double-encoded (detected %25)');
+    }
+
+    // Extract port from domain if %3A-encoded
+    let host = domainPart;
+    let port: number | undefined;
+
+    if (domainPart.includes('%3A')) {
+      const [h, p] = domainPart.split('%3A');
+      host = h;
+      const portNum = parseInt(p, 10);
+      if (isNaN(portNum) || portNum <= 0 || portNum > 65535) {
+        throw new Error(`Invalid port number: ${p}`);
+      }
+      port = portNum;
+    }
+
+    if (isIPAddress(host)) {
+      throw new Error('IP addresses are not allowed as hosts');
+    }
+
+    return {
+      canonicalHost: host,
+      canonicalPort: port,
+      didDomainComponent: domainPart,
+      paths: pathParts.length > 0 ? pathParts : undefined,
+    };
+  }
+
+  // Parse URL form: HTTPS everywhere, with localhost-only HTTP for local testing.
+  if (input.startsWith('https://') || input.startsWith('http://')) {
+    try {
+      const url = new URL(input);
+      if (url.protocol === 'http:' && url.hostname !== 'localhost') {
+        throw new Error('HTTP is only allowed for localhost; use HTTPS for non-local hosts');
+      }
+      const host = url.hostname;
+      const port = url.port ? parseInt(url.port, 10) : undefined;
+
+      if (isIPAddress(host)) {
+        throw new Error('IP addresses are not allowed as hosts');
+      }
+
+      let didDomainComponent = host;
+      if (port) {
+        didDomainComponent += `%3A${port}`;
+      }
+
+      const pathParts: string[] = [];
+      if (url.pathname && url.pathname !== '/') {
+        url.pathname
+          .split('/')
+          .filter(p => p.length > 0)
+          .forEach(p => pathParts.push(p));
+      }
+
+      return {
+        canonicalHost: host,
+        canonicalPort: port,
+        didDomainComponent,
+        paths: pathParts.length > 0 ? pathParts : undefined,
+      };
+    } catch (e: any) {
+      if (e.message && e.message.includes('not allowed')) throw e;
+      throw new Error(`Invalid URL: ${e.message}`);
+    }
+  }
+
+  // Parse domain string form (host or host:port)
+  // Detect double encoding
+  if (isDoubleEncoded(input)) {
+    throw new Error('Domain is double-encoded (detected %25)');
+  }
+
+  let host = input;
+  let port: number | undefined;
+
+  // Check if pre-encoded with %3A
+  if (input.includes('%3A')) {
+    const parts = input.split('%3A');
+    if (parts.length !== 2) {
+      throw new Error('Invalid pre-encoded port separator');
+    }
+    host = parts[0];
+    const portNum = parseInt(parts[1], 10);
+    if (isNaN(portNum) || portNum <= 0 || portNum > 65535) {
+      throw new Error(`Invalid port number: ${parts[1]}`);
+    }
+    port = portNum;
+  } else if (input.includes(':')) {
+    // Raw host:port form
+    const parts = input.split(':');
+    if (parts.length !== 2) {
+      throw new Error('Invalid host:port format');
+    }
+    host = parts[0];
+    const portNum = parseInt(parts[1], 10);
+    if (isNaN(portNum) || portNum <= 0 || portNum > 65535) {
+      throw new Error(`Invalid port number: ${parts[1]}`);
+    }
+    port = portNum;
+  }
+
+  if (isIPAddress(host)) {
+    throw new Error('IP addresses are not allowed as hosts');
+  }
+
+  let didDomainComponent = host;
+  if (port) {
+    didDomainComponent += `%3A${port}`;
+  }
+
+  return {
+    canonicalHost: host,
+    canonicalPort: port,
+    didDomainComponent,
+  };
+}
+
 // Environment detection - treat React Native like a browser, but Bun as Node-like
 const isNodeEnvironment = typeof process !== 'undefined'
   && typeof window === 'undefined'

--- a/test/domain-encoding.test.ts
+++ b/test/domain-encoding.test.ts
@@ -1,18 +1,104 @@
-import { describe, test, expect } from "bun:test";
-import { createDID } from "../src/method";
-import { generateTestVerificationMethod, createTestSigner, TestCryptoImplementation } from "./utils";
+import { describe, test, expect } from 'bun:test'
+import { createDID } from '../src/method'
+import { generateTestVerificationMethod, createTestSigner, TestCryptoImplementation } from './utils'
 
-describe("Domain encoding", () => {
-  test("encodes port number in DID", async () => {
-    const authKey = await generateTestVerificationMethod();
-    const verifier = new TestCryptoImplementation({ verificationMethod: authKey });
-    const { doc } = await createDID({
-      domain: 'localhost:3000',
-      signer: createTestSigner(authKey),
-      updateKeys: [authKey.publicKeyMultibase!],
-      verificationMethods: [authKey],
-      verifier
-    });
-    expect(doc.id).toContain('localhost%3A3000');
-  });
-});
+type InputKind = 'domain' | 'address'
+
+async function createFromInput(kind: InputKind, value: string) {
+  const authKey = await generateTestVerificationMethod()
+  const verifier = new TestCryptoImplementation({ verificationMethod: authKey })
+
+  const baseOptions = {
+    signer: createTestSigner(authKey),
+    updateKeys: [authKey.publicKeyMultibase!],
+    verificationMethods: [authKey],
+    verifier,
+  }
+
+  if (kind === 'domain') {
+    return createDID({
+      ...baseOptions,
+      domain: value,
+    })
+  }
+
+  return createDID({
+    ...baseOptions,
+    address: value,
+  } as any)
+}
+
+describe('Strict address input validation and parsing', () => {
+  test('accepts host-only domain input', async () => {
+    const { doc } = await createFromInput('domain', 'example.com')
+    expect(doc.id).toMatch(/^did:webvh:[^:]+:example\.com$/)
+  })
+
+  test('Accepts host:port domain input with canonical %3A encoding', async () => {
+    const { doc } = await createFromInput('domain', 'example.com:443')
+    expect(doc.id).toMatch(/^did:webvh:[^:]+:example\.com%3A443$/)
+  })
+
+  test('Accepts pre-encoded host%3Aport without double encoding', async () => {
+    const { doc } = await createFromInput('domain', 'localhost%3A8000')
+    expect(doc.id).toMatch(/^did:webvh:[^:]+:localhost%3A8000$/)
+  })
+
+  test('Accepts https URL address input', async () => {
+    const { doc } = await createFromInput('address', 'https://example.com/')
+    expect(doc.id).toMatch(/^did:webvh:[^:]+:example\.com$/)
+  })
+
+  test('Accepts URL with explicit port', async () => {
+    const { doc } = await createFromInput('address', 'https://example.com:8080/')
+    expect(doc.id).toMatch(/^did:webvh:[^:]+:example\.com%3A8080$/)
+  })
+
+  test('Accepts URL with custom path and converts to colon-delimited DID path', async () => {
+    const { doc } = await createFromInput('address', 'https://example.com/custom/path')
+    expect(doc.id).toMatch(/^did:webvh:[^:]+:example\.com:custom:path$/)
+  })
+
+  test('Accepts localhost HTTP URL with path and port', async () => {
+    const { doc } = await createFromInput('address', 'http://localhost:8000/test')
+    expect(doc.id).toMatch(/^did:webvh:[^:]+:localhost%3A8000:test$/)
+  })
+
+  test('Accepts localhost HTTPS URL with path and port', async () => {
+    const { doc } = await createFromInput('address', 'https://localhost:8000/test')
+    expect(doc.id).toMatch(/^did:webvh:[^:]+:localhost%3A8000:test$/)
+  })
+
+  test('Accepts canonical did:webvh input with port and path', async () => {
+    const { doc } = await createFromInput('address', 'did:webvh:{SCID}:example.com%3A8080:custom:path')
+    expect(doc.id).toMatch(/^did:webvh:[^:]+:example\.com%3A8080:custom:path$/)
+  })
+
+  test('Rejects unsupported URL scheme', async () => {
+    expect(createFromInput('address', 'ftp://example.com')).rejects.toThrow()
+  })
+
+  test('Rejects HTTP URL for non-local host', async () => {
+    expect(createFromInput('address', 'http://example.com')).rejects.toThrow()
+  })
+
+  test('Rejects out-of-range port', async () => {
+    expect(createFromInput('domain', 'example.com:999999')).rejects.toThrow()
+  })
+
+  test('Rejects IPv4 host input', async () => {
+    expect(createFromInput('domain', '192.168.1.10')).rejects.toThrow()
+  })
+
+  test('Rejects double-encoded separator', async () => {
+    expect(createFromInput('domain', 'example.com%253A8080')).rejects.toThrow()
+  })
+
+  test('Rejects mangled host:port input', async () => {
+    expect(createFromInput('domain', '%%%bad host%%%::notaport::')).rejects.toThrow()
+  })
+
+  test('Rejects mangled URL input', async () => {
+    expect(createFromInput('address', 'https://%%%bad host%%%::notaport::/%%%')).rejects.toThrow()
+  })
+})

--- a/test/resolve.test.ts
+++ b/test/resolve.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test, beforeAll } from "bun:test";
 import { createDID, resolveDIDFromLog, updateDID } from "../src/method";
 import type { DIDLog, VerificationMethod } from "../src/interfaces";
 import { generateTestVerificationMethod, createTestSigner, TestCryptoImplementation } from "./utils";
+import { getBaseUrl, getFileUrl } from "../src/utils";
 
 describe("resolveDIDFromLog with verificationMethod", () => {
   let initialDID: { did: string; doc: any; meta: any; log: DIDLog };
@@ -136,5 +137,25 @@ describe("resolveDIDFromLog with verificationMethod", () => {
     }
     expect(error).not.toBeNull();
     expect(error?.message).toBe("Cannot specify both verificationMethod and version number/id");
+  });
+});
+
+describe("Resolver URL derivation", () => {
+  test("Uses http for localhost DID host", () => {
+    const did = "did:webvh:scid:localhost%3A8000:test:path";
+    expect(getBaseUrl(did)).toBe("http://localhost:8000/test/path");
+    expect(getFileUrl(did)).toBe("http://localhost:8000/test/path/did.jsonl");
+  });
+
+  test("Uses https for non-localhost DID host", () => {
+    const did = "did:webvh:scid:example.com%3A8080:custom:path";
+    expect(getBaseUrl(did)).toBe("https://example.com:8080/custom/path");
+    expect(getFileUrl(did)).toBe("https://example.com:8080/custom/path/did.jsonl");
+  });
+
+  test("Uses .well-known did.jsonl when DID has no path", () => {
+    const did = "did:webvh:scid:example.com";
+    expect(getBaseUrl(did)).toBe("https://example.com");
+    expect(getFileUrl(did)).toBe("https://example.com/.well-known/did.jsonl");
   });
 });


### PR DESCRIPTION
Enhanced DID address parsing for `createDID` with backwards `domain` compatibility in api and cli:

* Supports multiple input forms including `host`, `host:port`, `http://localhost` (local testing), `https://url`, `did:webvh:`
* Strict validation to reject malformed URLs, canonical DIDs and invalid ports, IP-address hosts
* Port-containing domains normalise to percent encoding (`%3A`) with rejection of double encoding

Modified test suite to cover wide range of acceptable and unacceptable address forms and resolver URL derivations

Same parsing behaviour used in both `v1.0` and `v0.5` paths

