### PR TITLE
feat(witness): witness API endpoints and did:key handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,49 +53,61 @@ If you ever need to refresh the build (for example after local code changes), re
 The following commands are defined in the `package.json` file:
 
 1. `dev`: Run the Elysia resolver example in development mode with debugging enabled.
+
    ```bash
    bun run dev
    ```
+
   This command runs: `bun --watch --inspect-wait ./examples/elysia-resolver.ts`
 
-2. `server`: Run the Elysia resolver example in watch mode for development.
+1. `server`: Run the Elysia resolver example in watch mode for development.
+
    ```bash
    bun run server
    ```
+
   This command runs: `bun --watch ./examples/elysia-resolver.ts`
 
-3. `test`: Run all tests.
+1. `test`: Run all tests.
+
    ```bash
    bun run test
    ```
 
-4. `test:watch`: Run tests in watch mode.
+2. `test:watch`: Run tests in watch mode.
+
    ```bash
    bun run test:watch
    ```
 
-5. `test:bail`: Run tests in watch mode with bail and verbose options.
+3. `test:bail`: Run tests in watch mode with bail and verbose options.
+
    ```bash
    bun run test:bail
    ```
 
-6. `test:log`: Run tests and save logs to a file.
+4. `test:log`: Run tests and save logs to a file.
+
    ```bash
    bun run test:log
    ```
 
-7. `cli`: Run the CLI tool.
+5. `cli`: Run the CLI tool.
+
    ```bash
    bun run cli
    ```
+
    The CLI accepts a `--watcher` option during create and update operations to specify one or more watcher URLs.
 
-8. `build`: Build the package.
+6. `build`: Build the package.
+
    ```bash
    bun run build
    ```
 
-9. `build:clean`: Clean the build directory.
+7. `build:clean`: Clean the build directory.
+
    ```bash
    bun run build:clean
    ```
@@ -140,11 +152,13 @@ For this to work, the `didwebvh-ts` package on npmjs.com must have a Trusted Pub
 The `didwebvh-ts` library provides the core functionality for resolving DIDs, but it does not include a built-in HTTP resolver. You can create your own resolver using your preferred web framework by following these steps:
 
 1. Import the `resolveDID` function from the `didwebvh-ts` library:
+
    ```typescript
    import { resolveDID } from 'didwebvh-ts';
    ```
 
 2. Create endpoints for resolving DIDs:
+
    ```typescript
    // Example using Express
    app.get('/resolve/:id', async (req, res) => {
@@ -164,12 +178,30 @@ The `didwebvh-ts` library provides the core functionality for resolving DIDs, bu
 
 For complete examples, see the [examples](./examples/) directory.
 
+### Resolution metadata notes (v1.0)
+
+For `did:webvh:1.0` resolution flows, resolver failures that invalidate the DID are surfaced using:
+
+- `meta.error = "invalidDid"`
+- `meta.problemDetails` populated with RFC9457-style fields (`type`, `title`, `detail`)
+
+Absence cases (for example missing DID log or missing DID URL resource) use:
+
+- `meta.error = "notFound"`
+
+When resolving a requested earlier version (for example with `versionId`, `versionNumber`, or `versionTime`), the resolver may return a valid earlier document while still reporting `meta.error = "invalidDid"` if a later log entry fails verification.
+
 ## API Reference
 
 ### Core Functions
 
 - `resolveDID(did: string, options?: ResolutionOptions): Promise<{did: string, doc: any, meta: DIDResolutionMeta, controlled: boolean}>`
   Resolves a DID to its DID document.
+  For `v1.0`, `options.fastResolve` is an opt-in mode defaulting to `false` for full log parsing.
+
+- `resolveDIDFromLog(log: DIDLog, options?: ResolutionOptions & { witnessProofs?: WitnessProofFileEntry[] }): Promise<{did: string, doc: any, meta: DIDResolutionMeta}>`
+  Resolves directly from an in-memory DID log.
+  For `v1.0`, `options.fastResolve` is an opt-in mode defaulting to `false` for full log parsing.
 
 - `createDID(options: CreateDIDInterface): Promise<{did: string, doc: any, meta: DIDResolutionMeta, log: DIDLog, webDoc?: DIDDoc}>`
   Creates a new DID.
@@ -186,6 +218,17 @@ For complete examples, see the [examples](./examples/) directory.
 
 - `generateParallelDidWeb(didwebvhDid: string, didwebvhDoc: DIDDoc): DIDDoc`
   Generates the parallel `did:web` document defined by did:webvh v1.0 §3.7.10.
+
+### Witness Functions
+
+- `createWitnessProof(signer, versionId, verificationMethod, created?): Promise<DataIntegrityProof>`
+  Creates and signs one witness proof for a specific `versionId`.
+
+- `signWitnessProofEntry(options: WitnessSigningOptions): Promise<WitnessSigningResult>`
+  Signs one did-witness proof entry (`{ versionId, proof[] }`) for a single target version.
+
+- `signWitnessProofEntries(versionIds: string[], witnesses: WitnessEntry[], witnessSignersByDid: Record<string, WitnessSigner>, created?: string): Promise<WitnessSigningResult[]>`
+  Signs did-witness proof entries for multiple target versions.
 
 ### Cryptography Functions
 

--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -10,10 +10,6 @@ const isKeyAuthorized = (verificationMethod: string, updateKeys: string[]): bool
   const parsedVerificationMethod = parseDidKeyVerificationMethod(verificationMethod);
 
   return updateKeys.some((updateKey) => {
-    if (updateKey.startsWith('did:key:')) {
-      return parseDidKeyDid(updateKey).keyMultibase === parsedVerificationMethod.keyMultibase;
-    }
-
     return updateKey === parsedVerificationMethod.keyMultibase;
   });
 };

--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -1,4 +1,4 @@
-import { createSCID, deriveNextKeyHash, resolveVM } from "./utils";
+import { createSCID, deriveNextKeyHash, parseDidKeyDid, parseDidKeyVerificationMethod, resolveVM } from "./utils";
 import { canonicalize } from 'json-canonicalize';
 import { createHash } from './utils/crypto';
 import { concatBuffers } from './utils/buffer';
@@ -7,22 +7,15 @@ import { validateWitnessParameter } from './witness';
 import { multibaseDecode } from "./utils/multiformats";
 
 const isKeyAuthorized = (verificationMethod: string, updateKeys: string[]): boolean => {
-  if (verificationMethod.startsWith('did:key:')) {
-    const keyParts = verificationMethod.split('did:key:')[1].split('#');
-    const key = keyParts[0];
-    
-    const authorized = updateKeys.some(updateKey => {
-      let updateKeyPart = updateKey;
-      if (updateKey.startsWith('did:key:')) {
-        updateKeyPart = updateKey.split('did:key:')[1].split('#')[0];
-      }
-      
-      return updateKeyPart === key;
-    });
-    
-    return authorized;
-  }
-  return false;
+  const parsedVerificationMethod = parseDidKeyVerificationMethod(verificationMethod);
+
+  return updateKeys.some((updateKey) => {
+    if (updateKey.startsWith('did:key:')) {
+      return parseDidKeyDid(updateKey).keyMultibase === parsedVerificationMethod.keyMultibase;
+    }
+
+    return updateKey === parsedVerificationMethod.keyMultibase;
+  });
 };
 
 const isWitnessAuthorized = (verificationMethod: string, witnesses: string[]): boolean => {

--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -1,4 +1,4 @@
-import { createSCID, deriveNextKeyHash, parseDidKeyDid, parseDidKeyVerificationMethod, resolveVM } from "./utils";
+import { createSCID, deriveNextKeyHash, parseDidKeyVerificationMethod, resolveVM } from "./utils";
 import { canonicalize } from 'json-canonicalize';
 import { createHash } from './utils/crypto';
 import { concatBuffers } from './utils/buffer';
@@ -12,14 +12,6 @@ const isKeyAuthorized = (verificationMethod: string, updateKeys: string[]): bool
   return updateKeys.some((updateKey) => {
     return updateKey === parsedVerificationMethod.keyMultibase;
   });
-};
-
-const isWitnessAuthorized = (verificationMethod: string, witnesses: string[]): boolean => {
-  if (verificationMethod.startsWith('did:webvh:')) {
-    const didWithoutFragment = verificationMethod.split('#')[0];
-    return witnesses.includes(didWithoutFragment);
-  }
-  return false;
 };
 
 export const documentStateIsValid = async (
@@ -50,16 +42,12 @@ export const documentStateIsValid = async (
   for (let i = 0; i < proofs.length; i++) {
     const proof = proofs[i];
 
-    if (proof.verificationMethod.startsWith('did:key:')) {
-      if (!isKeyAuthorized(proof.verificationMethod, updateKeys)) {
-        throw new Error(`Key ${proof.verificationMethod} is not authorized to update.`);
-      }
-    } else if (proof.verificationMethod.startsWith('did:webvh:')) {
-      if (witness && witness.witnesses && witness.witnesses.length > 0 && !isWitnessAuthorized(proof.verificationMethod, witness.witnesses.map((w: {id: string}) => w.id))) {
-        throw new Error(`Key ${proof.verificationMethod} is not from an authorized witness.`);
-      }
-    } else {
-      throw new Error(`Unsupported verification method: ${proof.verificationMethod}`);
+    if (!proof.verificationMethod.startsWith('did:key:')) {
+      throw new Error(`Unsupported verification method for DID log entry authorization: ${proof.verificationMethod}`);
+    }
+
+    if (!isKeyAuthorized(proof.verificationMethod, updateKeys)) {
+      throw new Error(`Key ${proof.verificationMethod} is not authorized to update.`);
     }
     
     if (proof.type !== 'DataIntegrityProof') {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 
 import { createDID, updateDID, deactivateDID, resolveDIDFromLog } from './method';
-import { fetchLogFromIdentifier, readLogFromDisk, writeLogToDisk, writeVerificationMethodToEnv } from './utils';
+import { fetchLogFromIdentifier, parseDidKeyDid, readLogFromDisk, writeLogToDisk, writeVerificationMethodToEnv } from './utils';
 import { dirname } from 'path';
 import fs from 'fs';
-import { DIDLog, ServiceEndpoint, VerificationMethod, Verifier, DataIntegrityProofTemplate } from './interfaces';
+import { DIDLog, ServiceEndpoint, VerificationMethod, Verifier } from './interfaces';
 import { createBuffer } from './utils/buffer';
 import { bufferToString } from './utils/buffer';
 import { Signer, SigningInput, SigningOutput } from './interfaces';
@@ -18,7 +18,7 @@ import { createHash } from './utils/crypto';
 import { multibaseDecode } from './utils/multiformats';
 import { generateKeyPair } from '@stablelib/ed25519';
 
-import { createWitnessProof } from './witness';
+import { signWitnessProofEntries } from './witness';
 
 const usage = `
 Usage: bun run cli [command] [options]
@@ -47,12 +47,12 @@ Options:
   --witness-file [file]     Path to witness proofs file (optional for resolve)
 
   # Options for generate-witness-proof:
-  --version-id [id]         The version ID to generate proofs for (required)
+  --version-id [id]         The version ID to generate proofs for (required, can be used multiple times)
   --witness-did [did]       Witness DID (did:key) (can be used multiple times)
   --witness-secret [secret] Witness secret key multibase (matches witness-did order)
 
 Examples:
-  bun run cli create --address example.com --portable --witness did:example:witness1 --witness did:example:witness2
+  bun run cli create --address example.com --portable --witness did:key:z6Mk... --witness did:key:z6Mk...
   bun run cli create --address https://example.com --portable
   bun run cli create --address "example.com:3000" --portable
   bun run cli create --address "did:webvh:example.com:3000" --portable
@@ -62,6 +62,7 @@ Examples:
   bun run cli update --log ./did.jsonl --output ./updated-did.jsonl --add-vm keyAgreement --service LinkedDomains,https://example.com
   bun run cli deactivate --log ./did.jsonl --output ./deactivated-did.jsonl
   bun run cli generate-witness-proof --version-id 1-abc123 --witness-did did:key:z6Mk... --witness-secret z1A... --output did-witness.json
