### PR TITLE
fix: publish via npm OIDC trusted publishing (restore pre-#107 auth)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,6 +26,9 @@ jobs:
           node-version: 22
           registry-url: https://registry.npmjs.org
 
+      - name: Upgrade npm (needed for OIDC trusted publishing)
+        run: npm install -g npm@latest
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1
         with:
@@ -58,6 +61,4 @@ jobs:
         run: bun run build
 
       - name: Publish to npm
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_WEBVH_TS }}
         run: npm publish --provenance

--- a/README.md
+++ b/README.md
@@ -122,15 +122,18 @@ That will trigger the publish workflow, which will:
 - run `bun test` and `bun run build`
 - publish to npm
 
-### Repository secrets required
+### npm authentication
 
-- **`NPM_TOKEN_WEBVH_TS`**: an npm access token with permission to publish the package. Provided as an organization-level secret in the `decentralized-identity` org.
+Publishing uses [npm OIDC trusted publishing](https://docs.npmjs.com/trusted-publishers) — the workflow exchanges its GitHub Actions OIDC token for a short-lived npm publish token at publish time. No static `NPM_TOKEN` is required.
+
+For this to work, the `didwebvh-ts` package on npmjs.com must have a Trusted Publisher configured pointing at this repository and the `.github/workflows/publish.yml` workflow.
 
 ### Troubleshooting
 
 - **Tag rejected**: make sure it matches `vX.Y.Z` and is exactly one major/minor/patch bump over the latest `v*` tag.
 - **Permission rejected**: ensure the releasing user has write/maintain/admin permission on the GitHub repo.
-- **Publish failed auth**: ensure `NPM_TOKEN_WEBVH_TS` is configured (as a repo or org-level secret accessible to this repo).
+- **`EOTP` / OTP required at publish**: the npm token path is being used instead of OIDC. Make sure no `NODE_AUTH_TOKEN` is set on the publish step and that the workflow has `id-token: write` permission.
+- **OIDC exchange failed**: confirm the Trusted Publisher config on npmjs.com matches this repo's owner, name, and workflow file path (`.github/workflows/publish.yml`).
 
 ## Creating a DID Resolver
 


### PR DESCRIPTION
## Summary

The pre-#107 semantic-release-based workflow authenticated to npm via **OIDC trusted publishing**, not a static token. Past successful publish logs confirm this:

```
[@semantic-release/npm] › ℹ  Verifying OIDC context for publishing from GitHub Actions
[@semantic-release/npm] › ℹ  OIDC token exchange with the npm registry succeeded
```

After #107 we tried a static token (first `secrets.NPM_TOKEN`, which didn't exist; then `secrets.NPM_TOKEN_WEBVH_TS`). The org-scoped token authenticated but the package has 2FA-for-publish enforced, so `npm publish` failed with `EOTP` — only a legacy automation token or OIDC trusted publishing bypasses 2FA.

This PR restores the working pattern:

- Drop `NODE_AUTH_TOKEN` from the publish step.
- Upgrade the npm CLI so `npm publish` performs the OIDC token exchange natively (npm 11.5.1+).
- Update the README so the documented auth model matches what actually runs.

The `id-token: write` permission was already granted (for provenance) and is what OIDC trusted publishing needs.

## Notes

- The Trusted Publisher record on npmjs.com must point at this repo and `.github/workflows/publish.yml`. Since the workflow file path is unchanged, the existing config that was working pre-#107 should still apply.

## Test plan

- [ ] After merging, re-run the failed `v2.7.5` workflow (or cut a fresh release) and confirm the publish step succeeds without OTP and that provenance is still signed.