### PR TITLE
fix: run npm publish via npx to avoid npm self-upgrade bug

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,9 +26,6 @@ jobs:
           node-version: 22
           registry-url: https://registry.npmjs.org
 
-      - name: Upgrade npm (needed for OIDC trusted publishing)
-        run: npm install -g npm@latest
-
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1
         with:
@@ -61,4 +58,4 @@ jobs:
         run: bun run build
 
       - name: Publish to npm
-        run: npm publish --provenance
+        run: npx -y npm@latest publish --provenance


### PR DESCRIPTION
## Summary

The `Upgrade npm` step that landed in #109 hits the well-known `npm install -g npm@latest` self-upgrade bug: npm deletes some of its own dependencies (`promise-retry`) mid-install before the new npm is fully in place, leaving the global install in a broken state and failing the workflow with `MODULE_NOT_FOUND` (see [run 26185554592](https://github.com/decentralized-identity/didwebvh-ts/actions/runs/26185554592/job/77039938830)).

This PR:

- Removes the in-place `npm install -g npm@latest` step.
- Changes the publish step to `npx -y npm@latest publish --provenance`. `npx` pulls a fresh npm into its cache without touching the global install, and the recent npm performs the OIDC trusted-publishing exchange that bypasses 2FA.

## Test plan

- [ ] After merging, re-run the `v2.7.5` workflow (or cut a fresh release) and confirm the publish step succeeds, signs provenance, and shows the npm OIDC token exchange.