+  bun run cli generate-witness-proof --version-id 1-abc123 --version-id 2-def456 --witness-did did:key:z6Mk... --witness-secret z1A... --output did-witness.json
   bun run cli generate-vm
 `;
 
@@ -409,13 +410,18 @@ export async function handleDeactivate(args: string[]) {
 
 async function handleGenerateWitnessProof(args: string[]) {
   const options = parseOptions(args);
-  const versionId = options['version-id'] as string;
+  const rawVersionIds = options['version-id'];
+  const versionIds = Array.isArray(rawVersionIds)
+    ? rawVersionIds
+    : rawVersionIds
+      ? [rawVersionIds]
+      : [];
   const witnessDids = options['witness-did'] as string[] | undefined;
   const witnessSecrets = options['witness-secret'] as string[] | undefined;
   const output = options['output'] as string;
 
-  if (!versionId) {
-    console.error('Version ID is required');
+  if (versionIds.length === 0) {
+    console.error('At least one --version-id is required');
     process.exit(1);
   }
   if (!output) {
@@ -427,39 +433,34 @@ async function handleGenerateWitnessProof(args: string[]) {
     process.exit(1);
   }
 
-  const proofs = [];
+  const witnessSignersByDid: Record<string, Signer> = {};
+  const witnesses: { id: string }[] = [];
+
   for (let i = 0; i < witnessDids.length; i++) {
     const did = witnessDids[i];
     const secret = witnessSecrets[i];
-    const publicKeyMultibase = did.split(':')[2];
+    const { did: normalizedDid, keyMultibase: publicKeyMultibase } = parseDidKeyDid(did);
     const vm: VerificationMethod = {
       type: 'Multikey',
       publicKeyMultibase,
       secretKeyMultibase: secret,
       purpose: 'authentication'
     };
-    const crypto = createCustomCrypto(vm);
-    const signerFn = async (data: any) => {
-      const proofTemplate: DataIntegrityProofTemplate = {
-        type: 'DataIntegrityProof',
-        cryptosuite: 'eddsa-jcs-2022',
-        verificationMethod: `${did}#${publicKeyMultibase}`,
-        created: new Date().toISOString(),
-        proofPurpose: 'assertionMethod'
-      };
-      const signingInput = { document: data, proof: proofTemplate };
-      const signed = await crypto.sign(signingInput);
-      return { proof: { ...proofTemplate, proofValue: signed.proofValue } };
-    };
-    const verificationMethod = `${did}#${publicKeyMultibase}`;
-    const proof = await createWitnessProof(signerFn, versionId, verificationMethod);
-    proofs.push(proof);
+
+    witnessSignersByDid[normalizedDid] = createCustomCrypto(vm);
+    witnesses.push({ id: normalizedDid });
   }
 
-  const witnessFileContent = [{
-    versionId,
-    proof: proofs
-  }];
+  const witnessEntries = await signWitnessProofEntries(
+    versionIds,
+    witnesses,
+    witnessSignersByDid,
+  );
+
+  const witnessFileContent = witnessEntries.map((entry) => ({
+    versionId: entry.versionId,
+    proof: entry.proof
+  }));
 
   fs.writeFileSync(output, JSON.stringify(witnessFileContent, null, 2));
   console.log(`Witness proof file generated at ${output}`);
