### PR TITLE
fix: handle non-array doc.service during resolution

### DIFF
--- a/src/method_versions/method.v0.5.ts
+++ b/src/method_versions/method.v0.5.ts
@@ -229,7 +229,7 @@ export const resolveDIDFromLog = async (log: DIDLog, options: ResolutionOptions 
     did = doc.id;
 
     // Add default services if they don't exist
-    doc.service = doc.service || [];
+    doc.service = Array.isArray(doc.service) ? doc.service : [];
     const baseUrl = getBaseUrl(did);
 
     if (!doc.service.some((s: any) => s.id === '#files')) {

--- a/src/method_versions/method.v1.0.ts
+++ b/src/method_versions/method.v1.0.ts
@@ -241,7 +241,7 @@ export const resolveDIDFromLog = async (log: DIDLog, options: ResolutionOptions 
     // Only add default services for entries we need to process
     if (shouldVerifyEntry(i) || i === resolutionLog.length - 1) {
       // Add default services if they don't exist
-      doc.service = doc.service || [];
+      doc.service = Array.isArray(doc.service) ? doc.service : [];
       const baseUrl = getBaseUrl(did);
 
       if (!doc.service.some((s: any) => s.id === '#files')) {


### PR DESCRIPTION
This one appeared after I added a malformed "service" entry to the log that was an object, not a list. The change updates the lines that check for a "service" entry to confirm it is an array, not something else. If it isn't an array, it is treated as an empty array `[]`.