### PR TITLE
fix: publish via npm OIDC trusted publishing instead of static token

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,6 +58,4 @@ jobs:
         run: bun run build
 
       - name: Publish to npm
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_WEBVH_TS }}
-        run: npm publish --provenance
+        run: npx -y npm@latest publish --provenance

--- a/README.md
+++ b/README.md
@@ -122,15 +122,18 @@ That will trigger the publish workflow, which will:
 - run `bun test` and `bun run build`
 - publish to npm
 
-### Repository secrets required
+### npm authentication
 
-- **`NPM_TOKEN_WEBVH_TS`**: an npm access token with permission to publish the package. Provided as an organization-level secret in the `decentralized-identity` org.
+Publishing uses [npm OIDC trusted publishing](https://docs.npmjs.com/trusted-publishers) — the workflow exchanges its GitHub Actions OIDC token for a short-lived npm publish token at publish time. No static `NPM_TOKEN` is required.
+
+For this to work, the `didwebvh-ts` package on npmjs.com must have a Trusted Publisher configured pointing at this repository and the `.github/workflows/publish.yml` workflow.
 
 ### Troubleshooting
 
 - **Tag rejected**: make sure it matches `vX.Y.Z` and is exactly one major/minor/patch bump over the latest `v*` tag.
 - **Permission rejected**: ensure the releasing user has write/maintain/admin permission on the GitHub repo.
-- **Publish failed auth**: ensure `NPM_TOKEN_WEBVH_TS` is configured (as a repo or org-level secret accessible to this repo).
+- **`EOTP` / OTP required at publish**: the npm token path is being used instead of OIDC. Make sure no `NODE_AUTH_TOKEN` is set on the publish step and that the workflow has `id-token: write` permission.
+- **OIDC exchange failed**: confirm the Trusted Publisher config on npmjs.com matches this repo's owner, name, and workflow file path (`.github/workflows/publish.yml`).
 
 ## Creating a DID Resolver
 


### PR DESCRIPTION
The pre-#107 semantic-release-based workflow authenticated to npm via OIDC trusted publishing ("Verifying OIDC context for publishing from GitHub Actions" / "OIDC token exchange with the npm registry succeeded"). The static NPM_TOKEN_WEBVH_TS path adopted after #107 fails with EOTP because the token type does not bypass 2FA on this package.

Restore the previous auth pattern by dropping NODE_AUTH_TOKEN and running publish through npx with a recent npm (the npm shipped with node 22 is too old for native OIDC trusted publishing; an earlier attempt to upgrade the global npm in-place hit the known self-upgrade MODULE_NOT_FOUND bug, so npx is used instead). The id-token: write permission was already in place for provenance.

The Trusted Publisher configuration on npmjs.com must continue to match this repo and .github/workflows/publish.yml.