@@ -473,7 +474,7 @@ function parseOptions(args: string[]): Record<string, string | string[] | undefi
     if (args[i].startsWith('--')) {
       const key = args[i].slice(2);
       if (i + 1 < args.length && !args[i + 1].startsWith('--')) {
-        if (key === 'witness' || key === 'service' || key === 'also-known-as' || key === 'next-key-hash' || key === 'watcher' || key === 'witness-did' || key === 'witness-secret') {
+        if (key === 'witness' || key === 'service' || key === 'also-known-as' || key === 'next-key-hash' || key === 'watcher' || key === 'witness-did' || key === 'witness-secret' || key === 'version-id') {
           options[key] = options[key] || [];
           (options[key] as string[]).push(args[++i]);
         } else if (key === 'add-vm') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,10 @@
 export { resolveDID, resolveDIDFromLog, createDID, updateDID, deactivateDID } from './method';
 export { createDocumentSigner, prepareDataForSigning, createProof, createSigner, AbstractCrypto } from './cryptography';
+export {
+	createWitnessProof,
+	signWitnessProofsForVersion,
+	signWitnessProofsForVersions,
+} from './witness';
 export * from './interfaces';
-export { generateParallelDidWeb } from './utils';
+export { generateParallelDidWeb, parseDidKeyDid, parseDidKeyVerificationMethod } from './utils';
 export { multibaseEncode, multibaseDecode, MultibaseEncoding } from './utils/multiformats';

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,8 @@ export { resolveDID, resolveDIDFromLog, createDID, updateDID, deactivateDID } fr
 export { createDocumentSigner, prepareDataForSigning, createProof, createSigner, AbstractCrypto } from './cryptography';
 export {
 	createWitnessProof,
-	signWitnessProofsForVersion,
-	signWitnessProofsForVersions,
+	signWitnessProofEntry,
+	signWitnessProofEntries,
 } from './witness';
 export * from './interfaces';
 export { generateParallelDidWeb, parseDidKeyDid, parseDidKeyVerificationMethod } from './utils';

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -31,6 +31,11 @@ export interface Signer {
   getVerificationMethodId(): string;
 }
 
+export interface WitnessSigner {
+  sign(input: SigningInput): Promise<SigningOutput>;
+  getVerificationMethodId(): string;
+}
+
 export interface Verifier {
   verify(signature: Uint8Array, message: Uint8Array, publicKey: Uint8Array): Promise<boolean>;
 }
@@ -91,6 +96,24 @@ export interface VerificationMethod {
 
 export interface WitnessEntry {
   id: string;  // did:key DID
+}
+
+export interface ParsedDidKeyVerificationMethod {
+  did: string;
+  fragment?: string;
+  keyMultibase: string;
+}
+
+export interface WitnessSigningOptions {
+  versionId: string;
+  witnesses: WitnessEntry[];
+  witnessSignersByDid: Record<string, WitnessSigner>;
+  created?: string;
+}
+
+export interface WitnessSigningResult {
+  versionId: string;
+  proof: DataIntegrityProof[];
 }
 
 export interface WitnessParameter {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -31,11 +31,6 @@ export interface Signer {
   getVerificationMethodId(): string;
 }
 
-export interface WitnessSigner {
-  sign(input: SigningInput): Promise<SigningOutput>;
-  getVerificationMethodId(): string;
-}
-
 export interface Verifier {
   verify(signature: Uint8Array, message: Uint8Array, publicKey: Uint8Array): Promise<boolean>;
 }
@@ -124,7 +119,7 @@ export interface ParsedDidKeyVerificationMethod {
 export interface WitnessSigningOptions {
   versionId: string;
   witnesses: WitnessEntry[];
-  witnessSignersByDid: Record<string, WitnessSigner>;
+  witnessSignersByDid: Record<string, Signer>;
   created?: string;
 }
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -51,6 +51,23 @@ export interface ProblemDetails {
   detail: string;
 }
 
+export enum DidResolutionError {
+  NotFound = 'notFound',
+  InvalidDid = 'invalidDid',
+  LegacyNotFound = 'NOT_FOUND',
+  LegacyInvalidDid = 'INVALID_DID',
+  InvalidDidUrl = 'INVALID_DID_URL',
+  InvalidOptions = 'INVALID_OPTIONS',
+  RepresentationNotSupported = 'REPRESENTATION_NOT_SUPPORTED',
+  MethodNotSupported = 'METHOD_NOT_SUPPORTED',
+  UnsupportedPublicKeyType = 'UNSUPPORTED_PUBLIC_KEY_TYPE',
+  LegacyInvalidDidDocument = 'INVALID_DID_DOCUMENT',
+  InvalidPublicKey = 'INVALID_PUBLIC_KEY',
+  InvalidPublicKeyLength = 'INVALID_PUBLIC_KEY_LENGTH',
+  InvalidPublicKeyType = 'INVALID_PUBLIC_KEY_TYPE',
+  InternalError = 'INTERNAL_ERROR',
+}
+
 export interface DIDResolutionMeta {
   versionId: string;
   created: string;
@@ -64,7 +81,7 @@ export interface DIDResolutionMeta {
   deactivated: boolean;
   witness?: WitnessParameterResolution;
   watchers?: string[] | null;
-  error?: 'NOT_FOUND' | 'INVALID_DID' | 'INVALID_DID_URL' | 'INVALID_OPTIONS' | 'REPRESENTATION_NOT_SUPPORTED' | 'METHOD_NOT_SUPPORTED' | 'UNSUPPORTED_PUBLIC_KEY_TYPE' | 'INVALID_DID_DOCUMENT' | 'INVALID_PUBLIC_KEY' | 'INVALID_PUBLIC_KEY_LENGTH' | 'INVALID_PUBLIC_KEY_TYPE' | 'INTERNAL_ERROR';
+  error?: DidResolutionError;
   problemDetails?: ProblemDetails;
   latestVersionId?: string;
 }
@@ -240,6 +257,7 @@ export interface ResolutionOptions {
   verificationMethod?: string;
   verifier?: Verifier;
   scid?: string;
+  fastResolve?: boolean;
 }
 
 export interface WitnessProofFileEntry {

--- a/src/method.ts
+++ b/src/method.ts
@@ -1,4 +1,5 @@
 import { fetchLogFromIdentifier, getActiveDIDs, maybeWriteTestLog } from "./utils";
+import { DidResolutionError } from './interfaces';
 import type { CreateDIDInterface, CreateDIDResult, DIDLog, UpdateDIDInterface, UpdateDIDResult, DeactivateDIDInterface, ResolutionOptions, WitnessProofFileEntry } from './interfaces';
 import * as v1 from './method_versions/method.v1.0';
 import * as v0_5 from './method_versions/method.v0.5';
@@ -25,6 +26,12 @@ function getWebvhVersionFromOptions(options: any): string {
   return LATEST_VERSION;
 }
 
+/**
+ * Creates a new did:webvh DID and initial DID log.
+ *
+ * @param options DID creation options.
+ * @returns The created DID, resolved document, and DID log.
+ */
 export const createDID = async (options: CreateDIDInterface): Promise<CreateDIDResult> => {
   const version = getWebvhVersionFromOptions(options);
   const result = version === '0.5'
@@ -34,6 +41,16 @@ export const createDID = async (options: CreateDIDInterface): Promise<CreateDIDR
   return result;
 };
 
+/**
+ * Resolves a DID by fetching and validating its DID log.
+ *
+ * For `did:webvh:1.0`, `fastResolve` is forwarded to the v1 resolver.
+ * For `did:webvh:0.5`, `fastResolve` is ignored and not forwarded.
+ *
+ * @param did The DID to resolve.
+ * @param options Optional resolver settings.
+ * @returns The resolved DID result with resolution metadata and controlled status.
+ */
 export const resolveDID = async (did: string, options: ResolutionOptions & { witnessProofs?: WitnessProofFileEntry[] } = {}) => {
   const activeDIDs = await getActiveDIDs();
   const controlled = activeDIDs.includes(did);
@@ -45,18 +62,19 @@ export const resolveDID = async (did: string, options: ResolutionOptions & { wit
   try {
     const log = await fetchLogFromIdentifier(did, controlled);
     const version = getWebvhVersionFromLog(log);
-    const optsWithScid = { ...options, scid };
+    const { fastResolve, ...baseOptions } = options;
+    const optsWithScid = { ...baseOptions, scid };
     const result = version === '0.5'
       ? await v0_5.resolveDIDFromLog(log, optsWithScid)
-      : await v1.resolveDIDFromLog(log, optsWithScid);
+      : await v1.resolveDIDFromLog(log, { ...optsWithScid, fastResolve });
     maybeWriteTestLog(result.did, log);
 
     return { ...result, controlled };
   } catch (e: any) {
-    let errorType = 'INVALID_DID';
+    let errorType: DidResolutionError = DidResolutionError.InvalidDid;
     const message = e instanceof Error ? e.message : String(e);
     if (/not found/i.test(message) || /404/.test(message)) {
-      errorType = 'notFound';
+      errorType = DidResolutionError.NotFound;
     }
     return {
       did,
@@ -64,10 +82,10 @@ export const resolveDID = async (did: string, options: ResolutionOptions & { wit
       meta: {
         error: errorType,
         problemDetails: {
-          type: errorType === 'notFound'
+          type: errorType === DidResolutionError.NotFound
             ? 'https://w3id.org/security#NOT_FOUND'
             : 'https://w3id.org/security#INVALID_CONTROLLED_IDENTIFIER_DOCUMENT_ID',
-          title: errorType === 'notFound'
+          title: errorType === DidResolutionError.NotFound
             ? 'The DID Log or resource was not found.'
             : 'The resolved DID is invalid.',
           detail: message
@@ -78,18 +96,35 @@ export const resolveDID = async (did: string, options: ResolutionOptions & { wit
   }
 };
 
+/**
+ * Resolves a DID from an in-memory DID log.
+ *
+ * For `did:webvh:1.0`, `fastResolve` is forwarded to the v1 resolver.
+ * For `did:webvh:0.5`, `fastResolve` is ignored and not forwarded.
+ *
+ * @param log In-memory DID log entries.
+ * @param options Optional resolver settings.
+ * @returns The resolved DID result with resolution metadata.
+ */
 export const resolveDIDFromLog = async (log: DIDLog, options: ResolutionOptions & { witnessProofs?: WitnessProofFileEntry[] } = {}) => {
   const version = getWebvhVersionFromLog(log);
+  const { fastResolve, ...baseOptions } = options;
   if (version === '0.5') {
-    const result = await v0_5.resolveDIDFromLog(log, options);
+    const result = await v0_5.resolveDIDFromLog(log, baseOptions);
     maybeWriteTestLog(result.did, log);
     return result;
   }
-  const result = await v1.resolveDIDFromLog(log, options);
+  const result = await v1.resolveDIDFromLog(log, { ...baseOptions, fastResolve });
   maybeWriteTestLog(result.did, log);
   return result;
 };
 
+/**
+ * Updates an existing DID log with a new entry.
+ *
+ * @param options DID update options.
+ * @returns The updated DID, resolved document, and DID log.
+ */
 export const updateDID = async (options: UpdateDIDInterface & { services?: any[], domain?: string, updated?: string }): Promise<UpdateDIDResult> => {
   const version = options.log ? getWebvhVersionFromLog(options.log) : getWebvhVersionFromOptions(options);
   const result = version === '0.5'
@@ -99,6 +134,12 @@ export const updateDID = async (options: UpdateDIDInterface & { services?: any[]
   return result;
 };
 
+/**
+ * Deactivates an existing DID by appending a deactivation entry.
+ *
+ * @param options DID deactivation options.
+ * @returns The deactivated DID result and updated DID log.
+ */
 export const deactivateDID = async (options: DeactivateDIDInterface & { updateKeys?: string[] }) => {
   const version = options.log ? getWebvhVersionFromLog(options.log) : getWebvhVersionFromOptions(options);
   const result = version === '0.5'

--- a/src/method_versions/method.v0.5.ts
+++ b/src/method_versions/method.v0.5.ts
@@ -2,7 +2,7 @@ import { createDate, createDIDDoc, createSCID, deriveHash, findVerificationMetho
 import {METHOD, PLACEHOLDER } from '../constants';
 import { documentStateIsValid, hashChainValid, newKeysAreInNextKeys, scidIsFromHash } from '../assertions';
 import type { CreateDIDInterface, DIDResolutionMeta, DIDLogEntry, DIDLog, UpdateDIDInterface, DeactivateDIDInterface, ResolutionOptions, WitnessProofFileEntry, WitnessParameterResolution, DataIntegrityProof } from '../interfaces';
-import { verifyWitnessProofs, validateWitnessParameter, fetchWitnessProofs } from '../witness';
+import { countVerifiedWitnessApprovals, validateWitnessParameter, fetchWitnessProofs } from '../witness';
 
 const VERSION = '0.5';
 const PROTOCOL = `did:${METHOD}:${VERSION}`;
@@ -294,10 +294,15 @@ export const resolveDIDFromLog = async (log: DIDLog, options: ResolutionOptions 
         return wp.versionId === meta.versionId;
       });
 
-      if (validProofs.length > 0) {
-        await verifyWitnessProofs(resolutionLog[i], validProofs, meta.witness!, options.verifier);
-      } else if (meta.witness && meta.witness.threshold && parseInt(meta.witness.threshold.toString()) > 0) {
-        throw new Error('No witness proofs found for version ' + meta.versionId);
+      const approvals = await countVerifiedWitnessApprovals(
+        resolutionLog[i],
+        validProofs,
+        meta.witness,
+        options.verifier
+      );
+      const threshold = parseInt((meta.witness.threshold ?? 0).toString(), 10);
+      if (approvals < threshold) {
+        throw new Error(`Witness threshold not met for version ${meta.versionId}: got ${approvals}, need ${meta.witness.threshold}`);
       }
     }
 

--- a/src/method_versions/method.v1.0.ts
+++ b/src/method_versions/method.v1.0.ts
@@ -1,6 +1,7 @@
 import { createDate, createDIDDoc, createSCID, deriveHash, findVerificationMethod, getActiveDIDs, getBaseUrl, replaceValueInObject, deepClone, enrichAlsoKnownAs, generateParallelDidWeb, parseCanonicalAddress, replaceCreateDidPlaceholders, validateCreateDidDocument } from "../utils";
 import { METHOD, PLACEHOLDER } from '../constants';
 import { documentStateIsValid, hashChainValid, newKeysAreInNextKeys, scidIsFromHash } from '../assertions';
+import { DidResolutionError } from '../interfaces';
 import type { CreateDIDInterface, CreateDIDResult, DIDResolutionMeta, DIDLogEntry, DIDLog, UpdateDIDInterface, UpdateDIDResult, DeactivateDIDInterface, ResolutionOptions, WitnessProofFileEntry, DataIntegrityProof, WitnessParameterResolution } from '../interfaces';
 import { countVerifiedWitnessApprovals, validateWitnessParameter, fetchWitnessProofs } from '../witness';
 
@@ -378,10 +379,10 @@ export const resolveDIDFromLog = async (log: DIDLog, options: ResolutionOptions 
     }
     if (resolvedMeta) {
       const message = e instanceof Error ? e.message : String(e);
-      resolvedMeta.error = 'INVALID_DID_DOCUMENT';
+      resolvedMeta.error = DidResolutionError.InvalidDid;
       resolvedMeta.problemDetails = {
-        type: 'https://w3id.org/security#INVALID_DID_DOCUMENT',
-        title: 'Verification of a later log entry failed.',
+        type: 'https://w3id.org/security#INVALID_CONTROLLED_IDENTIFIER_DOCUMENT_ID',
+        title: 'The resolved DID is invalid.',
         detail: message
       };
     }

--- a/src/method_versions/method.v1.0.ts
+++ b/src/method_versions/method.v1.0.ts
@@ -1,8 +1,8 @@
 import { createDate, createDIDDoc, createSCID, deriveHash, findVerificationMethod, getActiveDIDs, getBaseUrl, replaceValueInObject, deepClone, enrichAlsoKnownAs, generateParallelDidWeb, parseCanonicalAddress, replaceCreateDidPlaceholders, validateCreateDidDocument } from "../utils";
 import { METHOD, PLACEHOLDER } from '../constants';
 import { documentStateIsValid, hashChainValid, newKeysAreInNextKeys, scidIsFromHash } from '../assertions';
-import type { CreateDIDInterface, CreateDIDResult, DIDResolutionMeta, DIDLogEntry, DIDLog, UpdateDIDInterface, UpdateDIDResult, DeactivateDIDInterface, ResolutionOptions, WitnessProofFileEntry, DataIntegrityProof } from '../interfaces';
-import { verifyWitnessProofs, validateWitnessParameter, fetchWitnessProofs } from '../witness';
+import type { CreateDIDInterface, CreateDIDResult, DIDResolutionMeta, DIDLogEntry, DIDLog, UpdateDIDInterface, UpdateDIDResult, DeactivateDIDInterface, ResolutionOptions, WitnessProofFileEntry, DataIntegrityProof, WitnessParameterResolution } from '../interfaces';
+import { countVerifiedWitnessApprovals, validateWitnessParameter, fetchWitnessProofs } from '../witness';
 
 const VERSION = '1.0';
 const PROTOCOL = `did:${METHOD}:${VERSION}`;
@@ -154,9 +154,10 @@ export const resolveDIDFromLog = async (log: DIDLog, options: ResolutionOptions 
   let lastValidMeta: DIDResolutionMeta | null = null;
   let i = 0;
   let host = '';
+  const requiredWitnessChecks: RequiredWitnessCheck[] = [];
 
-  // Fast resolution: Only verify critical entries (first and last few entries)
-  const fastResolve = options.fastResolve ?? true; // Default to fast resolution
+  // Fast resolution is opt-in; full verification is the default conformant path.
+  const fastResolve = options.fastResolve ?? false;
   const isFirstEntry = (idx: number) => idx === 0;
   const isLastFewEntries = (idx: number) => idx >= resolutionLog.length - 10; // Verify last 10 entries
   const shouldVerifyEntry = (idx: number) => !fastResolve || isFirstEntry(idx) || isLastFewEntries(idx);
@@ -165,6 +166,7 @@ export const resolveDIDFromLog = async (log: DIDLog, options: ResolutionOptions 
   while (i < resolutionLog.length) {
     const { versionId, versionTime, parameters, state, proof } = resolutionLog[i];
     const [version, entryHash] = versionId.split('-');
+    const previousWitness = meta.witness ? deepClone(meta.witness) : undefined;
     if (parseInt(version) !== i + 1) {
       throw new Error(`version '${version}' in log doesn't match expected '${i + 1}'.`);
     }
@@ -271,6 +273,15 @@ export const resolveDIDFromLog = async (log: DIDLog, options: ResolutionOptions 
         meta.watchers = parameters.watchers ?? null;
       }
     }
+
+    const requiredWitness = getRequiredWitnessForEntry(previousWitness, parameters, meta.witness);
+    if (requiredWitness) {
+      requiredWitnessChecks.push({
+        targetVersionId: meta.versionId,
+        targetVersionNumber: parseInt(version, 10),
+        witness: requiredWitness,
+      });
+    }
     
     // Optimized: Use efficient cloning instead of clone() function
     doc = deepClone(newDoc);
@@ -327,26 +338,39 @@ export const resolveDIDFromLog = async (log: DIDLog, options: ResolutionOptions 
       }
     }
 
-    if (meta.witness && i === resolutionLog.length - 1) {
-      if (!options.witnessProofs) {
-        options.witnessProofs = await fetchWitnessProofs(did);
-      }
-
-      const validProofs = options.witnessProofs.filter((wp: WitnessProofFileEntry) => {
-        return wp.versionId === meta.versionId;
-      });
-
-      if (validProofs.length > 0) {
-        await verifyWitnessProofs(resolutionLog[i], validProofs, meta.witness!, options.verifier);
-      } else if (meta.witness && meta.witness.threshold && parseInt(meta.witness.threshold.toString()) > 0) {
-        throw new Error('No witness proofs found for version ' + meta.versionId);
-      }
-    }
-
     lastValidDoc = deepClone(doc);
     lastValidMeta = { ...meta };
 
     i++;
+  }
+
+  if (requiredWitnessChecks.length > 0) {
+    if (!options.witnessProofs) {
+      options.witnessProofs = await fetchWitnessProofs(did);
+    }
+
+    const publishedVersionNumbers = new Map(
+      resolutionLog.map((entry, index) => [entry.versionId, index + 1])
+    );
+
+    for (const check of requiredWitnessChecks) {
+      const candidateProofs = (options.witnessProofs ?? []).filter((witnessProof) => {
+        const proofVersionNumber = publishedVersionNumbers.get(witnessProof.versionId);
+        return proofVersionNumber !== undefined && proofVersionNumber >= check.targetVersionNumber;
+      });
+
+      const approvals = await countVerifiedWitnessApprovals(
+        resolutionLog[check.targetVersionNumber - 1],
+        candidateProofs,
+        check.witness,
+        options.verifier
+      );
+      const threshold = parseInt((check.witness.threshold ?? 0).toString(), 10);
+
+      if (approvals < threshold) {
+        throw new Error(`Witness threshold not met for version ${check.targetVersionId}: got ${approvals}, need ${check.witness.threshold}`);
+      }
+    }
   }
   } catch (e) {
     if (!resolvedDoc) {
@@ -536,4 +560,60 @@ export const deactivateDID = async (options: DeactivateDIDInterface & { updateKe
       prelimEntry
     ]
   }
-} 
+}
+
+interface RequiredWitnessCheck {
+  targetVersionId: string;
+  targetVersionNumber: number;
+  witness: WitnessParameterResolution;
+}
+
+const getEntryWitnessParameter = (parameters: DIDLogEntry['parameters']): WitnessParameterResolution | undefined => {
+  if ('witness' in parameters) {
+    return parameters.witness ?? {};
+  }
+
+  if ((parameters as any).witnesses) {
+    return {
+      witnesses: (parameters as any).witnesses,
+      threshold: (parameters as any).witnessThreshold || (parameters as any).witnesses.length,
+    };
+  }
+
+  return undefined;
+};
+
+const isWitnessActive = (witness?: WitnessParameterResolution | null): witness is WitnessParameterResolution => {
+  if (!witness?.witnesses || witness.witnesses.length === 0) {
+    return false;
+  }
+
+  const threshold = parseInt((witness.threshold ?? 0).toString(), 10);
+  return threshold > 0;
+};
+
+const getRequiredWitnessForEntry = (
+  previousWitness: WitnessParameterResolution | undefined,
+  parameters: DIDLogEntry['parameters'],
+  currentWitness: WitnessParameterResolution | undefined
+): WitnessParameterResolution | undefined => {
+  const explicitWitness = getEntryWitnessParameter(parameters);
+
+  if (explicitWitness !== undefined) {
+    if (isWitnessActive(currentWitness)) {
+      return deepClone(currentWitness);
+    }
+
+    if (isWitnessActive(previousWitness)) {
+      return deepClone(previousWitness);
+    }
+
+    return undefined;
+  }
+
+  if (isWitnessActive(previousWitness)) {
+    return deepClone(previousWitness);
+  }
+
+  return undefined;
+};

--- a/src/method_versions/method.v1.0.ts
+++ b/src/method_versions/method.v1.0.ts
@@ -270,6 +270,9 @@ export const resolveDIDFromLog = async (log: DIDLog, options: ResolutionOptions 
           threshold: parameters.witnessThreshold || parameters.witnesses.length
         };
       }
+      if (meta.witness?.witnesses?.length) {
+        validateWitnessParameter(meta.witness);
+      }
       if ('watchers' in parameters) {
         meta.watchers = parameters.watchers ?? null;
       }
@@ -414,15 +417,23 @@ export const updateDID = async (options: UpdateDIDInterface & { services?: any[]
   const versionNumber = log.length + 1;
   const createdDate = createDate(options.updated);
   const watchersValue = options.watchers !== undefined ? options.watchers : lastMeta.watchers;
+  const witnessInput = options.witness;
+  const witness = witnessInput?.witnesses?.length
+    ? {
+        witnesses: witnessInput.witnesses,
+        threshold: witnessInput.threshold ?? 0,
+      }
+    : {};
   const params = {
     updateKeys: options.updateKeys ?? [],
     nextKeyHashes: options.nextKeyHashes ?? [],
-    witness: (options.witness !== undefined && options.witness !== null) ? {
-      witnesses: options.witness?.witnesses || [],
-      threshold: options.witness?.threshold || 0
-    } : {},
+    witness,
     watchers: watchersValue ?? []
   };
+  
+  if (params.witness?.witnesses?.length) {
+    validateWitnessParameter(params.witness);
+  }
   
   // Safety guard: Strip secret keys from verification methods before creating DID document  
   const safeVerificationMethods = options.verificationMethods?.map(vm => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,11 +1,68 @@
 import { canonicalize } from 'json-canonicalize';
 import { config } from './config';
 import { BASE_CONTEXT } from './constants';
-import type { CreateDIDInterface, DIDDoc, DIDLog, ServiceEndpoint, VerificationMethod, WitnessProofFileEntry } from './interfaces';
+import type { CreateDIDInterface, DIDDoc, DIDLog, ParsedDidKeyVerificationMethod, ServiceEndpoint, VerificationMethod, WitnessProofFileEntry } from './interfaces';
 import { resolveDIDFromLog } from './method';
 import { bufferToString, createBuffer } from './utils/buffer';
 import { createHash } from './utils/crypto';
-import { createMultihash, encodeBase58Btc, MultihashAlgorithm } from './utils/multiformats';
+import { createMultihash, encodeBase58Btc, MultihashAlgorithm, multibaseDecode } from './utils/multiformats';
+
+const DID_KEY_PREFIX = 'did:key:';
+
+function validateDidKeyMultibase(keyMultibase: string): void {
+  if (!keyMultibase) {
+    throw new Error('Malformed did:key identifier');
+  }
+
+  try {
+    multibaseDecode(keyMultibase);
+  } catch (error: any) {
+    throw new Error(`Malformed did:key identifier: ${error.message}`);
+  }
+}
+
+export function parseDidKeyDid(input: string): { did: string; keyMultibase: string } {
+  if (typeof input !== 'string') {
+    throw new Error('did:key DID must be a string');
+  }
+
+  const match = input.match(/^did:key:([^#/?]+)$/);
+  if (!match) {
+    throw new Error('Malformed did:key DID');
+  }
+
+  const keyMultibase = match[1];
+  validateDidKeyMultibase(keyMultibase);
+
+  return {
+    did: `${DID_KEY_PREFIX}${keyMultibase}`,
+    keyMultibase,
+  };
+}
+
+export function parseDidKeyVerificationMethod(input: string): ParsedDidKeyVerificationMethod {
+  if (typeof input !== 'string') {
+    throw new Error('did:key verificationMethod must be a string');
+  }
+
+  if (input.startsWith('#')) {
+    throw new Error('did:key verificationMethod must be an absolute DID URL');
+  }
+
+  const match = input.match(/^did:key:([^#/?]+)(?:#([^#/?]+))?$/);
+  if (!match) {
+    throw new Error('Malformed did:key verificationMethod');
+  }
+
+  const parsedDid = parseDidKeyDid(`${DID_KEY_PREFIX}${match[1]}`);
+  const fragment = match[2];
+
+  return {
+    did: parsedDid.did,
+    fragment,
+    keyMultibase: parsedDid.keyMultibase,
+  };
+}
 
 // Canonical address parser for strict parity with didwebvh-rs
 interface ParsedAddress {
@@ -701,7 +758,8 @@ export const normalizeVMs = (verificationMethod: VerificationMethod[] | undefine
 export const resolveVM = async (vm: string) => {
   try {
     if (vm.startsWith('did:key:')) {
-      return {publicKeyMultibase: vm.split('did:key:')[1].split('#')[0]}
+      const parsedVerificationMethod = parseDidKeyVerificationMethod(vm);
+      return {publicKeyMultibase: parsedVerificationMethod.keyMultibase}
     }
     else if (vm.startsWith('did:webvh:')) {
       const url = getFileUrl(vm.split('#')[0]);

--- a/src/witness.ts
+++ b/src/witness.ts
@@ -41,6 +41,15 @@ function createWitnessProofSigner(signer: WitnessSigner) {
   };
 }
 
+/**
+ * Creates a single witness DataIntegrityProof for one `versionId`.
+ *
+ * @param signer Proof signer callback.
+ * @param versionId Target DID log version id.
+ * @param verificationMethod Witness verification method DID URL.
+ * @param created Optional proof creation time in ISO format.
+ * @returns A complete DataIntegrityProof for did-witness processing.
+ */
 export async function createWitnessProof(
   signer: (
     doc: { versionId: string },
@@ -78,7 +87,15 @@ export async function createWitnessProof(
   };
 }
 
-export async function signWitnessProofsForVersion(
+/**
+ * Signs one did-witness proof entry for a single target `versionId`.
+ *
+ * The signer map is keyed by witness DID (`did:key:...`).
+ *
+ * @param options Witness signing options for one target version.
+ * @returns A witness proof file entry for the target version.
+ */
+export async function signWitnessProofEntry(
   options: WitnessSigningOptions
 ): Promise<WitnessSigningResult> {
   if (!options.versionId) {
@@ -121,7 +138,16 @@ export async function signWitnessProofsForVersion(
   };
 }
 
-export async function signWitnessProofsForVersions(
+/**
+ * Signs did-witness proof entries for multiple target `versionId`s.
+ *
+ * @param versionIds Target DID log version ids.
+ * @param witnesses Witness DID entries used to sign.
+ * @param witnessSignersByDid Signer map keyed by witness did:key DID.
+ * @param created Optional proof creation time in ISO format.
+ * @returns A witness proof file entry per version id.
+ */
+export async function signWitnessProofEntries(
   versionIds: string[],
   witnesses: WitnessEntry[],
   witnessSignersByDid: Record<string, WitnessSigner>,
@@ -129,7 +155,7 @@ export async function signWitnessProofsForVersions(
 ): Promise<WitnessSigningResult[]> {
   return Promise.all(
     versionIds.map((versionId) =>
-      signWitnessProofsForVersion({
+      signWitnessProofEntry({
         versionId,
         witnesses,
         witnessSignersByDid,

--- a/src/witness.ts
+++ b/src/witness.ts
@@ -283,7 +283,13 @@ export async function countVerifiedWitnessApprovals(
 
         approvals++;
         processedWitnesses.add(witness.id);
-      } catch {
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.warn(
+          `Ignoring invalid witness proof for version ${proofSet.versionId} ` +
+          `(verificationMethod: ${proof.verificationMethod}): ${message}`
+        );
+
         // Individual invalid proofs do not count toward threshold if other valid proofs remain.
         continue;
       }
@@ -291,116 +297,6 @@ export async function countVerifiedWitnessApprovals(
   }
 
   return approvals;
-}
-
-export async function verifyWitnessProofs(
-  logEntry: DIDLogEntry,
-  witnessProofs: WitnessProofFileEntry[],
-  currentWitness: WitnessParameterResolution,
-  verifier?: Verifier
-): Promise<void> {
-  if (!verifier) {
-    throw new Error('Verifier implementation is required');
-  }
-
-  let approvals = 0;
-  const processedWitnesses = new Set<string>();
-  const witnessesByDid = new Map(
-    (currentWitness.witnesses ?? []).map((witness) => {
-      const parsedDid = parseDidKeyDid(witness.id);
-      return [parsedDid.did, witness];
-    })
-  );
-
-  // Process each proof set
-  for (const proofSet of witnessProofs) {
-    // Process each proof in the set
-    for (const proof of proofSet.proof) {
-      if (proof.type !== 'DataIntegrityProof') {
-        throw new Error('Invalid witness proof type');
-      }
-
-      if (proof.proofPurpose !== 'assertionMethod') {
-        throw new Error('Invalid witness proof purpose');
-      }
-
-      if (proof.cryptosuite !== 'eddsa-jcs-2022') {
-        throw new Error('Invalid witness proof cryptosuite');
-      }
-
-      const parsedVerificationMethod = parseDidKeyVerificationMethod(proof.verificationMethod);
-      const witness = witnessesByDid.get(parsedVerificationMethod.did);
-      if (!witness) {
-        throw new Error('Proof from unauthorized witness');
-      }
-
-      if (processedWitnesses.has(witness.id)) {
-        continue; // Skip duplicate proofs from same witness
-      }
-
-      try {
-        // Resolve verification method
-        const vm = await resolveVM(proof.verificationMethod);
-        if (!vm || !vm.publicKeyMultibase) {
-          throw new Error(`Verification Method ${proof.verificationMethod} not found`);
-        }
-
-        // Decode public key
-        let publicKey: Uint8Array;
-        try {
-          publicKey = multibaseDecode(vm.publicKeyMultibase).bytes;
-        } catch (error: any) {
-          throw new Error(`Failed to decode public key: ${error.message}`);
-        }
-        
-        if (publicKey.length !== 34) {
-          throw new Error(`Invalid public key length ${publicKey.length} (should be 34 bytes)`);
-        }
-
-        // Extract proof value and prepare data for verification
-        const { proofValue, ...proofWithoutValue } = proof;
-        
-        // Create hashes
-        const canonicalizedData = canonicalize({versionId: logEntry.versionId});
-        const canonicalizedProof = canonicalize(proofWithoutValue);
-        
-        const dataHash = await createHash(canonicalizedData);
-        const proofHash = await createHash(canonicalizedProof);
-        
-        // Concatenate buffers
-        const input = concatBuffers(proofHash, dataHash);
-
-        // Decode signature
-        let signature: Uint8Array;
-        try {
-          signature = multibaseDecode(proofValue).bytes;
-        } catch (error: any) {
-          throw new Error(`Failed to decode signature: ${error.message}`);
-        }
-
-        // Verify signature
-        const verified = await verifier.verify(
-          signature,
-          input,
-          publicKey.slice(2)
-        );
-
-        if (!verified) {
-          throw new Error('Invalid witness proof signature');
-        }
-
-        approvals++;
-        processedWitnesses.add(witness.id);
-
-      } catch (error: any) {
-        throw new Error(`Invalid witness proof: ${error.message}`);
-      }
-    }
-  }
-
-  if (approvals < parseInt(currentWitness.threshold?.toString() ?? '0')) {
-    throw new Error(`Witness threshold not met: got ${approvals}, need ${currentWitness.threshold}`);
-  }
 }
 
 export { fetchWitnessProofs }; 

--- a/src/witness.ts
+++ b/src/witness.ts
@@ -4,10 +4,10 @@ import type {
   DataIntegrityProof,
   DataIntegrityProofTemplate,
   DIDLogEntry,
+  Signer,
   SigningInput,
   WitnessEntry,
   WitnessProofFileEntry,
-  WitnessSigner,
   WitnessSigningOptions,
   WitnessSigningResult,
   Verifier,
@@ -18,7 +18,7 @@ import { concatBuffers } from './utils/buffer';
 import { fetchWitnessProofs } from './utils';
 import { multibaseDecode } from './utils/multiformats';
 
-function createWitnessProofSigner(signer: WitnessSigner) {
+function createWitnessProofSigner(signer: Signer) {
   return async (
     document: { versionId: string },
     proofTemplate?: DataIntegrityProofTemplate
@@ -150,7 +150,7 @@ export async function signWitnessProofEntry(
 export async function signWitnessProofEntries(
   versionIds: string[],
   witnesses: WitnessEntry[],
-  witnessSignersByDid: Record<string, WitnessSigner>,
+  witnessSignersByDid: Record<string, Signer>,
   created?: string
 ): Promise<WitnessSigningResult[]> {
   return Promise.all(

--- a/src/witness.ts
+++ b/src/witness.ts
@@ -1,10 +1,45 @@
 import { canonicalize } from 'json-canonicalize';
 import { createHash } from './utils/crypto';
-import type { DataIntegrityProof, DataIntegrityProofTemplate, DIDLogEntry, WitnessEntry, WitnessProofFileEntry, Verifier, WitnessParameterResolution } from './interfaces';
-import { resolveVM } from "./utils";
+import type {
+  DataIntegrityProof,
+  DataIntegrityProofTemplate,
+  DIDLogEntry,
+  SigningInput,
+  WitnessEntry,
+  WitnessProofFileEntry,
+  WitnessSigner,
+  WitnessSigningOptions,
+  WitnessSigningResult,
+  Verifier,
+  WitnessParameterResolution,
+} from './interfaces';
+import { parseDidKeyDid, parseDidKeyVerificationMethod, resolveVM } from "./utils";
 import { concatBuffers } from './utils/buffer';
 import { fetchWitnessProofs } from './utils';
 import { multibaseDecode } from './utils/multiformats';
+
+function createWitnessProofSigner(signer: WitnessSigner) {
+  return async (
+    document: { versionId: string },
+    proofTemplate?: DataIntegrityProofTemplate
+  ): Promise<{ proof: Partial<DataIntegrityProof> }> => {
+    if (!proofTemplate) {
+      throw new Error('Witness proof template is required');
+    }
+
+    const signed = await signer.sign({
+      document,
+      proof: proofTemplate,
+    } satisfies SigningInput);
+
+    return {
+      proof: {
+        verificationMethod: proofTemplate.verificationMethod,
+        proofValue: signed.proofValue,
+      },
+    };
+  };
+}
 
 export async function createWitnessProof(
   signer: (
@@ -12,13 +47,14 @@ export async function createWitnessProof(
     proofTemplate?: DataIntegrityProofTemplate
   ) => Promise<{ proof: Partial<DataIntegrityProof> }>,
   versionId: string,
-  verificationMethod: string
+  verificationMethod: string,
+  created: string = new Date().toISOString()
 ): Promise<DataIntegrityProof> {
   const proofTemplate: DataIntegrityProofTemplate = {
     type: "DataIntegrityProof",
     cryptosuite: "eddsa-jcs-2022",
     verificationMethod,
-    created: new Date().toISOString(),
+    created,
     proofPurpose: "assertionMethod"
   };
 
@@ -42,6 +78,67 @@ export async function createWitnessProof(
   };
 }
 
+export async function signWitnessProofsForVersion(
+  options: WitnessSigningOptions
+): Promise<WitnessSigningResult> {
+  if (!options.versionId) {
+    throw new Error('versionId is required');
+  }
+
+  const witnessCount = options.witnesses.length;
+  if (witnessCount === 0) {
+    throw new Error('Witness list cannot be empty');
+  }
+
+  const proofs = await Promise.all(
+    options.witnesses.map(async (witness) => {
+      const { did } = parseDidKeyDid(witness.id);
+      const signer = options.witnessSignersByDid[did];
+
+      if (!signer) {
+        throw new Error(`Missing witness signer for ${did}`);
+      }
+
+      const verificationMethod = signer.getVerificationMethodId();
+      const parsedVerificationMethod = parseDidKeyVerificationMethod(verificationMethod);
+
+      if (parsedVerificationMethod.did !== did) {
+        throw new Error(`Witness signer verificationMethod DID does not match witness id: ${did}`);
+      }
+
+      return createWitnessProof(
+        createWitnessProofSigner(signer),
+        options.versionId,
+        verificationMethod,
+        options.created
+      );
+    })
+  );
+
+  return {
+    versionId: options.versionId,
+    proof: proofs,
+  };
+}
+
+export async function signWitnessProofsForVersions(
+  versionIds: string[],
+  witnesses: WitnessEntry[],
+  witnessSignersByDid: Record<string, WitnessSigner>,
+  created?: string
+): Promise<WitnessSigningResult[]> {
+  return Promise.all(
+    versionIds.map((versionId) =>
+      signWitnessProofsForVersion({
+        versionId,
+        witnesses,
+        witnessSignersByDid,
+        created,
+      })
+    )
+  );
+}
+
 export function validateWitnessParameter(witness: WitnessParameterResolution): void {
   if (!witness.witnesses || !Array.isArray(witness.witnesses) || witness.witnesses.length === 0) {
     throw new Error('Witness list cannot be empty');
@@ -53,21 +150,32 @@ export function validateWitnessParameter(witness: WitnessParameterResolution): v
 
   const ids = new Set<string>();
   for (const w of witness.witnesses) {
-    if (!w.id.startsWith('did:key:')) {
+    let parsedDid;
+    try {
+      parsedDid = parseDidKeyDid(w.id);
+    } catch {
       throw new Error('Witness DIDs must be did:key format');
     }
-    if (ids.has(w.id)) {
+
+    if (ids.has(parsedDid.did)) {
       throw new Error(`Duplicate witness id: ${w.id}`);
     }
-    ids.add(w.id);
+    ids.add(parsedDid.did);
   }
 }
 
-export function calculateWitnessWeight(proofs: DataIntegrityProof[], witnesses: WitnessEntry[]): number {
+export function countWitnessApprovals(proofs: DataIntegrityProof[], witnesses: WitnessEntry[]): number {
   const processed = new Set<string>();
+  const witnessesByDid = new Map(
+    witnesses.map((witness) => {
+      const parsedDid = parseDidKeyDid(witness.id);
+      return [parsedDid.did, witness];
+    })
+  );
 
   for (const proof of proofs) {
-    const witness = witnesses.find(w => proof.verificationMethod.startsWith(w.id));
+    const parsedVerificationMethod = parseDidKeyVerificationMethod(proof.verificationMethod);
+    const witness = witnessesByDid.get(parsedVerificationMethod.did);
     if (witness) {
       if (proof.cryptosuite !== 'eddsa-jcs-2022') {
         throw new Error('Invalid witness proof cryptosuite');
@@ -77,6 +185,86 @@ export function calculateWitnessWeight(proofs: DataIntegrityProof[], witnesses: 
   }
 
   return processed.size;
+}
+
+export async function countVerifiedWitnessApprovals(
+  logEntry: DIDLogEntry,
+  witnessProofs: WitnessProofFileEntry[],
+  currentWitness: WitnessParameterResolution,
+  verifier?: Verifier
+): Promise<number> {
+  if (!verifier) {
+    throw new Error('Verifier implementation is required');
+  }
+
+  let approvals = 0;
+  const processedWitnesses = new Set<string>();
+  const witnessesByDid = new Map(
+    (currentWitness.witnesses ?? []).map((witness) => {
+      const parsedDid = parseDidKeyDid(witness.id);
+      return [parsedDid.did, witness];
+    })
+  );
+
+  for (const proofSet of witnessProofs) {
+    for (const proof of proofSet.proof) {
+      try {
+        if (proof.type !== 'DataIntegrityProof') {
+          throw new Error('Invalid witness proof type');
+        }
+
+        if (proof.proofPurpose !== 'assertionMethod') {
+          throw new Error('Invalid witness proof purpose');
+        }
+
+        if (proof.cryptosuite !== 'eddsa-jcs-2022') {
+          throw new Error('Invalid witness proof cryptosuite');
+        }
+
+        const parsedVerificationMethod = parseDidKeyVerificationMethod(proof.verificationMethod);
+        const witness = witnessesByDid.get(parsedVerificationMethod.did);
+        if (!witness || processedWitnesses.has(witness.id)) {
+          continue;
+        }
+
+        const vm = await resolveVM(proof.verificationMethod);
+        if (!vm || !vm.publicKeyMultibase) {
+          throw new Error(`Verification Method ${proof.verificationMethod} not found`);
+        }
+
+        const publicKey = multibaseDecode(vm.publicKeyMultibase).bytes;
+        if (publicKey.length !== 34) {
+          throw new Error(`Invalid public key length ${publicKey.length} (should be 34 bytes)`);
+        }
+
+        const { proofValue, ...proofWithoutValue } = proof;
+        const canonicalizedData = canonicalize({ versionId: logEntry.versionId });
+        const canonicalizedProof = canonicalize(proofWithoutValue);
+        const dataHash = await createHash(canonicalizedData);
+        const proofHash = await createHash(canonicalizedProof);
+        const input = concatBuffers(proofHash, dataHash);
+        const signature = multibaseDecode(proofValue).bytes;
+
+        const verified = await verifier.verify(
+          signature,
+          input,
+          publicKey.slice(2)
+        );
+
+        if (!verified) {
+          throw new Error('Invalid witness proof signature');
+        }
+
+        approvals++;
+        processedWitnesses.add(witness.id);
+      } catch {
+        // Individual invalid proofs do not count toward threshold if other valid proofs remain.
+        continue;
+      }
+    }
+  }
+
+  return approvals;
 }
 
 export async function verifyWitnessProofs(
@@ -91,6 +279,12 @@ export async function verifyWitnessProofs(
 
   let approvals = 0;
   const processedWitnesses = new Set<string>();
+  const witnessesByDid = new Map(
+    (currentWitness.witnesses ?? []).map((witness) => {
+      const parsedDid = parseDidKeyDid(witness.id);
+      return [parsedDid.did, witness];
+    })
+  );
 
   // Process each proof set
   for (const proofSet of witnessProofs) {
@@ -108,7 +302,8 @@ export async function verifyWitnessProofs(
         throw new Error('Invalid witness proof cryptosuite');
       }
 
-      const witness = currentWitness.witnesses?.find(w => proof.verificationMethod.startsWith(w.id));
+      const parsedVerificationMethod = parseDidKeyVerificationMethod(proof.verificationMethod);
+      const witness = witnessesByDid.get(parsedVerificationMethod.did);
       if (!witness) {
         throw new Error('Proof from unauthorized witness');
       }

--- a/test/cli-e2e.test.ts
+++ b/test/cli-e2e.test.ts
@@ -238,4 +238,23 @@ describe("Witness CLI End-to-End Tests", async () => {
       throw error;
     }
   });
+
+  test("Generate witness proof for multiple version IDs", async () => {
+    const witness = await generateTestVerificationMethod();
+    const witnessDid = `did:key:${witness.publicKeyMultibase}`;
+    const outputFile = join(TEST_DIR, 'did-witness-multi.json');
+
+    const proc = await $`bun run cli generate-witness-proof --version-id 1-abc123 --version-id 2-def456 --witness-did ${witnessDid} --witness-secret ${witness.secretKeyMultibase!} --output ${outputFile}`.quiet();
+    expect(proc.exitCode).toBe(0);
+
+    const content = JSON.parse(fs.readFileSync(outputFile, 'utf8'));
+    expect(Array.isArray(content)).toBe(true);
+    expect(content).toHaveLength(2);
+    expect(content[0].versionId).toBe('1-abc123');
+    expect(content[1].versionId).toBe('2-def456');
+    expect(content[0].proof).toHaveLength(1);
+    expect(content[1].proof).toHaveLength(1);
+    expect(content[0].proof[0].proofPurpose).toBe('assertionMethod');
+    expect(content[1].proof[0].proofPurpose).toBe('assertionMethod');
+  });
 });

--- a/test/cli-e2e.test.ts
+++ b/test/cli-e2e.test.ts
@@ -214,11 +214,11 @@ describe("Witness CLI End-to-End Tests", async () => {
     try {
       // Use the test implementation instead of generateEd25519VerificationMethod
       const witness = await generateTestVerificationMethod();
-      // Parse the witness log and get the verification key from the state
-      const witnessDIDKey = `did:key:${witness.publicKeyMultibase}#${witness.publicKeyMultibase}`;
+      // Witness ids are did:key DIDs (not DID URLs with fragments)
+      const witnessDid = `did:key:${witness.publicKeyMultibase}`;
       
       // Run the CLI create command with witness
-      const proc = await $`bun run cli create --domain localhost:8000 --output ${logFile} --witness ${witnessDIDKey} --witness-threshold 1`.quiet();
+      const proc = await $`bun run cli create --domain localhost:8000 --output ${logFile} --witness ${witnessDid} --witness-threshold 1`.quiet();
 
       expect(proc.exitCode).toBe(0);
       
@@ -231,7 +231,7 @@ describe("Witness CLI End-to-End Tests", async () => {
       }
       
       expect(log[0].parameters.witness.witnesses).toHaveLength(1);
-      expect(log[0].parameters.witness.witnesses?.[0]?.id).toBe(witnessDIDKey);
+      expect(log[0].parameters.witness.witnesses?.[0]?.id).toBe(witnessDid);
       expect(log[0].parameters.witness.threshold).toBe(1);
     } catch (error) {
       console.error('Error in witness test:', error);

--- a/test/cryptography.test.ts
+++ b/test/cryptography.test.ts
@@ -2,7 +2,7 @@ import { beforeAll, describe, expect, test } from "bun:test";
 import { AbstractCrypto, createDocumentSigner } from "../src/cryptography";
 import { SigningInput, SigningOutput, SignerOptions, Verifier } from "../src/interfaces";
 import { documentStateIsValid } from "../src/assertions";
-import { verifyWitnessProofs } from "../src/witness";
+import { countVerifiedWitnessApprovals } from "../src/witness";
 import { MultibaseEncoding } from "../src/utils/multiformats";
 import { multibaseEncode } from "../src/utils/multiformats";
 
@@ -116,7 +116,7 @@ describe("Injectable Cryptography Tests", () => {
     ).rejects.toThrow("Proof 0 failed verification");
   });
 
-  test("Verify witness proofs with successful implementation", async () => {
+  test("Count verified witness approvals with successful implementation", async () => {
     const logEntry = {
       versionId: "test-version",
       versionTime: "2024-03-06T00:00:00Z",
@@ -139,11 +139,11 @@ describe("Injectable Cryptography Tests", () => {
       }]
     };
 
-    // Should not throw — mockImplementation.verify() returns true
-    await verifyWitnessProofs(logEntry, witnessProofs, witness, mockImplementation);
+    const approvals = await countVerifiedWitnessApprovals(logEntry, witnessProofs, witness, mockImplementation);
+    expect(approvals).toBe(1);
   });
 
-  test("Verify witness proofs with failing implementation", async () => {
+  test("Count verified witness approvals logs and skips invalid proofs", async () => {
     const logEntry = {
       versionId: "test-version",
       versionTime: "2024-03-06T00:00:00Z",
@@ -166,9 +166,20 @@ describe("Injectable Cryptography Tests", () => {
       }]
     };
 
-    expect(
-      verifyWitnessProofs(logEntry, witnessProofs, witness, failingMockImplementation)
-    ).rejects.toThrow("Invalid witness proof: Invalid witness proof signature");
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args.map(String).join(" "));
+    };
+
+    try {
+      const approvals = await countVerifiedWitnessApprovals(logEntry, witnessProofs, witness, failingMockImplementation);
+      expect(approvals).toBe(0);
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    expect(warnings.some((msg) => msg.includes("Invalid witness proof signature"))).toBe(true);
   });
 
   test("Require verifier implementation", async () => {
@@ -209,7 +220,7 @@ describe("Injectable Cryptography Tests", () => {
     };
 
     expect(
-      verifyWitnessProofs(logEntry, witnessProofs, witness)
+      countVerifiedWitnessApprovals(logEntry, witnessProofs, witness)
     ).rejects.toThrow("Verifier implementation is required");
   });
 }); 

--- a/test/cryptography.test.ts
+++ b/test/cryptography.test.ts
@@ -30,6 +30,7 @@ describe("Injectable Cryptography Tests", () => {
   let failingMockImplementation: MockCryptoImplementation;
   let testDoc: any;
   let testProof: any;
+  const updateKey = "z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
 
   beforeAll(() => {
     // Create a mock implementation that succeeds verification
@@ -37,7 +38,7 @@ describe("Injectable Cryptography Tests", () => {
       verificationMethod: {
         id: "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK",
         type: "Multikey",
-        publicKeyMultibase: "z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK"
+        publicKeyMultibase: updateKey
       }
     });
 
@@ -46,7 +47,7 @@ describe("Injectable Cryptography Tests", () => {
       verificationMethod: {
         id: "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK",
         type: "Multikey",
-        publicKeyMultibase: "z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK"
+        publicKeyMultibase: updateKey
       }
     }, false);
 
@@ -86,7 +87,7 @@ describe("Injectable Cryptography Tests", () => {
 
     const result = await documentStateIsValid(
       signedDoc,
-      [mockImplementation.getVerificationMethodId()],
+      [updateKey],
       null,
       true,
       mockImplementation
@@ -104,10 +105,10 @@ describe("Injectable Cryptography Tests", () => {
       }
     };
 
-    await expect(
+    expect(
       documentStateIsValid(
         signedDoc,
-        [failingMockImplementation.getVerificationMethodId()],
+        [updateKey],
         null,
         true,
         failingMockImplementation
@@ -179,7 +180,7 @@ describe("Injectable Cryptography Tests", () => {
       }
     };
 
-    await expect(
+    expect(
       documentStateIsValid(signedDoc, [mockImplementation.getVerificationMethodId()], null, true)
     ).rejects.toThrow("Verifier implementation is required");
   });
@@ -207,7 +208,7 @@ describe("Injectable Cryptography Tests", () => {
       }]
     };
 
-    await expect(
+    expect(
       verifyWitnessProofs(logEntry, witnessProofs, witness)
     ).rejects.toThrow("Verifier implementation is required");
   });

--- a/test/must.test.ts
+++ b/test/must.test.ts
@@ -204,7 +204,7 @@ describe("did:webvh normative witness tests", async () => {
       err = e;
     }
     expect(err).toBeDefined();
-    expect(err.message).toContain("Invalid witness proof cryptosuite");
+    expect(err.message).toContain("Witness threshold not met");
   });
 
   test("resolver MUST verify witness proofs before accepting DID update", async () => {
@@ -232,7 +232,7 @@ describe("did:webvh normative witness tests", async () => {
       err = e;
     }
     expect(err).toBeDefined();
-    expect(err.message).toContain("Invalid witness proof");
+    expect(err.message).toContain("Witness threshold not met");
   });
 });
 

--- a/test/must.test.ts
+++ b/test/must.test.ts
@@ -172,7 +172,7 @@ describe("did:webvh normative witness tests", async () => {
 
     let err;
     try {
-      await resolveDIDFromLog(initialDID.log, { 
+      await resolveDIDFromLog(initialDID.log, {
         witnessProofs: mockWitnessProofs as any,
         verifier: testImplementation
       });
@@ -194,17 +194,26 @@ describe("did:webvh normative witness tests", async () => {
       }
     ];
 
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args.map(String).join(" "));
+    };
+
     let err;
     try {
-      await resolveDIDFromLog(initialDID.log, { 
+      await resolveDIDFromLog(initialDID.log, {
         witnessProofs: mockWitnessProofs as any,
         verifier: testImplementation
       });
     } catch (e: any) {
       err = e;
+    } finally {
+      console.warn = originalWarn;
     }
     expect(err).toBeDefined();
     expect(err.message).toContain("Witness threshold not met");
+    expect(warnings.some((msg) => msg.includes("Invalid witness proof cryptosuite"))).toBe(true);
   });
 
   test("resolver MUST verify witness proofs before accepting DID update", async () => {
@@ -224,7 +233,7 @@ describe("did:webvh normative witness tests", async () => {
 
     let err;
     try {
-      await resolveDIDFromLog(initialDID.log, { 
+      await resolveDIDFromLog(initialDID.log, {
         witnessProofs: mockWitnessProofs as any,
         verifier: testImplementation
       });

--- a/test/not-so-happy-path.test.ts
+++ b/test/not-so-happy-path.test.ts
@@ -92,11 +92,46 @@ describe("Not So Happy Path Tests", () => {
     const tamperedLog: DIDLog = JSON.parse(JSON.stringify(currentLog));
     tamperedLog[3].state.alsoKnownAs = ['did:example:tampered'];
 
-    // fastResolve defaults to true — middle entries skip signature checks
-    // but hash chain should still be verified
+    // Hash chain validation remains active even when fastResolve is opted in.
+    await expect(
+      resolveDIDFromLog(tamperedLog, { verifier: testImplementation, fastResolve: true })
+    ).rejects.toThrow('Hash chain broken');
+  });
+
+  test("Default resolve verifies every log entry proof", async () => {
+    let currentLog: DIDLog;
+    const { log: log0 } = await createDID({
+      domain: 'example.com',
+      signer: createTestSigner(authKey),
+      updateKeys: [authKey.publicKeyMultibase!],
+      verificationMethods: [authKey],
+      verifier: testImplementation
+    });
+    currentLog = log0;
+
+    for (let j = 0; j < 12; j++) {
+      const { log: nextLog } = await updateDID({
+        log: currentLog,
+        signer: createTestSigner(authKey),
+        updateKeys: [authKey.publicKeyMultibase!],
+        verificationMethods: [authKey],
+        verifier: testImplementation
+      });
+      currentLog = nextLog;
+    }
+
+    const tamperedLog: DIDLog = JSON.parse(JSON.stringify(currentLog));
+    // With 13 entries, index 1 is outside the fastResolve verification window
+    // (first entry + last 10 entries), but still checked in default full mode.
+    tamperedLog[1].proof[0].proofValue = 'zinvalid-proof';
+
     await expect(
       resolveDIDFromLog(tamperedLog, { verifier: testImplementation })
-    ).rejects.toThrow('Hash chain broken');
+    ).rejects.toThrow();
+
+    await expect(
+      resolveDIDFromLog(tamperedLog, { verifier: testImplementation, fastResolve: true })
+    ).resolves.toBeDefined();
   });
 
   test("Error metadata on later-entry failure", async () => {

--- a/test/not-so-happy-path.test.ts
+++ b/test/not-so-happy-path.test.ts
@@ -172,10 +172,10 @@ describe("Not So Happy Path Tests", () => {
     });
 
     expect(result.doc).not.toBeNull();
-    expect(result.meta.error).toBe('INVALID_DID_DOCUMENT');
+    expect(result.meta.error).toBe('invalidDid');
     expect(result.meta.problemDetails).toBeDefined();
-    expect(result.meta.problemDetails!.type).toBe('https://w3id.org/security#INVALID_DID_DOCUMENT');
-    expect(result.meta.problemDetails!.title).toBe('Verification of a later log entry failed.');
+    expect(result.meta.problemDetails!.type).toBe('https://w3id.org/security#INVALID_CONTROLLED_IDENTIFIER_DOCUMENT_ID');
+    expect(result.meta.problemDetails!.title).toBe('The resolved DID is invalid.');
     expect(result.meta.problemDetails!.detail).toContain('Hash chain broken');
   });
 

--- a/test/witness.test.ts
+++ b/test/witness.test.ts
@@ -460,12 +460,24 @@ describe("Witness Implementation Tests", async () => {
       }
     ];
 
-    await expect(
-      resolveDIDFromLog(initialDID.log, {
-        witnessProofs,
-        verifier: testImplementation
-      })
-    ).rejects.toThrow(`Witness threshold not met for version ${initialDID.log[0].versionId}`);
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args.map(String).join(" "));
+    };
+
+    try {
+      await expect(
+        resolveDIDFromLog(initialDID.log, {
+          witnessProofs,
+          verifier: testImplementation
+        })
+      ).rejects.toThrow(`Witness threshold not met for version ${initialDID.log[0].versionId}`);
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    expect(warnings.some((msg) => msg.includes("Invalid witness proof purpose"))).toBe(true);
   });
 
   test("parseDidKeyDid accepts a valid did:key DID", () => {

--- a/test/witness.test.ts
+++ b/test/witness.test.ts
@@ -1,9 +1,9 @@
 import { beforeAll, describe, expect, test } from "bun:test";
 import { createDID, resolveDIDFromLog, updateDID } from "../src/method";
 import { DidResolutionError } from "../src/interfaces";
-import type { DIDLog, Signer, VerificationMethod } from "../src/interfaces";
+import type { DIDLog, Signer, VerificationMethod, DataIntegrityProofTemplate } from "../src/interfaces";
 import { generateTestVerificationMethod, createTestSigner, TestCryptoImplementation } from "./utils";
-import { parseDidKeyDid, parseDidKeyVerificationMethod } from "../src/utils";
+import { deriveHash, parseDidKeyDid, parseDidKeyVerificationMethod } from "../src/utils";
 import {
   countWitnessApprovals,
   createWitnessProof,
@@ -125,6 +125,60 @@ describe("Witness Implementation Tests", async () => {
     expect(resolved.meta?.witness?.threshold).toBe(2);
     expect(updatedDID.log).toHaveLength(2);
     expect(resolved.meta?.witness?.witnesses).toHaveLength(2);
+  });
+
+  test("Resolve DID rejects duplicate witness IDs in witness parameters", async () => {
+    const noWitnessDID = await createDID({
+      domain: 'example.com',
+      signer: createTestSigner(authKey),
+      updateKeys: [authKey.publicKeyMultibase!],
+      verificationMethods: [authKey],
+      verifier: testImplementation
+    });
+
+    const duplicateWitnessId = `did:key:${witness1.publicKeyMultibase}`;
+    const newAuthKey = await generateTestVerificationMethod();
+
+    const updatedDID = await updateDID({
+      log: noWitnessDID.log,
+      signer: createTestSigner(authKey),
+      updateKeys: [newAuthKey.publicKeyMultibase!],
+      verificationMethods: [newAuthKey],
+      verifier: testImplementation
+    });
+
+    const duplicateWitnessEntry = JSON.parse(JSON.stringify(updatedDID.log[1]));
+    duplicateWitnessEntry.parameters.witness = {
+      threshold: 2,
+      witnesses: [
+        { id: duplicateWitnessId },
+        { id: duplicateWitnessId }
+      ]
+    };
+
+    delete duplicateWitnessEntry.proof;
+    const logEntryHash = await deriveHash({
+      ...duplicateWitnessEntry,
+      versionId: updatedDID.log[0].versionId,
+    });
+    duplicateWitnessEntry.versionId = `2-${logEntryHash}`;
+
+    const signer = createTestSigner(authKey);
+    const proofTemplate: DataIntegrityProofTemplate = {
+      type: 'DataIntegrityProof',
+      cryptosuite: 'eddsa-jcs-2022',
+      verificationMethod: signer.getVerificationMethodId(),
+      created: duplicateWitnessEntry.versionTime,
+      proofPurpose: 'assertionMethod' as const,
+    };
+    const signedProof = await signer.sign({ document: duplicateWitnessEntry, proof: proofTemplate });
+    duplicateWitnessEntry.proof = [{ ...proofTemplate, proofValue: signedProof.proofValue }];
+
+    const tamperedLog = [updatedDID.log[0], duplicateWitnessEntry];
+
+    expect(resolveDIDFromLog(tamperedLog, {
+      verifier: testImplementation
+    })).rejects.toThrow(`Duplicate witness id: ${duplicateWitnessId}`);
   });
 
   test("API e2e: create, update, witness, and resolve with raw multibase updateKeys", async () => {
@@ -698,6 +752,58 @@ describe("Witness Implementation Tests", async () => {
     expect(resolved.meta.problemDetails!.type).toBe('https://w3id.org/security#INVALID_CONTROLLED_IDENTIFIER_DOCUMENT_ID');
     expect(resolved.meta.problemDetails!.title).toBe('The resolved DID is invalid.');
     expect(resolved.meta.problemDetails!.detail).toContain('Witness threshold not met');
+  });
+
+  test("Update DID rejects duplicate witness IDs", async () => {
+    const noWitnessDID = await createDID({
+      domain: 'example.com',
+      signer: createTestSigner(authKey),
+      updateKeys: [authKey.publicKeyMultibase!],
+      verificationMethods: [authKey],
+      verifier: testImplementation
+    });
+
+    const duplicateWitnessId = `did:key:${witness1.publicKeyMultibase}`;
+
+    expect(updateDID({
+      log: noWitnessDID.log,
+      signer: createTestSigner(authKey),
+      updateKeys: [authKey.publicKeyMultibase!],
+      verificationMethods: [authKey],
+      witness: {
+        threshold: 2,
+        witnesses: [
+          { id: duplicateWitnessId },
+          { id: duplicateWitnessId }
+        ]
+      },
+      verifier: testImplementation
+    })).rejects.toThrow(`Duplicate witness id: ${duplicateWitnessId}`);
+  });
+
+  test("Update DID normalizes empty witness list to inactive state", async () => {
+    const noWitnessDID = await createDID({
+      domain: 'example.com',
+      signer: createTestSigner(authKey),
+      updateKeys: [authKey.publicKeyMultibase!],
+      verificationMethods: [authKey],
+      verifier: testImplementation
+    });
+
+    const updatedDID = await updateDID({
+      log: noWitnessDID.log,
+      signer: createTestSigner(authKey),
+      updateKeys: [authKey.publicKeyMultibase!],
+      verificationMethods: [authKey],
+      witness: {
+        threshold: 2,
+        witnesses: []
+      },
+      verifier: testImplementation
+    });
+
+    expect(updatedDID.meta.witness).toEqual({});
+    expect(updatedDID.log[1].parameters.witness).toEqual({});
   });
 
   const createWitnessSigner = (verificationMethod: VerificationMethod) => {

--- a/test/witness.test.ts
+++ b/test/witness.test.ts
@@ -2,7 +2,13 @@ import { beforeAll, describe, expect, test } from "bun:test";
 import { createDID, resolveDIDFromLog, updateDID } from "../src/method";
 import type { DIDLog, VerificationMethod } from "../src/interfaces";
 import { generateTestVerificationMethod, createTestSigner, TestCryptoImplementation } from "./utils";
-import { createWitnessProof } from "../src/witness";
+import { parseDidKeyDid, parseDidKeyVerificationMethod } from "../src/utils";
+import {
+  countWitnessApprovals,
+  createWitnessProof,
+  signWitnessProofsForVersion,
+  signWitnessProofsForVersions,
+} from "../src/witness";
 
 describe("Witness Implementation Tests", async () => {
   let authKey: VerificationMethod;
@@ -159,7 +165,7 @@ describe("Witness Implementation Tests", async () => {
     
     const resolved = await resolveDIDFromLog(updatedDID.log, { 
       verifier: testImplementation,
-      witnessProofs: newWitnessProofs
+      witnessProofs: [...witnessProofs, ...newWitnessProofs]
     });
     expect(resolved.meta?.witness?.witnesses).toHaveLength(1);
     expect(resolved.meta?.witness?.threshold).toBe(1);
@@ -186,7 +192,19 @@ describe("Witness Implementation Tests", async () => {
       witnessProofs
     });
 
-    const resolved = await resolveDIDFromLog(updatedDID.log, { verifier: testImplementation });
+    const newVersionId = updatedDID.log[1].versionId;
+    const deactivationProofs = await Promise.all([
+      createWitnessProof(createWitnessSigner(witness1), newVersionId, witnessVerificationMethod(witness1)),
+      createWitnessProof(createWitnessSigner(witness2), newVersionId, witnessVerificationMethod(witness2)),
+    ]);
+
+    const resolved = await resolveDIDFromLog(updatedDID.log, {
+      verifier: testImplementation,
+      witnessProofs: [
+        ...witnessProofs,
+        { versionId: newVersionId, proof: deactivationProofs },
+      ]
+    });
     expect(resolved.meta.witness).toBeEmpty();
   });
 
@@ -235,7 +253,7 @@ describe("Witness Implementation Tests", async () => {
         proof: [
           {
             ...badProof,
-            proofPurpose: "authentication"
+            proofPurpose: "authentication" as const
           }
         ]
       }
@@ -246,7 +264,251 @@ describe("Witness Implementation Tests", async () => {
         witnessProofs,
         verifier: testImplementation
       })
-    ).rejects.toThrow("Invalid witness proof purpose");
+    ).rejects.toThrow(`Witness threshold not met for version ${initialDID.log[0].versionId}`);
+  });
+
+  test("parseDidKeyDid accepts a valid did:key DID", () => {
+    const did = `did:key:${witness1.publicKeyMultibase}`;
+
+    expect(parseDidKeyDid(did)).toEqual({
+      did,
+      keyMultibase: witness1.publicKeyMultibase!,
+    });
+  });
+
+  test("parseDidKeyDid rejects malformed DID input", () => {
+    expect(() => parseDidKeyDid(`did:key:${witness1.publicKeyMultibase}#fragment`)).toThrow(
+      "Malformed did:key DID"
+    );
+    expect(() => parseDidKeyDid("did:web:example.com")).toThrow("Malformed did:key DID");
+  });
+
+  test("parseDidKeyVerificationMethod accepts fragment and no-fragment forms", () => {
+    const withFragment = witnessVerificationMethod(witness1);
+    const withoutFragment = `did:key:${witness1.publicKeyMultibase}`;
+
+    expect(parseDidKeyVerificationMethod(withFragment)).toEqual({
+      did: withoutFragment,
+      fragment: witness1.publicKeyMultibase,
+      keyMultibase: witness1.publicKeyMultibase!,
+    });
+    expect(parseDidKeyVerificationMethod(withoutFragment)).toEqual({
+      did: withoutFragment,
+      fragment: undefined,
+      keyMultibase: witness1.publicKeyMultibase!,
+    });
+  });
+
+  test("parseDidKeyVerificationMethod rejects relative and non-did:key values", () => {
+    expect(() => parseDidKeyVerificationMethod(`#${witness1.publicKeyMultibase}`)).toThrow(
+      "did:key verificationMethod must be an absolute DID URL"
+    );
+    expect(() => parseDidKeyVerificationMethod("did:web:example.com#key-1")).toThrow(
+      "Malformed did:key verificationMethod"
+    );
+  });
+
+  test("signWitnessProofsForVersion signs for every configured witness", async () => {
+    const versionId = initialDID.log[0].versionId;
+    const created = "2026-05-22T12:00:00Z";
+    const result = await signWitnessProofsForVersion({
+      versionId,
+      witnesses: [
+        { id: `did:key:${witness1.publicKeyMultibase}` },
+        { id: `did:key:${witness2.publicKeyMultibase}` },
+      ],
+      witnessSignersByDid: {
+        [`did:key:${witness1.publicKeyMultibase}`]: createTestSigner(witness1),
+        [`did:key:${witness2.publicKeyMultibase}`]: createTestSigner(witness2),
+      },
+      created,
+    });
+
+    expect(result.versionId).toBe(versionId);
+    expect(result.proof).toHaveLength(2);
+    expect(result.proof[0].created).toBe(created);
+    expect(result.proof[1].created).toBe(created);
+    expect(result.proof.map((proof) => proof.proofPurpose)).toEqual([
+      "assertionMethod",
+      "assertionMethod",
+    ]);
+  });
+
+  test("signWitnessProofsForVersion rejects missing signer", async () => {
+    await expect(
+      signWitnessProofsForVersion({
+        versionId: initialDID.log[0].versionId,
+        witnesses: [
+          { id: `did:key:${witness1.publicKeyMultibase}` },
+          { id: `did:key:${witness2.publicKeyMultibase}` },
+        ],
+        witnessSignersByDid: {
+          [`did:key:${witness1.publicKeyMultibase}`]: createTestSigner(witness1),
+        },
+      })
+    ).rejects.toThrow(`Missing witness signer for did:key:${witness2.publicKeyMultibase}`);
+  });
+
+  test("signWitnessProofsForVersion rejects malformed signer verificationMethod", async () => {
+    await expect(
+      signWitnessProofsForVersion({
+        versionId: initialDID.log[0].versionId,
+        witnesses: [{ id: `did:key:${witness1.publicKeyMultibase}` }],
+        witnessSignersByDid: {
+          [`did:key:${witness1.publicKeyMultibase}`]: {
+            sign: async () => ({ proofValue: "zbad" }),
+            getVerificationMethodId: () => "#relative",
+          },
+        },
+      })
+    ).rejects.toThrow("did:key verificationMethod must be an absolute DID URL");
+  });
+
+  test("signWitnessProofsForVersions signs multiple versionIds", async () => {
+    const results = await signWitnessProofsForVersions(
+      [initialDID.log[0].versionId, "2-test-version"],
+      [{ id: `did:key:${witness1.publicKeyMultibase}` }],
+      {
+        [`did:key:${witness1.publicKeyMultibase}`]: createTestSigner(witness1),
+      },
+      "2026-05-22T12:00:00Z"
+    );
+
+    expect(results).toHaveLength(2);
+    expect(results.map((result) => result.versionId)).toEqual([
+      initialDID.log[0].versionId,
+      "2-test-version",
+    ]);
+    expect(results[0].proof).toHaveLength(1);
+    expect(results[1].proof).toHaveLength(1);
+  });
+
+  test("countWitnessApprovals uses exact did:key DID matching", async () => {
+    const proofs = [
+      await createWitnessProof(
+        createWitnessSigner(witness1),
+        initialDID.log[0].versionId,
+        witnessVerificationMethod(witness1)
+      ),
+    ];
+
+    expect(
+      countWitnessApprovals(proofs, [{ id: `did:key:${witness1.publicKeyMultibase}` }])
+    ).toBe(1);
+    expect(
+      countWitnessApprovals(proofs, [{ id: `did:key:${witness2.publicKeyMultibase}` }])
+    ).toBe(0);
+  });
+
+  test("Resolve requires witness threshold for each required entry", async () => {
+    const witnessDid = `did:key:${witness1.publicKeyMultibase}`;
+    const didWithWitness = await createDID({
+      domain: 'example.com',
+      signer: createTestSigner(authKey),
+      updateKeys: [authKey.publicKeyMultibase!],
+      verificationMethods: [authKey],
+      witness: {
+        threshold: 1,
+        witnesses: [{ id: witnessDid }],
+      },
+      verifier: testImplementation,
+    });
+
+    const updatedDid = await updateDID({
+      log: didWithWitness.log,
+      signer: createTestSigner(authKey),
+      updateKeys: [authKey.publicKeyMultibase!],
+      verificationMethods: [authKey],
+      verifier: testImplementation,
+      witnessProofs: [{
+        versionId: didWithWitness.log[0].versionId,
+        proof: [await createWitnessProof(createWitnessSigner(witness1), didWithWitness.log[0].versionId, witnessVerificationMethod(witness1))],
+      }],
+    });
+
+    await expect(
+      resolveDIDFromLog(updatedDid.log, {
+        verifier: testImplementation,
+        witnessProofs: [{
+          versionId: updatedDid.log[1].versionId,
+          proof: [await createWitnessProof(createWitnessSigner(witness1), updatedDid.log[1].versionId, witnessVerificationMethod(witness1))],
+        }],
+      })
+    ).rejects.toThrow(`Witness threshold not met for version ${didWithWitness.log[0].versionId}`);
+  });
+
+  test("Resolve accepts later proof for earlier required entry", async () => {
+    const witnessDid = `did:key:${witness1.publicKeyMultibase}`;
+    const didWithWitness = await createDID({
+      domain: 'example.com',
+      signer: createTestSigner(authKey),
+      updateKeys: [authKey.publicKeyMultibase!],
+      verificationMethods: [authKey],
+      witness: {
+        threshold: 1,
+        witnesses: [{ id: witnessDid }],
+      },
+      verifier: testImplementation,
+    });
+
+    const updatedDid = await updateDID({
+      log: didWithWitness.log,
+      signer: createTestSigner(authKey),
+      updateKeys: [authKey.publicKeyMultibase!],
+      verificationMethods: [authKey],
+      verifier: testImplementation,
+      witnessProofs: [{
+        versionId: didWithWitness.log[0].versionId,
+        proof: [await createWitnessProof(createWitnessSigner(witness1), didWithWitness.log[0].versionId, witnessVerificationMethod(witness1))],
+      }],
+    });
+
+    const resolved = await resolveDIDFromLog(updatedDid.log, {
+      verifier: testImplementation,
+      witnessProofs: [{
+        versionId: updatedDid.log[1].versionId,
+        proof: [
+          // Published in version 2 while signing version 1 (later publication for earlier target).
+          await createWitnessProof(createWitnessSigner(witness1), didWithWitness.log[0].versionId, witnessVerificationMethod(witness1)),
+          // Also satisfy the version 2 target check.
+          await createWitnessProof(createWitnessSigner(witness1), updatedDid.log[1].versionId, witnessVerificationMethod(witness1)),
+        ],
+      }],
+    });
+
+    expect(resolved.did).toBe(updatedDid.did);
+  });
+
+  test("Resolve ignores invalid witness proof if enough valid proofs remain", async () => {
+    const witnessDid1 = `did:key:${witness1.publicKeyMultibase}`;
+    const witnessDid2 = `did:key:${witness2.publicKeyMultibase}`;
+    const didWithWitness = await createDID({
+      domain: 'example.com',
+      signer: createTestSigner(authKey),
+      updateKeys: [authKey.publicKeyMultibase!],
+      verificationMethods: [authKey],
+      witness: {
+        threshold: 1,
+        witnesses: [{ id: witnessDid1 }, { id: witnessDid2 }],
+      },
+      verifier: testImplementation,
+    });
+
+    const resolved = await resolveDIDFromLog(didWithWitness.log, {
+      verifier: testImplementation,
+      witnessProofs: [{
+        versionId: didWithWitness.log[0].versionId,
+        proof: [
+          {
+            ...(await createWitnessProof(createWitnessSigner(witness1), didWithWitness.log[0].versionId, witnessVerificationMethod(witness1))),
+            proofValue: 'zinvalid',
+          },
+          await createWitnessProof(createWitnessSigner(witness2), didWithWitness.log[0].versionId, witnessVerificationMethod(witness2)),
+        ],
+      }],
+    });
+
+    expect(resolved.did).toBe(didWithWitness.did);
   });
 
   const createWitnessSigner = (verificationMethod: VerificationMethod) => {

--- a/test/witness.test.ts
+++ b/test/witness.test.ts
@@ -1,13 +1,14 @@
 import { beforeAll, describe, expect, test } from "bun:test";
 import { createDID, resolveDIDFromLog, updateDID } from "../src/method";
+import { DidResolutionError } from "../src/interfaces";
 import type { DIDLog, VerificationMethod } from "../src/interfaces";
 import { generateTestVerificationMethod, createTestSigner, TestCryptoImplementation } from "./utils";
 import { parseDidKeyDid, parseDidKeyVerificationMethod } from "../src/utils";
 import {
   countWitnessApprovals,
   createWitnessProof,
-  signWitnessProofsForVersion,
-  signWitnessProofsForVersions,
+  signWitnessProofEntry,
+  signWitnessProofEntries,
 } from "../src/witness";
 
 describe("Witness Implementation Tests", async () => {
@@ -124,6 +125,124 @@ describe("Witness Implementation Tests", async () => {
     expect(resolved.meta?.witness?.threshold).toBe(2);
     expect(updatedDID.log).toHaveLength(2);
     expect(resolved.meta?.witness?.witnesses).toHaveLength(2);
+  });
+
+  test("API e2e: create, update, witness, and resolve with raw multibase updateKeys", async () => {
+    const authKey2 = await generateTestVerificationMethod();
+
+    const created = await createDID({
+      domain: 'example.com',
+      signer: createTestSigner(authKey),
+      updateKeys: [authKey.publicKeyMultibase!],
+      verificationMethods: [authKey],
+      witness: {
+        threshold: 1,
+        witnesses: [{ id: `did:key:${witness1.publicKeyMultibase}` }],
+      },
+      verifier: testImplementation,
+    });
+
+    const version1Proof = await createWitnessProof(
+      createWitnessSigner(witness1),
+      created.log[0].versionId,
+      witnessVerificationMethod(witness1)
+    );
+
+    const updated = await updateDID({
+      log: created.log,
+      signer: createTestSigner(authKey),
+      updateKeys: [authKey2.publicKeyMultibase!],
+      verificationMethods: [authKey2],
+      verifier: testImplementation,
+      witnessProofs: [{
+        versionId: created.log[0].versionId,
+        proof: [version1Proof],
+      }],
+    });
+
+    const version2Proof = await createWitnessProof(
+      createWitnessSigner(witness1),
+      updated.log[1].versionId,
+      witnessVerificationMethod(witness1)
+    );
+
+    const resolved = await resolveDIDFromLog(updated.log, {
+      verifier: testImplementation,
+      witnessProofs: [
+        {
+          versionId: created.log[0].versionId,
+          proof: [version1Proof],
+        },
+        {
+          versionId: updated.log[1].versionId,
+          proof: [version2Proof],
+        },
+      ],
+    });
+
+    expect(resolved.did).toBe(updated.did);
+    expect(resolved.meta?.updateKeys).toEqual([authKey2.publicKeyMultibase!]);
+  });
+
+  test("API e2e: rejects did:key-formatted updateKeys in update flow", async () => {
+    const authKey2 = await generateTestVerificationMethod();
+    const authKey3 = await generateTestVerificationMethod();
+
+    const created = await createDID({
+      domain: 'example.com',
+      signer: createTestSigner(authKey),
+      updateKeys: [authKey.publicKeyMultibase!],
+      verificationMethods: [authKey],
+      witness: {
+        threshold: 1,
+        witnesses: [{ id: `did:key:${witness1.publicKeyMultibase}` }],
+      },
+      verifier: testImplementation,
+    });
+
+    const version1Proof = await createWitnessProof(
+      createWitnessSigner(witness1),
+      created.log[0].versionId,
+      witnessVerificationMethod(witness1)
+    );
+
+    const firstUpdate = await updateDID({
+      log: created.log,
+      signer: createTestSigner(authKey),
+      updateKeys: [`did:key:${authKey2.publicKeyMultibase}`],
+      verificationMethods: [authKey2],
+      verifier: testImplementation,
+      witnessProofs: [{
+        versionId: created.log[0].versionId,
+        proof: [version1Proof],
+      }],
+    });
+
+    const version2Proof = await createWitnessProof(
+      createWitnessSigner(witness1),
+      firstUpdate.log[1].versionId,
+      witnessVerificationMethod(witness1)
+    );
+
+    await expect(
+      updateDID({
+        log: firstUpdate.log,
+        signer: createTestSigner(authKey2),
+        updateKeys: [authKey3.publicKeyMultibase!],
+        verificationMethods: [authKey3],
+        verifier: testImplementation,
+        witnessProofs: [
+          {
+            versionId: created.log[0].versionId,
+            proof: [version1Proof],
+          },
+          {
+            versionId: firstUpdate.log[1].versionId,
+            proof: [version2Proof],
+          },
+        ],
+      })
+    ).rejects.toThrow("is not authorized to update.");
   });
 
   test("Replace witness list with new witnesses", async () => {
@@ -308,10 +427,10 @@ describe("Witness Implementation Tests", async () => {
     );
   });
 
-  test("signWitnessProofsForVersion signs for every configured witness", async () => {
+  test("signWitnessProofEntry signs for every configured witness", async () => {
     const versionId = initialDID.log[0].versionId;
     const created = "2026-05-22T12:00:00Z";
-    const result = await signWitnessProofsForVersion({
+    const result = await signWitnessProofEntry({
       versionId,
       witnesses: [
         { id: `did:key:${witness1.publicKeyMultibase}` },
@@ -334,9 +453,9 @@ describe("Witness Implementation Tests", async () => {
     ]);
   });
 
-  test("signWitnessProofsForVersion rejects missing signer", async () => {
+  test("signWitnessProofEntry rejects missing signer", async () => {
     await expect(
-      signWitnessProofsForVersion({
+      signWitnessProofEntry({
         versionId: initialDID.log[0].versionId,
         witnesses: [
           { id: `did:key:${witness1.publicKeyMultibase}` },
@@ -349,9 +468,9 @@ describe("Witness Implementation Tests", async () => {
     ).rejects.toThrow(`Missing witness signer for did:key:${witness2.publicKeyMultibase}`);
   });
 
-  test("signWitnessProofsForVersion rejects malformed signer verificationMethod", async () => {
+  test("signWitnessProofEntry rejects malformed signer verificationMethod", async () => {
     await expect(
-      signWitnessProofsForVersion({
+      signWitnessProofEntry({
         versionId: initialDID.log[0].versionId,
         witnesses: [{ id: `did:key:${witness1.publicKeyMultibase}` }],
         witnessSignersByDid: {
@@ -364,8 +483,8 @@ describe("Witness Implementation Tests", async () => {
     ).rejects.toThrow("did:key verificationMethod must be an absolute DID URL");
   });
 
-  test("signWitnessProofsForVersions signs multiple versionIds", async () => {
-    const results = await signWitnessProofsForVersions(
+  test("signWitnessProofEntries signs multiple versionIds", async () => {
+    const results = await signWitnessProofEntries(
       [initialDID.log[0].versionId, "2-test-version"],
       [{ id: `did:key:${witness1.publicKeyMultibase}` }],
       {
@@ -509,6 +628,48 @@ describe("Witness Implementation Tests", async () => {
     });
 
     expect(resolved.did).toBe(didWithWitness.did);
+  });
+
+  test("Resolve maps witness threshold failure to invalidDid metadata for partial results", async () => {
+    const witnessDid = `did:key:${witness1.publicKeyMultibase}`;
+    const didWithWitness = await createDID({
+      domain: 'example.com',
+      signer: createTestSigner(authKey),
+      updateKeys: [authKey.publicKeyMultibase!],
+      verificationMethods: [authKey],
+      witness: {
+        threshold: 1,
+        witnesses: [{ id: witnessDid }],
+      },
+      verifier: testImplementation,
+    });
+
+    const updatedDid = await updateDID({
+      log: didWithWitness.log,
+      signer: createTestSigner(authKey),
+      updateKeys: [authKey.publicKeyMultibase!],
+      verificationMethods: [authKey],
+      verifier: testImplementation,
+      witnessProofs: [{
+        versionId: didWithWitness.log[0].versionId,
+        proof: [await createWitnessProof(createWitnessSigner(witness1), didWithWitness.log[0].versionId, witnessVerificationMethod(witness1))],
+      }],
+    });
+
+    const resolved = await resolveDIDFromLog(updatedDid.log, {
+      versionNumber: 1,
+      verifier: testImplementation,
+      witnessProofs: [{
+        versionId: didWithWitness.log[0].versionId,
+        proof: [await createWitnessProof(createWitnessSigner(witness1), didWithWitness.log[0].versionId, witnessVerificationMethod(witness1))],
+      }],
+    });
+
+    expect(resolved.meta.error).toBe(DidResolutionError.InvalidDid);
+    expect(resolved.meta.problemDetails).toBeDefined();
+    expect(resolved.meta.problemDetails!.type).toBe('https://w3id.org/security#INVALID_CONTROLLED_IDENTIFIER_DOCUMENT_ID');
+    expect(resolved.meta.problemDetails!.title).toBe('The resolved DID is invalid.');
+    expect(resolved.meta.problemDetails!.detail).toContain('Witness threshold not met');
   });
 
   const createWitnessSigner = (verificationMethod: VerificationMethod) => {

--- a/test/witness.test.ts
+++ b/test/witness.test.ts
@@ -1,7 +1,7 @@
 import { beforeAll, describe, expect, test } from "bun:test";
 import { createDID, resolveDIDFromLog, updateDID } from "../src/method";
 import { DidResolutionError } from "../src/interfaces";
-import type { DIDLog, VerificationMethod } from "../src/interfaces";
+import type { DIDLog, Signer, VerificationMethod } from "../src/interfaces";
 import { generateTestVerificationMethod, createTestSigner, TestCryptoImplementation } from "./utils";
 import { parseDidKeyDid, parseDidKeyVerificationMethod } from "../src/utils";
 import {
@@ -243,6 +243,34 @@ describe("Witness Implementation Tests", async () => {
         ],
       })
     ).rejects.toThrow("is not authorized to update.");
+  });
+
+  test("API e2e: rejects did:webvh verificationMethod in DID log entry proof", async () => {
+    const authKey2 = await generateTestVerificationMethod();
+
+    const created = await createDID({
+      domain: 'example.com',
+      signer: createTestSigner(authKey),
+      updateKeys: [authKey.publicKeyMultibase!],
+      verificationMethods: [authKey],
+      verifier: testImplementation,
+    });
+
+    const baseSigner = createTestSigner(authKey);
+    const nonCompliantSigner: Signer = {
+      sign: (input) => baseSigner.sign(input),
+      getVerificationMethodId: () => `${created.did}#controller-key`,
+    };
+
+    await expect(
+      updateDID({
+        log: created.log,
+        signer: nonCompliantSigner,
+        updateKeys: [authKey2.publicKeyMultibase!],
+        verificationMethods: [authKey2],
+        verifier: testImplementation,
+      })
+    ).rejects.toThrow("Unsupported verification method for DID log entry authorization");
   });
 
   test("Replace witness list with new witnesses", async () => {


### PR DESCRIPTION
Implemented API endpoints (wired to CLI) for witness interactions & hardened did:key handling

### New API methods:

* `createWitnessProof` (create and sign one witness proof for a specific `versionId`)
* `signWitnessProofEntry` (sign one witness proof entry for a specific `versionId`)
* `signWitnessProofEntries` (batch signing of multiple entries)

### Witness threshold

Implemented witness thresholding, accepting failing witnesses per spec

### did:key

`did:key` handling now has strict parser helpers for DID-form versus verification method form in `utils.ts` to match spec requirements. Inspired by did:key handling in rust and python codebases.

* `parseDidKeyDid`
* `parseDidKeyVerificationMethod`

Witness identity now uses exact parsed DID equality (not prefix matching), each witness DID parsed strictly when presented

### did:webvh

Removed `did:webvh` as shortcut witness authorisation path for DID log entry proofs to align with strict spec requirement for key-based (`did:key`) verificationMethod

### Error types

Error types now have strict enum for supported error types with spec-aligned reporting in witness paths

### Other

`fastResolve` is now a user-accessible option through the API, defaulting to `false` for spec compliance

### Test coverage

Tests for e2e witness lifecycle coverage