### PR TITLE
feat: accept ecdsa-jcs-2019 + P-256 multikey in proof verification

### DIFF
--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -76,7 +76,7 @@ export const documentStateIsValid = async (
     if (proof.proofPurpose !== 'authentication' && proof.proofPurpose !== 'assertionMethod') {
       throw new Error(`Unknown proof purpose ${proof.proofPurpose}`);
     }
-    if (proof.cryptosuite !== 'eddsa-jcs-2022') {
+    if (proof.cryptosuite !== 'eddsa-jcs-2022' && proof.cryptosuite !== 'ecdsa-jcs-2019') {
       throw new Error(`Unknown cryptosuite ${proof.cryptosuite}`);
     }
 
@@ -86,8 +86,15 @@ export const documentStateIsValid = async (
     }
 
     const publicKey = multibaseDecode(vm.publicKeyMultibase).bytes;
-    if (publicKey[0] !== 0xed || publicKey[1] !== 0x01) {
-      throw new Error(`multiKey doesn't include ed25519 header (0xed01)`);
+    // Multikey multicodec prefixes (varint-encoded):
+    //   Ed25519 (0xed)  → [0xed, 0x01]
+    //   P-256   (0x1200) → [0x80, 0x24]
+    // The Verifier hook is algorithm-agnostic — the consumer's `verify`
+    // implementation is responsible for picking the right primitive.
+    const isEd25519MultiKey = publicKey[0] === 0xed && publicKey[1] === 0x01;
+    const isP256MultiKey = publicKey[0] === 0x80 && publicKey[1] === 0x24;
+    if (!isEd25519MultiKey && !isP256MultiKey) {
+      throw new Error(`multiKey doesn't include ed25519 (0xed01) or p256 (0x8024) header`);
     }
 
     const {proofValue, ...restProof} = proof;

--- a/src/witness.ts
+++ b/src/witness.ts
@@ -52,7 +52,7 @@ export function calculateWitnessWeight(proofs: DataIntegrityProof[], witnesses: 
   for (const proof of proofs) {
     const witness = witnesses.find(w => proof.verificationMethod.startsWith(w.id));
     if (witness) {
-      if (proof.cryptosuite !== 'eddsa-jcs-2022') {
+      if (proof.cryptosuite !== 'eddsa-jcs-2022' && proof.cryptosuite !== 'ecdsa-jcs-2019') {
         throw new Error('Invalid witness proof cryptosuite');
       }
       processed.add(witness.id);
@@ -79,7 +79,7 @@ export async function verifyWitnessProofs(
   for (const proofSet of witnessProofs) {
     // Process each proof in the set
     for (const proof of proofSet.proof) {
-      if (proof.cryptosuite !== 'eddsa-jcs-2022') {
+      if (proof.cryptosuite !== 'eddsa-jcs-2022' && proof.cryptosuite !== 'ecdsa-jcs-2019') {
         throw new Error('Invalid witness proof cryptosuite');
       }
 
@@ -107,8 +107,10 @@ export async function verifyWitnessProofs(
           throw new Error(`Failed to decode public key: ${error.message}`);
         }
         
-        if (publicKey.length !== 34) {
-          throw new Error(`Invalid public key length ${publicKey.length} (should be 34 bytes)`);
+        // 34 bytes = 2-byte multicodec prefix + 32-byte Ed25519 raw key
+        // 35 bytes = 2-byte multicodec prefix + 33-byte SEC1-compressed P-256 key
+        if (publicKey.length !== 34 && publicKey.length !== 35) {
+          throw new Error(`Invalid public key length ${publicKey.length} (should be 34 (Ed25519) or 35 (P-256) bytes)`);
         }
 
         // Extract proof value and prepare data for verification


### PR DESCRIPTION
## Summary

The W3C VC Data Integrity spec defines multiple ECDSA cryptosuites — `eddsa-jcs-2022` for Ed25519 and `ecdsa-jcs-2019` for P-256 — over the same JCS canonicalization. Today this library accepts only `eddsa-jcs-2022`, so `did:webvh` logs minted with P-256 keys are unresolvable through `resolveDIDFromLog` and `verifyWitnessProofs`, even though the underlying hash + signature primitives are interchangeable and the `Verifier` hook is already algorithm-agnostic.

This PR extends three checks in the verify path to accept the P-256 path alongside Ed25519. **Backward-compatible** — the new conditions are strictly broader; every existing Ed25519 log continues to verify unchanged. **No API change** — the `Verifier.verify(signature, message, publicKey)` hook stays the same; consumers pick the right ECDSA/EdDSA primitive in their own implementation.

## What changed

`src/assertions.ts` (`documentStateIsValid`):

- Cryptosuite check now accepts `eddsa-jcs-2022` **or** `ecdsa-jcs-2019`.
- Multikey-header byte check now accepts Ed25519 `[0xed, 0x01]` **or** P-256 `[0x80, 0x24]` (varint-encoded multicodec `0x1200` for `p256-pub`).

`src/witness.ts` (`calculateWitnessWeight` + `verifyWitnessProofs`):

- Two cryptosuite checks extended the same way.
- Public-key length check now accepts `34` (Ed25519: 2-byte prefix + 32-byte raw) **or** `35` (P-256: 2-byte prefix + 33-byte SEC1-compressed).

## Why this is safe

- The `Verifier` interface (`src/interfaces.ts`) is already algorithm-agnostic: `verify(signature, message, publicKey)`. Accepting a P-256 cryptosuite doesn't require any verifier change in the library — the consumer's `verify` implementation does the right thing for the public key it sees.
- The signing side (`createProof`, `method.v0.5`, `method.v1.0`, `cli.ts`) is **not** touched in this PR. Those still hardcode `cryptosuite: 'eddsa-jcs-2022'` for compatibility, and signers that want to mint P-256 logs continue to do so via their own `Signer` implementation (as before, just now with the reciprocal verify path supported by this library).
- The existing test suite for Ed25519 keeps passing; no test fixture is changed.

## How it was tested

The change has been running in production at Raisonnai (an art catalogue + identity-infrastructure project that uses `did:webvh` for P-256-signed verifiable credentials). Our integration test now exercises a full `prepareGenesisLogEntry → finalizeGenesisLogEntry → resolveDIDFromLog` round-trip with P-256 keys against this patch — it had previously been skipped with a `// TODO: library hardcodes eddsa-jcs-2022` comment.

Happy to add an in-tree P-256 test if you'd like — that would mean a new dev-dep (e.g. `@noble/curves`), so I left it out to keep this PR minimal. Let me know your preference.

## Notes

- A future PR could extend `createProof` and the v1.0/v0.5 method implementations to mint P-256 logs from this library directly (currently consumers compose the signing themselves). That's larger and orthogonal — happy to follow up if it's wanted, but separating the two felt right since this PR's goal is to unblock cross-implementation interop on the *verify* side.