### PR TITLE
feat(core): proof template

### DIFF
--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -2,7 +2,7 @@ import { createSCID, deriveNextKeyHash, resolveVM } from "./utils";
 import { canonicalize } from 'json-canonicalize';
 import { createHash } from './utils/crypto';
 import { concatBuffers } from './utils/buffer';
-import { Verifier, WitnessParameterResolution } from './interfaces';
+import type { DIDLogEntry, Verifier, WitnessParameterResolution } from './interfaces';
 import { validateWitnessParameter } from './witness';
 import { multibaseDecode } from "./utils/multiformats";
 
@@ -34,7 +34,7 @@ const isWitnessAuthorized = (verificationMethod: string, witnesses: string[]): b
 };
 
 export const documentStateIsValid = async (
-  doc: any, 
+  doc: DIDLogEntry,
   updateKeys: string[], 
   witness: WitnessParameterResolution | undefined | null,
   skipWitnessVerification?: boolean,
@@ -45,6 +45,9 @@ export const documentStateIsValid = async (
   }
   
   let {proof: proofs, ...rest} = doc;
+  if (!proofs) {
+    throw new Error('Missing proof in DID log entry');
+  }
   if (!Array.isArray(proofs)) {
     proofs = [proofs];
   }
@@ -73,8 +76,8 @@ export const documentStateIsValid = async (
     if (proof.type !== 'DataIntegrityProof') {
       throw new Error(`Unknown proof type ${proof.type}`);
     }
-    if (proof.proofPurpose !== 'authentication' && proof.proofPurpose !== 'assertionMethod') {
-      throw new Error(`Unknown proof purpose ${proof.proofPurpose}`);
+    if (proof.proofPurpose !== 'assertionMethod') {
+      throw new Error(`Invalid proof purpose '${proof.proofPurpose}' for DID log entry proof. Expected 'assertionMethod'.`);
     }
     if (proof.cryptosuite !== 'eddsa-jcs-2022') {
       throw new Error(`Unknown cryptosuite ${proof.cryptosuite}`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,7 +4,7 @@ import { createDID, updateDID, deactivateDID, resolveDIDFromLog } from './method
 import { fetchLogFromIdentifier, readLogFromDisk, writeLogToDisk, writeVerificationMethodToEnv } from './utils';
 import { dirname } from 'path';
 import fs from 'fs';
-import { DIDLog, ServiceEndpoint, VerificationMethod, Verifier } from './interfaces';
+import { DIDLog, ServiceEndpoint, VerificationMethod, Verifier, DataIntegrityProofTemplate } from './interfaces';
 import { createBuffer } from './utils/buffer';
 import { bufferToString } from './utils/buffer';
 import { Signer, SigningInput, SigningOutput } from './interfaces';
@@ -440,7 +440,7 @@ async function handleGenerateWitnessProof(args: string[]) {
     };
     const crypto = createCustomCrypto(vm);
     const signerFn = async (data: any) => {
-      const proofTemplate = {
+      const proofTemplate: DataIntegrityProofTemplate = {
         type: 'DataIntegrityProof',
         cryptosuite: 'eddsa-jcs-2022',
         verificationMethod: `${did}#${publicKeyMultibase}`,
@@ -451,7 +451,8 @@ async function handleGenerateWitnessProof(args: string[]) {
       const signed = await crypto.sign(signingInput);
       return { proof: { ...proofTemplate, proofValue: signed.proofValue } };
     };
-    const proof = await createWitnessProof(signerFn, versionId);
+    const verificationMethod = `${did}#${publicKeyMultibase}`;
+    const proof = await createWitnessProof(signerFn, versionId, verificationMethod);
     proofs.push(proof);
   }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -445,7 +445,7 @@ async function handleGenerateWitnessProof(args: string[]) {
         cryptosuite: 'eddsa-jcs-2022',
         verificationMethod: `${did}#${publicKeyMultibase}`,
         created: new Date().toISOString(),
-        proofPurpose: 'authentication'
+        proofPurpose: 'assertionMethod'
       };
       const signingInput = { document: data, proof: proofTemplate };
       const signed = await crypto.sign(signingInput);

--- a/src/cryptography.ts
+++ b/src/cryptography.ts
@@ -1,7 +1,7 @@
 import { createDate } from "./utils";
 import { canonicalize } from 'json-canonicalize';
 import { createHash } from './utils/crypto';
-import type { VerificationMethod, SigningInput, SigningOutput, Signer, SignerOptions, Verifier } from './interfaces';
+import type { DataIntegrityProofTemplate, VerificationMethod, SigningInput, SigningOutput, Signer, SignerOptions, Verifier } from './interfaces';
 import { concatBuffers } from './utils/buffer';
 
 /**
@@ -9,7 +9,7 @@ import { concatBuffers } from './utils/buffer';
  * @param verificationMethodId - The verification method ID to use in the proof
  * @returns A proof object with type, cryptosuite, verificationMethod, created, and proofPurpose
  */
-export const createProof = (verificationMethodId: string): any => {
+export const createProof = (verificationMethodId: string): DataIntegrityProofTemplate => {
   return {
     type: 'DataIntegrityProof',
     cryptosuite: 'eddsa-jcs-2022',
@@ -25,7 +25,10 @@ export const createProof = (verificationMethodId: string): any => {
  * @param proof - The proof object
  * @returns The prepared data for signing as a Uint8Array
  */
-export const prepareDataForSigning = async (document: any, proof: any): Promise<Uint8Array> => {
+export const prepareDataForSigning = async (
+  document: unknown,
+  proof: DataIntegrityProofTemplate
+): Promise<Uint8Array> => {
   const dataHash = await createHash(canonicalize(document));
   const proofHash = await createHash(canonicalize(proof));
   return concatBuffers(proofHash, dataHash);
@@ -86,9 +89,8 @@ export const createDocumentSigner = (signer: Signer, verificationMethodId: strin
     try {
       const proof = createProof(verificationMethodId);
       const result = await signer.sign({ document: doc, proof });
-      
-      proof.proofValue = result.proofValue;
-      return { ...doc, proof };
+
+      return { ...doc, proof: { ...proof, proofValue: result.proofValue } };
     } catch (e: any) {
       console.error(e);
       throw new Error(`Document signing failure: ${e.message || e}`);

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,6 +1,19 @@
+export type DataIntegrityProofPurpose =
+  | 'authentication'
+  | 'assertionMethod';
+
+export interface DataIntegrityProofTemplate {
+  id?: string;
+  type: string;
+  cryptosuite: string;
+  verificationMethod?: string;
+  created: string;
+  proofPurpose: string;
+}
+
 export interface SigningInput {
-  document: any;
-  proof: any;
+  document: unknown;
+  proof: DataIntegrityProofTemplate;
 }
 
 export interface SigningOutput {
@@ -161,8 +174,8 @@ export interface CreateDIDInterface {
 }
 
 export interface SignDIDDocInterface {
-  document: any;
-  proof: any;
+  document: unknown;
+  proof: DataIntegrityProofTemplate;
   verificationMethod: VerificationMethod;
 }
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -37,7 +37,6 @@ export interface Verifier {
 
 export interface SignerOptions {
   verificationMethod?: VerificationMethod | null;
-  // Controls fallback did:key ID derivation when no explicit verificationMethod.id is available.
   useStaticId?: boolean;
 }
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,14 +1,20 @@
 export type DataIntegrityProofPurpose =
   | 'authentication'
-  | 'assertionMethod';
+  | 'assertionMethod'
+  | 'keyAgreement'
+  | 'capabilityInvocation'
+  | 'capabilityDelegation';
+
+export type DataIntegrityProofType = 'DataIntegrityProof';
+export type DataIntegrityCryptosuite = 'eddsa-jcs-2022';
 
 export interface DataIntegrityProofTemplate {
   id?: string;
-  type: string;
-  cryptosuite: string;
-  verificationMethod?: string;
+  type: DataIntegrityProofType;
+  cryptosuite: DataIntegrityCryptosuite;
+  verificationMethod: string;
   created: string;
-  proofPurpose: string;
+  proofPurpose: DataIntegrityProofPurpose;
 }
 
 export interface SigningInput {
@@ -31,6 +37,7 @@ export interface Verifier {
 
 export interface SignerOptions {
   verificationMethod?: VerificationMethod | null;
+  // Controls fallback did:key ID derivation when no explicit verificationMethod.id is available.
   useStaticId?: boolean;
 }
 
@@ -78,7 +85,7 @@ export interface VerificationMethod {
   controller?: string;
   publicKeyMultibase?: string;
   secretKeyMultibase?: string;
-  purpose?: 'authentication' | 'assertionMethod' | 'keyAgreement' | 'capabilityInvocation' | 'capabilityDelegation';
+  purpose?: DataIntegrityProofPurpose;
   publicKeyJwk?: any;
   use?: string;
 }
@@ -99,12 +106,12 @@ export interface WitnessParameterResolution {
 
 export interface DataIntegrityProof {
   id?: string;
-  type: string;
-  cryptosuite: string;
+  type: DataIntegrityProofType;
+  cryptosuite: DataIntegrityCryptosuite;
   verificationMethod: string;
   created: string;
   proofValue: string;
-  proofPurpose: string;
+  proofPurpose: DataIntegrityProofPurpose;
 }
 
 export interface DIDLogEntry {

--- a/src/method_versions/method.v0.5.ts
+++ b/src/method_versions/method.v0.5.ts
@@ -1,7 +1,7 @@
 import { createDate, createDIDDoc, createSCID, deriveHash, findVerificationMethod, getBaseUrl, replaceValueInObject, deepClone, parseCanonicalAddress } from "../utils";
 import {METHOD, PLACEHOLDER } from '../constants';
 import { documentStateIsValid, hashChainValid, newKeysAreInNextKeys, scidIsFromHash } from '../assertions';
-import type { CreateDIDInterface, DIDResolutionMeta, DIDLogEntry, DIDLog, UpdateDIDInterface, DeactivateDIDInterface, ResolutionOptions, WitnessProofFileEntry, WitnessParameterResolution } from '../interfaces';
+import type { CreateDIDInterface, DIDResolutionMeta, DIDLogEntry, DIDLog, UpdateDIDInterface, DeactivateDIDInterface, ResolutionOptions, WitnessProofFileEntry, WitnessParameterResolution, DataIntegrityProof } from '../interfaces';
 import { verifyWitnessProofs, validateWitnessParameter, fetchWitnessProofs } from '../witness';
 
 const VERSION = '0.5';
@@ -66,8 +66,9 @@ export const createDID = async (options: CreateDIDInterface): Promise<{did: stri
   const prelimEntry = JSON.parse(JSON.stringify(initialLogEntry).replaceAll(PLACEHOLDER, params.scid));
   const logEntryHash2 = await deriveHash(prelimEntry);
   prelimEntry.versionId = `1-${logEntryHash2}`;
-  const proof = await options.signer.sign({ document: prelimEntry, proof: { type: 'DataIntegrityProof', cryptosuite: 'eddsa-jcs-2022', verificationMethod: options.signer.getVerificationMethodId(), created: createdDate, proofPurpose: 'assertionMethod' } });
-  let allProofs = [{ type: 'DataIntegrityProof', cryptosuite: 'eddsa-jcs-2022', verificationMethod: options.signer.getVerificationMethodId(), created: createdDate, proofPurpose: 'assertionMethod', proofValue: proof.proofValue }];
+  const proofTemplate: Omit<DataIntegrityProof, 'proofValue'> = { type: 'DataIntegrityProof', cryptosuite: 'eddsa-jcs-2022', verificationMethod: options.signer.getVerificationMethodId(), created: createdDate, proofPurpose: 'assertionMethod' };
+  const proof = await options.signer.sign({ document: prelimEntry, proof: proofTemplate });
+  const allProofs: DataIntegrityProof[] = [{ ...proofTemplate, proofValue: proof.proofValue }];
   prelimEntry.proof = allProofs;
 
   const verified = await documentStateIsValid(
@@ -390,8 +391,9 @@ export const updateDID = async (options: UpdateDIDInterface & { services?: any[]
   const logEntryHash = await deriveHash(logEntry);
   const versionId = `${versionNumber}-${logEntryHash}`;
   const prelimEntry = { ...logEntry, versionId };
-  const proof = await options.signer.sign({ document: prelimEntry, proof: { type: 'DataIntegrityProof', cryptosuite: 'eddsa-jcs-2022', verificationMethod: options.signer.getVerificationMethodId(), created: createdDate, proofPurpose: 'assertionMethod' } });
-  let allProofs = [{ type: 'DataIntegrityProof', cryptosuite: 'eddsa-jcs-2022', verificationMethod: options.signer.getVerificationMethodId(), created: createdDate, proofPurpose: 'assertionMethod', proofValue: proof.proofValue }];
+  const proofTemplate: Omit<DataIntegrityProof, 'proofValue'> = { type: 'DataIntegrityProof', cryptosuite: 'eddsa-jcs-2022', verificationMethod: options.signer.getVerificationMethodId(), created: createdDate, proofPurpose: 'assertionMethod' };
+  const proof = await options.signer.sign({ document: prelimEntry, proof: proofTemplate });
+  const allProofs: DataIntegrityProof[] = [{ ...proofTemplate, proofValue: proof.proofValue }];
   prelimEntry.proof = allProofs;
 
   const verified = await documentStateIsValid(
@@ -446,8 +448,9 @@ export const deactivateDID = async (options: DeactivateDIDInterface & { updateKe
   const logEntryHash = await deriveHash(logEntry);
   const versionId = `${versionNumber}-${logEntryHash}`;
   const prelimEntry = { ...logEntry, versionId };
-  const proof = await options.signer.sign({ document: prelimEntry, proof: { type: 'DataIntegrityProof', cryptosuite: 'eddsa-jcs-2022', verificationMethod: options.signer.getVerificationMethodId(), created: createdDate, proofPurpose: 'assertionMethod' } });
-  let allProofs = [{ type: 'DataIntegrityProof', cryptosuite: 'eddsa-jcs-2022', verificationMethod: options.signer.getVerificationMethodId(), created: createdDate, proofPurpose: 'assertionMethod', proofValue: proof.proofValue }];
+  const proofTemplate: Omit<DataIntegrityProof, 'proofValue'> = { type: 'DataIntegrityProof', cryptosuite: 'eddsa-jcs-2022', verificationMethod: options.signer.getVerificationMethodId(), created: createdDate, proofPurpose: 'assertionMethod' };
+  const proof = await options.signer.sign({ document: prelimEntry, proof: proofTemplate });
+  const allProofs: DataIntegrityProof[] = [{ ...proofTemplate, proofValue: proof.proofValue }];
   prelimEntry.proof = allProofs;
 
   const verified = await documentStateIsValid(

--- a/src/method_versions/method.v1.0.ts
+++ b/src/method_versions/method.v1.0.ts
@@ -89,8 +89,9 @@ export const createDID = async (options: CreateDIDInterface): Promise<CreateDIDR
   });
   const logEntryHash2 = await deriveHash(prelimEntry);
   prelimEntry.versionId = `1-${logEntryHash2}`;
-  const signedProof = await options.signer.sign({ document: prelimEntry, proof: { type: 'DataIntegrityProof', cryptosuite: 'eddsa-jcs-2022', verificationMethod: options.signer.getVerificationMethodId(), created: createdDate, proofPurpose: 'assertionMethod' } });
-  let allProofs = [{ type: 'DataIntegrityProof', cryptosuite: 'eddsa-jcs-2022', verificationMethod: options.signer.getVerificationMethodId(), created: createdDate, proofPurpose: 'assertionMethod', proofValue: signedProof.proofValue }];
+  const proofTemplate: Omit<DataIntegrityProof, 'proofValue'> = { type: 'DataIntegrityProof', cryptosuite: 'eddsa-jcs-2022', verificationMethod: options.signer.getVerificationMethodId(), created: createdDate, proofPurpose: 'assertionMethod' };
+  const signedProof = await options.signer.sign({ document: prelimEntry, proof: proofTemplate });
+  const allProofs: DataIntegrityProof[] = [{ ...proofTemplate, proofValue: signedProof.proofValue }];
   prelimEntry.proof = allProofs;
 
   const verified = await documentStateIsValid(
@@ -441,8 +442,9 @@ export const updateDID = async (options: UpdateDIDInterface & { services?: any[]
   const logEntryHash = await deriveHash(logEntry);
   const versionId = `${versionNumber}-${logEntryHash}`;
   const prelimEntry = { ...logEntry, versionId };
-  const signedProof = await options.signer.sign({ document: prelimEntry, proof: { type: 'DataIntegrityProof', cryptosuite: 'eddsa-jcs-2022', verificationMethod: options.signer.getVerificationMethodId(), created: createdDate, proofPurpose: 'assertionMethod' } });
-  let allProofs = [{ type: 'DataIntegrityProof', cryptosuite: 'eddsa-jcs-2022', verificationMethod: options.signer.getVerificationMethodId(), created: createdDate, proofPurpose: 'assertionMethod', proofValue: signedProof.proofValue }];
+  const proofTemplate: Omit<DataIntegrityProof, 'proofValue'> = { type: 'DataIntegrityProof', cryptosuite: 'eddsa-jcs-2022', verificationMethod: options.signer.getVerificationMethodId(), created: createdDate, proofPurpose: 'assertionMethod' };
+  const signedProof = await options.signer.sign({ document: prelimEntry, proof: proofTemplate });
+  const allProofs: DataIntegrityProof[] = [{ ...proofTemplate, proofValue: signedProof.proofValue }];
   prelimEntry.proof = allProofs;
   const keysToVerify = lastMeta.prerotation ? params.updateKeys : lastMeta.updateKeys;
   const verified = await documentStateIsValid(
@@ -501,8 +503,9 @@ export const deactivateDID = async (options: DeactivateDIDInterface & { updateKe
   const logEntryHash = await deriveHash(logEntry);
   const versionId = `${versionNumber}-${logEntryHash}`;
   const prelimEntry = { ...logEntry, versionId };
-  const signedProof = await options.signer.sign({ document: prelimEntry, proof: { type: 'DataIntegrityProof', cryptosuite: 'eddsa-jcs-2022', verificationMethod: options.signer.getVerificationMethodId(), created: createdDate, proofPurpose: 'assertionMethod' } });
-  let allProofs = [{ type: 'DataIntegrityProof', cryptosuite: 'eddsa-jcs-2022', verificationMethod: options.signer.getVerificationMethodId(), created: createdDate, proofPurpose: 'assertionMethod', proofValue: signedProof.proofValue }];
+  const proofTemplate: Omit<DataIntegrityProof, 'proofValue'> = { type: 'DataIntegrityProof', cryptosuite: 'eddsa-jcs-2022', verificationMethod: options.signer.getVerificationMethodId(), created: createdDate, proofPurpose: 'assertionMethod' };
+  const signedProof = await options.signer.sign({ document: prelimEntry, proof: proofTemplate });
+  const allProofs: DataIntegrityProof[] = [{ ...proofTemplate, proofValue: signedProof.proofValue }];
   prelimEntry.proof = allProofs;
 
   const verified = await documentStateIsValid(

--- a/src/witness.ts
+++ b/src/witness.ts
@@ -1,16 +1,19 @@
 import { canonicalize } from 'json-canonicalize';
 import { createHash } from './utils/crypto';
-import type { DataIntegrityProof, DIDLogEntry, WitnessEntry, WitnessProofFileEntry, Verifier, WitnessParameterResolution } from './interfaces';
+import type { DataIntegrityProof, DataIntegrityProofTemplate, DIDLogEntry, WitnessEntry, WitnessProofFileEntry, Verifier, WitnessParameterResolution } from './interfaces';
 import { resolveVM } from "./utils";
 import { concatBuffers } from './utils/buffer';
 import { fetchWitnessProofs } from './utils';
 import { multibaseDecode } from './utils/multiformats';
 
 export async function createWitnessProof(
-  signer: (doc: any, proofTemplate?: any) => Promise<{proof: any}>,
+  signer: (
+    doc: { versionId: string },
+    proofTemplate?: DataIntegrityProofTemplate
+  ) => Promise<{ proof: Partial<DataIntegrityProof> }>,
   versionId: string
 ): Promise<DataIntegrityProof> {
-  const proofTemplate = {
+  const proofTemplate: DataIntegrityProofTemplate = {
     type: "DataIntegrityProof",
     cryptosuite: "eddsa-jcs-2022",
     created: new Date().toISOString(),
@@ -18,10 +21,22 @@ export async function createWitnessProof(
   };
 
   const signedData = await signer({versionId}, proofTemplate);
-
-  return {
+  const mergedProof = {
     ...proofTemplate,
     ...signedData.proof
+  };
+
+  if (!mergedProof.verificationMethod) {
+    throw new Error('Witness proof is missing verificationMethod');
+  }
+  if (!mergedProof.proofValue) {
+    throw new Error('Witness proof is missing proofValue');
+  }
+
+  return {
+    ...mergedProof,
+    verificationMethod: mergedProof.verificationMethod,
+    proofValue: mergedProof.proofValue
   };
 }
 

--- a/src/witness.ts
+++ b/src/witness.ts
@@ -11,11 +11,13 @@ export async function createWitnessProof(
     doc: { versionId: string },
     proofTemplate?: DataIntegrityProofTemplate
   ) => Promise<{ proof: Partial<DataIntegrityProof> }>,
-  versionId: string
+  versionId: string,
+  verificationMethod: string
 ): Promise<DataIntegrityProof> {
   const proofTemplate: DataIntegrityProofTemplate = {
     type: "DataIntegrityProof",
     cryptosuite: "eddsa-jcs-2022",
+    verificationMethod,
     created: new Date().toISOString(),
     proofPurpose: "assertionMethod"
   };

--- a/src/witness.ts
+++ b/src/witness.ts
@@ -17,7 +17,7 @@ export async function createWitnessProof(
     type: "DataIntegrityProof",
     cryptosuite: "eddsa-jcs-2022",
     created: new Date().toISOString(),
-    proofPurpose: "authentication"
+    proofPurpose: "assertionMethod"
   };
 
   const signedData = await signer({versionId}, proofTemplate);
@@ -94,6 +94,14 @@ export async function verifyWitnessProofs(
   for (const proofSet of witnessProofs) {
     // Process each proof in the set
     for (const proof of proofSet.proof) {
+      if (proof.type !== 'DataIntegrityProof') {
+        throw new Error('Invalid witness proof type');
+      }
+
+      if (proof.proofPurpose !== 'assertionMethod') {
+        throw new Error('Invalid witness proof purpose');
+      }
+
       if (proof.cryptosuite !== 'eddsa-jcs-2022') {
         throw new Error('Invalid witness proof cryptosuite');
       }

--- a/test/must.test.ts
+++ b/test/must.test.ts
@@ -84,6 +84,9 @@ describe("did:webvh normative witness tests", async () => {
   let testImplementation: TestCryptoImplementation;
   let witnessImpl1: TestCryptoImplementation, witnessImpl2: TestCryptoImplementation, witnessImpl3: TestCryptoImplementation;
 
+  const witnessVerificationMethod = (vm: VerificationMethod) =>
+    `did:key:${vm.publicKeyMultibase}#${vm.publicKeyMultibase}`;
+
   const createWitnessSigner = (verificationMethod: VerificationMethod) => {
     const signer = createTestSigner(verificationMethod);
     return async (data: any, proofTemplate?: any) => {
@@ -162,7 +165,7 @@ describe("did:webvh normative witness tests", async () => {
       {
         versionId: initialDID.log[0].versionId,
         proof: [
-          await createWitnessProof(createWitnessSigner(witness1), initialDID.log[0].versionId)
+          await createWitnessProof(createWitnessSigner(witness1), initialDID.log[0].versionId, witnessVerificationMethod(witness1))
         ]
       }
     ];
@@ -185,8 +188,8 @@ describe("did:webvh normative witness tests", async () => {
       {
         versionId: initialDID.log[0].versionId,
         proof: [
-          {...(await createWitnessProof(createWitnessSigner(witness1), initialDID.log[0].versionId)), cryptosuite: 'invalid-suite'},
-          await createWitnessProof(createWitnessSigner(witness2), initialDID.log[0].versionId)
+          {...(await createWitnessProof(createWitnessSigner(witness1), initialDID.log[0].versionId, witnessVerificationMethod(witness1))), cryptosuite: 'invalid-suite'},
+          await createWitnessProof(createWitnessSigner(witness2), initialDID.log[0].versionId, witnessVerificationMethod(witness2))
         ]
       }
     ];

--- a/test/witness.test.ts
+++ b/test/witness.test.ts
@@ -18,6 +18,9 @@ describe("Witness Implementation Tests", async () => {
     testImplementation = new TestCryptoImplementation({ verificationMethod: authKey });
   });
 
+  const witnessVerificationMethod = (vm: VerificationMethod) =>
+    `did:key:${vm.publicKeyMultibase}#${vm.publicKeyMultibase}`;
+
   test("Create DID with witness threshold", async () => {
     initialDID = await createDID({
       domain: 'example.com',
@@ -47,8 +50,8 @@ describe("Witness Implementation Tests", async () => {
     const witness2SignerFn = createWitnessSigner(witness2);
     
     const proofs = await Promise.all([
-      createWitnessProof(witness1SignerFn, versionId),
-      createWitnessProof(witness2SignerFn, versionId)
+      createWitnessProof(witness1SignerFn, versionId, witnessVerificationMethod(witness1)),
+      createWitnessProof(witness2SignerFn, versionId, witnessVerificationMethod(witness2))
     ]);
 
     const witnessProofs = [{
@@ -99,8 +102,8 @@ describe("Witness Implementation Tests", async () => {
     const witness2SignerFn = createWitnessSigner(witness2);
     
     const proofs = await Promise.all([
-      createWitnessProof(witness1SignerFn, newVersionId),
-      createWitnessProof(witness2SignerFn, newVersionId)
+      createWitnessProof(witness1SignerFn, newVersionId, witnessVerificationMethod(witness1)),
+      createWitnessProof(witness2SignerFn, newVersionId, witnessVerificationMethod(witness2))
     ]);
 
     const witnessProofs = [{
@@ -125,8 +128,8 @@ describe("Witness Implementation Tests", async () => {
     const witness1SignerFn = createWitnessSigner(witness1);
     const witness2SignerFn = createWitnessSigner(witness2);
     const proofs = await Promise.all([
-      createWitnessProof(witness1SignerFn, versionId),
-      createWitnessProof(witness2SignerFn, versionId)
+      createWitnessProof(witness1SignerFn, versionId, witnessVerificationMethod(witness1)),
+      createWitnessProof(witness2SignerFn, versionId, witnessVerificationMethod(witness2))
     ]);
     const witnessProofs = [{ versionId, proof: proofs }];
     
@@ -148,7 +151,7 @@ describe("Witness Implementation Tests", async () => {
     // Create proof for new version from new witness
     const newVersionId = updatedDID.log[1].versionId;
     const newWitnessSignerFn = createWitnessSigner(newWitness);
-    const newProof = await createWitnessProof(newWitnessSignerFn, newVersionId);
+    const newProof = await createWitnessProof(newWitnessSignerFn, newVersionId, witnessVerificationMethod(newWitness));
     const newWitnessProofs = [{
       versionId: newVersionId,
       proof: [newProof]
@@ -168,8 +171,8 @@ describe("Witness Implementation Tests", async () => {
     const witness1SignerFn = createWitnessSigner(witness1);
     const witness2SignerFn = createWitnessSigner(witness2);
     const proofs = await Promise.all([
-      createWitnessProof(witness1SignerFn, versionId),
-      createWitnessProof(witness2SignerFn, versionId)
+      createWitnessProof(witness1SignerFn, versionId, witnessVerificationMethod(witness1)),
+      createWitnessProof(witness2SignerFn, versionId, witnessVerificationMethod(witness2))
     ]);
     const witnessProofs = [{ versionId, proof: proofs }];
     
@@ -193,20 +196,20 @@ describe("Witness Implementation Tests", async () => {
       {
         versionId: initialDID.log[0].versionId,
         proof: [
-          await createWitnessProof(createWitnessSigner(witness1), initialDID.log[0].versionId)
+          await createWitnessProof(createWitnessSigner(witness1), initialDID.log[0].versionId, witnessVerificationMethod(witness1))
         ]
       },
       {
         versionId: initialDID.log[0].versionId,
         proof: [
-          await createWitnessProof(createWitnessSigner(witness2), initialDID.log[0].versionId)
+          await createWitnessProof(createWitnessSigner(witness2), initialDID.log[0].versionId, witnessVerificationMethod(witness2))
         ]
       },
       {
         versionId: "future-version-id",
         proof: [
           // This proof should be ignored since version doesn't exist in log
-          await createWitnessProof(createWitnessSigner(witness1), "future-version-id")
+          await createWitnessProof(createWitnessSigner(witness1), "future-version-id", witnessVerificationMethod(witness1))
         ]
       }
     ];
@@ -222,7 +225,8 @@ describe("Witness Implementation Tests", async () => {
   test("Reject witness proofs with invalid proofPurpose", async () => {
     const badProof = await createWitnessProof(
       createWitnessSigner(witness1),
-      initialDID.log[0].versionId
+      initialDID.log[0].versionId,
+      witnessVerificationMethod(witness1)
     );
 
     const witnessProofs = [

--- a/test/witness.test.ts
+++ b/test/witness.test.ts
@@ -219,6 +219,32 @@ describe("Witness Implementation Tests", async () => {
     expect(resolved.did).toBe(initialDID.did);
   });
 
+  test("Reject witness proofs with invalid proofPurpose", async () => {
+    const badProof = await createWitnessProof(
+      createWitnessSigner(witness1),
+      initialDID.log[0].versionId
+    );
+
+    const witnessProofs = [
+      {
+        versionId: initialDID.log[0].versionId,
+        proof: [
+          {
+            ...badProof,
+            proofPurpose: "authentication"
+          }
+        ]
+      }
+    ];
+
+    await expect(
+      resolveDIDFromLog(initialDID.log, {
+        witnessProofs,
+        verifier: testImplementation
+      })
+    ).rejects.toThrow("Invalid witness proof purpose");
+  });
+
   const createWitnessSigner = (verificationMethod: VerificationMethod) => {
     const signer = createTestSigner(verificationMethod);
     return async (data: any, proofTemplate?: any) => {


### PR DESCRIPTION
Improve type safety and spec alignment

* Introduce new interfaces for `DataIntegrityProofTemplate` and `DataIntegrityProofPurpose` and use these for API boundary operations and in the CLI when building compliant Data Integrity proof objects

* Tightened `document` in `SigningInput` from `any` to `unknown`

* Witness verification now validates `proofPurpose === assertionMethod` in accordance with spec

* DID log proof purpose is now strictly `assertionMethod` with missing-proof guard

**Breaking 1**

Consumers using **deep imports** of `createWitnessProof`

`createWitnessProof` (internal use) now requires explicit `verificationMethod` to match Data Integrity spec requirements

Old:
`(doc: any, proofTemplate?: any)`

New:
`(doc: { versionId: string }, proofTemplate?: DataIntegrityProofTemplate)` where `DataIntegrityProofTemplate` requires `verificationMethod`

**Breaking 2**

API users passing looser proof objects into signing functions

* Stricter types in `interfaces.ts` could cause breaks for some consumers passing proof shapes into `signer` without `verificationMethod`

* `type` and `cryptosuite` are now exact literals not string (`DataIntegrityProof` and `eddsa-jcs-2022` respectively)