### PR TITLE
fix(core): type safety

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -24,7 +24,7 @@
         "useImportType": "error"
       },
       "suspicious": {
-        "noExplicitAny": "off",
+        "noExplicitAny": "error",
         "noImplicitAnyLet": "error"
       }
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,12 +5,14 @@ import { dirname } from 'node:path';
 import { sign as ed25519Sign, verify as ed25519Verify, generateKeyPair } from '@stablelib/ed25519';
 import type {
   DIDLog,
+  ResolutionOptions,
   ServiceEndpoint,
   Signer,
   SigningInput,
   SigningOutput,
   VerificationMethod,
   Verifier,
+  WitnessProofFileEntry,
 } from './interfaces';
 import { createDID, deactivateDID, resolveDIDFromLog, updateDID } from './method';
 import {
@@ -78,6 +80,23 @@ function showHelp() {
   console.log(usage);
 }
 
+function requirePublicKeyMultibase(value: { publicKeyMultibase?: string }): string {
+  if (!value.publicKeyMultibase) throw new Error('Expected verification method to include publicKeyMultibase');
+  return value.publicKeyMultibase;
+}
+
+function parseExplicitPaths(pathsOption: string | string[] | undefined): string[] | undefined {
+  if (!pathsOption) return undefined;
+
+  const rawParts = Array.isArray(pathsOption) ? pathsOption : [pathsOption];
+  const paths = rawParts
+    .flatMap((part) => part.split(':'))
+    .map((part) => part.trim())
+    .filter(Boolean);
+
+  return paths.length > 0 ? paths : undefined;
+}
+
 async function generateVerificationMethod(
   purpose:
     | 'authentication'
@@ -107,7 +126,8 @@ class CustomCryptoImplementation implements Signer, Verifier {
     if (!this.verificationMethod) {
       throw new Error('Verification method not set');
     }
-    return `did:key:${this.verificationMethod.publicKeyMultibase}#${this.verificationMethod.publicKeyMultibase}`;
+    const publicKeyMultibase = requirePublicKeyMultibase(this.verificationMethod);
+    return `did:key:${publicKeyMultibase}#${publicKeyMultibase}`;
   }
 
   async sign(input: SigningInput): Promise<SigningOutput> {
@@ -121,7 +141,11 @@ class CustomCryptoImplementation implements Signer, Verifier {
     const dataHash = await createHash(canonicalizeStrict(document));
     const proofHash = await createHash(canonicalizeStrict(proof));
     const message = concatBuffers(proofHash, dataHash);
-    const secretKey = multibaseDecode(this.verificationMethod.secretKeyMultibase).bytes.slice(2);
+    const secretKeyMultibase = this.verificationMethod.secretKeyMultibase;
+    if (!secretKeyMultibase) {
+      throw new Error('Verification method secretKeyMultibase not set');
+    }
+    const secretKey = multibaseDecode(secretKeyMultibase).bytes.slice(2);
     const signature = ed25519Sign(secretKey, message);
     return {
       proofValue: multibaseEncode(signature, MultibaseEncoding.BASE58_BTC),
@@ -145,7 +169,7 @@ export async function handleCreate(args: string[]) {
 
   // Extract optional explicit paths (colon-delimited) from CLI args
   // If provided, these override any paths parsed from address input
-  const explicitPaths = options.paths as string[] | undefined;
+  const explicitPaths = parseExplicitPaths(options.paths);
 
   const output = options.output as string | undefined;
   const portable = options.portable !== undefined;
@@ -178,12 +202,13 @@ export async function handleCreate(args: string[]) {
     };
 
     // Use new address parameter for strict parsing and encoding
+    const publicKeyMultibase = requirePublicKeyMultibase(authKey);
     const { did, doc, meta, log } = await createDID({
       address: addressInput,
       paths: explicitPaths,
       signer: crypto,
       verifier: crypto,
-      updateKeys: [authKey.publicKeyMultibase],
+      updateKeys: [publicKeyMultibase],
       verificationMethods: [publicAuthKey],
       portable,
       witness: witnesses?.length
@@ -213,7 +238,7 @@ export async function handleCreate(args: string[]) {
       await writeVerificationMethodToEnv({
         ...authKey,
         controller: did,
-        id: `${did}#${authKey.publicKeyMultibase?.slice(-8)}`,
+        id: `${did}#${publicKeyMultibase.slice(-8)}`,
       });
       console.log(`DID verification method saved to env`);
     } else {
@@ -248,7 +273,7 @@ export async function handleResolve(args: string[]) {
       log = await fetchLogFromIdentifier(didIdentifier);
     }
 
-    const resolutionOptions: any = {};
+    const resolutionOptions: ResolutionOptions & { witnessProofs?: WitnessProofFileEntry[]; verifier?: Verifier } = {};
     if (witnessFile) {
       const witnessProofs = JSON.parse(fs.readFileSync(witnessFile, 'utf8'));
       resolutionOptions.witnessProofs = witnessProofs;
@@ -297,16 +322,28 @@ export async function handleUpdate(args: string[]) {
     // console.log('Current meta:', meta);
 
     // Get the verification method from environment
-    const envVMs = JSON.parse(bufferToString(createBuffer(process.env.DID_VERIFICATION_METHODS || 'W10=', 'base64')));
+    const envVMs = JSON.parse(
+      bufferToString(createBuffer(process.env.DID_VERIFICATION_METHODS || 'W10=', 'base64'))
+    ) as VerificationMethod[];
 
-    let vm = envVMs.find((vm: any) => vm.controller === did);
-
-    if (!vm) {
-      // Try to find VM by matching public key with current update keys
-      vm = envVMs.find((vm: any) => meta.updateKeys.includes(vm.publicKeyMultibase));
+    let vm: VerificationMethod | undefined;
+    if (updateKey) {
+      vm = envVMs.find((candidateVm) => candidateVm.publicKeyMultibase === updateKey);
+      if (!vm) {
+        throw new Error(`No verification method found for update key: ${updateKey}`);
+      }
+    } else {
+      vm = envVMs.find((candidateVm) => candidateVm.controller === did);
     }
 
-    if (!vm && envVMs.length > 0) {
+    if (!vm && !updateKey) {
+      // Try to find VM by matching public key with current update keys
+      vm = envVMs.find((candidateVm) =>
+        candidateVm.publicKeyMultibase ? meta.updateKeys.includes(candidateVm.publicKeyMultibase) : false
+      );
+    }
+
+    if (!vm && !updateKey && envVMs.length > 0) {
       // Fall back to first available VM with warning
       console.warn('Warning: No matching verification method found for DID or update keys. Using first available VM.');
       vm = envVMs[0];
@@ -321,12 +358,14 @@ export async function handleUpdate(args: string[]) {
       throw new Error('Verification method missing publicKeyMultibase');
     }
 
+    const vmPublicKeyMultibase = requirePublicKeyMultibase(vm);
+
     // Create verification methods array
     const verificationMethods: VerificationMethod[] = [];
 
     // If we're adding VMs, create a VM for each type
     if (addVm && addVm.length > 0) {
-      const vmId = `${did}#${vm.publicKeyMultibase?.slice(-8)}`;
+      const vmId = `${did}#${vmPublicKeyMultibase.slice(-8)}`;
 
       // Add a verification method for each type
       for (const vmType of addVm) {
@@ -334,7 +373,7 @@ export async function handleUpdate(args: string[]) {
           id: vmId,
           type: 'Multikey',
           controller: did,
-          publicKeyMultibase: vm.publicKeyMultibase,
+          publicKeyMultibase: vmPublicKeyMultibase,
           purpose: vmType as VerificationMethodType,
         };
         verificationMethods.push(newVM);
@@ -342,10 +381,10 @@ export async function handleUpdate(args: string[]) {
     } else {
       // For non-VM updates (services, alsoKnownAs), still need a VM with purpose
       verificationMethods.push({
-        id: `${did}#${vm.publicKeyMultibase?.slice(-8)}`,
+        id: `${did}#${vmPublicKeyMultibase.slice(-8)}`,
         type: 'Multikey',
         controller: did,
-        publicKeyMultibase: vm.publicKeyMultibase,
+        publicKeyMultibase: vmPublicKeyMultibase,
         purpose: 'assertionMethod',
       });
     }
@@ -355,7 +394,7 @@ export async function handleUpdate(args: string[]) {
       log,
       signer: crypto,
       verifier: crypto,
-      updateKeys: [vm.publicKeyMultibase],
+      updateKeys: [vmPublicKeyMultibase],
       verificationMethods,
       witness: witnesses?.length
         ? {
@@ -403,13 +442,13 @@ export async function handleDeactivate(args: string[]) {
     }
 
     // Parse the VM from env
-    const vms = JSON.parse(bufferToString(createBuffer(vmMatch[1], 'base64')));
+    const vms = JSON.parse(bufferToString(createBuffer(vmMatch[1], 'base64'))) as VerificationMethod[];
     if (!vms || vms.length === 0) {
       throw new Error('No verification method found in environment');
     }
 
     // Find VM that matches the current update key
-    let vm = vms.find((v: any) => v.publicKeyMultibase === meta.updateKeys[0]);
+    let vm = vms.find((candidateVm) => candidateVm.publicKeyMultibase === meta.updateKeys[0]);
 
     if (!vm) {
       // If no matching VM found, use the first one and warn

--- a/src/cryptography.ts
+++ b/src/cryptography.ts
@@ -1,5 +1,7 @@
 import type {
+  DataIntegrityProof,
   DataIntegrityProofTemplate,
+  SignableDocument,
   Signer,
   SignerOptions,
   SigningInput,
@@ -92,16 +94,20 @@ export abstract class AbstractCrypto implements Signer, Verifier {
  * @param verificationMethodId - The verification method ID to use in proofs
  * @returns A function that signs a document and returns the document with proof
  */
-export const createDocumentSigner = (signer: Signer, verificationMethodId: string) => {
-  return async (doc: any) => {
+export const createDocumentSigner = <TDocument extends SignableDocument>(
+  signer: Signer<TDocument>,
+  verificationMethodId: string
+) => {
+  return async (doc: TDocument): Promise<TDocument & { proof: DataIntegrityProof }> => {
     try {
       const proof = createProof(verificationMethodId);
       const result = await signer.sign({ document: doc, proof });
 
       return { ...doc, proof: { ...proof, proofValue: result.proofValue } };
-    } catch (e: any) {
+    } catch (e) {
       console.error(e);
-      throw new Error(`Document signing failure: ${e.message || e}`);
+      const message = e instanceof Error ? e.message : String(e);
+      throw new Error(`Document signing failure: ${message}`);
     }
   };
 };
@@ -112,20 +118,21 @@ export const createDocumentSigner = (signer: Signer, verificationMethodId: strin
 export const createSigner = (vm: VerificationMethod, useStatic: boolean = true) => {
   console.warn('createSigner is deprecated. Use createDocumentSigner with your own Signer implementation instead.');
 
-  return async (doc: any) => {
+  return async (doc: SignableDocument) => {
     try {
       const verificationMethodId = useStatic
         ? `did:key:${vm.publicKeyMultibase}#${vm.publicKeyMultibase}`
         : vm.id || '';
 
-      const proof = createProof(verificationMethodId);
+      const proof: DataIntegrityProofTemplate = createProof(verificationMethodId);
 
       // This is a placeholder for backward compatibility
       // Users should implement their own signing logic
       throw new Error('createSigner is deprecated. Implement your own Signer and use createDocumentSigner instead.');
-    } catch (e: any) {
+    } catch (e) {
       console.error(e);
-      throw new Error(`Document signing failure: ${e.message || e}`);
+      const message = e instanceof Error ? e.message : String(e);
+      throw new Error(`Document signing failure: ${message}`);
     }
   };
 };

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -21,8 +21,10 @@ export interface DataIntegrityProofTemplate {
   proofPurpose: DataIntegrityProofPurpose;
 }
 
-export interface SigningInput {
-  document: unknown;
+export type SignableDocument = DIDLogEntry | DIDDoc | Pick<DIDLogEntry, 'versionId'>;
+
+export interface SigningInput<TDocument = SignableDocument> {
+  document: TDocument;
   proof: DataIntegrityProofTemplate;
 }
 
@@ -30,8 +32,8 @@ export interface SigningOutput {
   proofValue: string;
 }
 
-export interface Signer {
-  sign(input: SigningInput): Promise<SigningOutput>;
+export interface Signer<TDocument = SignableDocument> {
+  sign(input: SigningInput<TDocument>): Promise<SigningOutput>;
   getVerificationMethodId(): string;
 }
 
@@ -106,7 +108,7 @@ export interface VerificationMethod {
   publicKeyMultibase?: string;
   secretKeyMultibase?: string;
   purpose?: DataIntegrityProofPurpose;
-  publicKeyJwk?: any;
+  publicKeyJwk?: JsonObject;
   use?: string;
 }
 
@@ -174,7 +176,7 @@ export type DIDLog = DIDLogEntry[];
 export interface ServiceEndpoint {
   id?: string;
   type: string | string[];
-  serviceEndpoint?: string | string[] | any;
+  serviceEndpoint?: string | string[] | JsonValue;
   [key: string]: unknown;
 }
 

--- a/src/method.ts
+++ b/src/method.ts
@@ -4,6 +4,7 @@ import type {
   DeactivateDIDInterface,
   DIDLog,
   ResolutionOptions,
+  ServiceEndpoint,
   UpdateDIDInterface,
   UpdateDIDResult,
   WitnessProofFileEntry,
@@ -28,9 +29,12 @@ function getWebvhVersionFromLog(log: DIDLog): string {
   return LATEST_VERSION;
 }
 
-function getWebvhVersionFromOptions(options: any): string {
-  if (options?.method) {
-    return getWebvhVersionFromMethod(options.method);
+function getWebvhVersionFromOptions(options?: unknown): string {
+  if (typeof options === 'object' && options && 'method' in options) {
+    const method = (options as { method?: unknown }).method;
+    if (typeof method === 'string') {
+      return getWebvhVersionFromMethod(method);
+    }
   }
   return LATEST_VERSION;
 }
@@ -80,7 +84,7 @@ export const resolveDID = async (
     maybeWriteTestLog(result.did, log);
 
     return { ...result, controlled };
-  } catch (e: any) {
+  } catch (e) {
     let errorType: DidResolutionError = DidResolutionError.InvalidDid;
     const message = e instanceof Error ? e.message : String(e);
     if (/not found/i.test(message) || /404/.test(message)) {
@@ -141,7 +145,7 @@ export const resolveDIDFromLog = async (
  * @returns The updated DID, resolved document, and DID log.
  */
 export const updateDID = async (
-  options: UpdateDIDInterface & { services?: any[]; domain?: string; updated?: string }
+  options: UpdateDIDInterface & { services?: ServiceEndpoint[]; domain?: string; updated?: string }
 ): Promise<UpdateDIDResult> => {
   const version = options.log ? getWebvhVersionFromLog(options.log) : getWebvhVersionFromOptions(options);
   const result = version === '0.5' ? await v0_5.updateDID(options) : await v1.updateDID(options);

--- a/src/method_versions/method.v0.5.ts
+++ b/src/method_versions/method.v0.5.ts
@@ -4,10 +4,12 @@ import type {
   CreateDIDInterface,
   DataIntegrityProof,
   DeactivateDIDInterface,
+  DIDDoc,
   DIDLog,
   DIDLogEntry,
   DIDResolutionMeta,
   ResolutionOptions,
+  ServiceEndpoint,
   UpdateDIDInterface,
   WitnessProofFileEntry,
 } from '../interfaces';
@@ -36,7 +38,7 @@ const requireDidId = (id: string | undefined): string => {
 
 export const createDID = async (
   options: CreateDIDInterface
-): Promise<{ did: string; doc: any; meta: DIDResolutionMeta; log: DIDLog }> => {
+): Promise<{ did: string; doc: DIDDoc; meta: DIDResolutionMeta; log: DIDLog }> => {
   if (!options.updateKeys) {
     throw new Error('Update keys not supplied');
   }
@@ -146,7 +148,7 @@ export const createDID = async (
 export const resolveDIDFromLog = async (
   log: DIDLog,
   options: ResolutionOptions & { witnessProofs?: WitnessProofFileEntry[] } = {}
-): Promise<{ did: string; doc: any; meta: DIDResolutionMeta }> => {
+): Promise<{ did: string; doc: DIDDoc; meta: DIDResolutionMeta }> => {
   if (options.verificationMethod && (options.versionNumber || options.versionId)) {
     throw new Error('Cannot specify both verificationMethod and version number/id');
   }
@@ -155,7 +157,7 @@ export const resolveDIDFromLog = async (
   if (protocol !== PROTOCOL) {
     throw new Error(`'${protocol}' protocol unknown.`);
   }
-  let doc: any = {};
+  let doc: DIDDoc = {};
   let did = '';
   const meta: DIDResolutionMeta = {
     versionId: '',
@@ -174,9 +176,9 @@ export const resolveDIDFromLog = async (
   let host = '';
   let i = 0;
 
-  let resolvedDoc: any = null;
+  let resolvedDoc: DIDDoc | null = null;
   let resolvedMeta: DIDResolutionMeta | null = null;
-  let lastValidDoc: any = null;
+  let lastValidDoc: DIDDoc | null = null;
   let lastValidMeta: DIDResolutionMeta | null = null;
 
   try {
@@ -195,10 +197,10 @@ export const resolveDIDFromLog = async (
       if (version === '1') {
         meta.created = versionTime;
         newDoc = state;
-        host = newDoc.id.split(':').at(-1);
-        meta.scid = parameters.scid;
+        host = requireDidId(newDoc.id).split(':').at(-1) ?? '';
+        meta.scid = parameters.scid as string;
         meta.portable = parameters.portable ?? meta.portable;
-        meta.updateKeys = parameters.updateKeys;
+        meta.updateKeys = parameters.updateKeys as string[];
         meta.nextKeyHashes = parameters.nextKeyHashes || [];
         meta.prerotation = meta.nextKeyHashes.length > 0;
         meta.witness = parameters.witness || meta.witness;
@@ -233,13 +235,13 @@ export const resolveDIDFromLog = async (
         }
       } else {
         // version number > 1
-        const newHost = newDoc.id.split(':').at(-1);
+        const newHost = requireDidId(newDoc.id).split(':').at(-1) ?? '';
         if (!meta.portable && newHost !== host) {
           throw new Error('Cannot move DID: portability is disabled');
         } else if (newHost !== host) {
           host = newHost;
         }
-        const keys = meta.prerotation ? parameters.updateKeys : meta.updateKeys;
+        const keys = meta.prerotation ? (parameters.updateKeys as string[]) : meta.updateKeys;
         const verified = await documentStateIsValid(resolutionLog[i], keys, meta.witness, false, options.verifier);
         if (!verified) {
           throw new Error(`version ${meta.versionId} failed verification of the proof.`);
@@ -266,12 +268,17 @@ export const resolveDIDFromLog = async (
           meta.nextKeyHashes = [];
           meta.prerotation = false;
         }
+        const legacyParameters = parameters as typeof parameters & {
+          witnesses?: { id: string }[];
+          witnessThreshold?: string | number;
+        };
+
         if ('witness' in parameters) {
           meta.witness = parameters.witness;
-        } else if (parameters.witnesses) {
+        } else if (legacyParameters.witnesses) {
           meta.witness = {
-            witnesses: parameters.witnesses,
-            threshold: parameters.witnessThreshold || parameters.witnesses.length.toString(),
+            witnesses: legacyParameters.witnesses,
+            threshold: legacyParameters.witnessThreshold || legacyParameters.witnesses.length.toString(),
           };
         }
         if ('watchers' in parameters) {
@@ -280,13 +287,13 @@ export const resolveDIDFromLog = async (
       }
       // Optimized: Use efficient cloning instead of clone() function
       doc = deepClone(newDoc);
-      did = doc.id;
+      did = requireDidId(doc.id);
 
       // Add default services if they don't exist
       doc.service = Array.isArray(doc.service) ? doc.service : [];
       const baseUrl = getBaseUrl(did);
 
-      if (!doc.service.some((s: any) => s.id === '#files')) {
+      if (!doc.service.some((s: ServiceEndpoint) => s.id === '#files')) {
         doc.service.push({
           id: '#files',
           type: 'relativeRef',
@@ -294,7 +301,7 @@ export const resolveDIDFromLog = async (
         });
       }
 
-      if (!doc.service.some((s: any) => s.id === '#whois')) {
+      if (!doc.service.some((s: ServiceEndpoint) => s.id === '#whois')) {
         doc.service.push({
           '@context': 'https://identity.foundation/linked-vp/contexts/v1',
           id: '#whois',
@@ -375,12 +382,12 @@ export const resolveDIDFromLog = async (
     finalMeta.witness.threshold = finalMeta.witness.threshold?.toString() || '0';
   }
 
-  return { did: finalDoc.id, doc: finalDoc, meta: finalMeta };
+  return { did: requireDidId(finalDoc.id), doc: finalDoc, meta: finalMeta };
 };
 
 export const updateDID = async (
-  options: UpdateDIDInterface & { services?: any[]; domain?: string; updated?: string }
-): Promise<{ did: string; doc: any; meta: DIDResolutionMeta; log: DIDLog }> => {
+  options: UpdateDIDInterface & { services?: ServiceEndpoint[]; domain?: string; updated?: string }
+): Promise<{ did: string; doc: DIDDoc; meta: DIDResolutionMeta; log: DIDLog }> => {
   const log = options.log;
   const lastEntry = log[log.length - 1];
   const lastMeta = (await resolveDIDFromLog(log, { verifier: options.verifier, witnessProofs: options.witnessProofs }))
@@ -485,7 +492,7 @@ export const updateDID = async (
   const didId = requireDidId(prelimEntry.state.id);
 
   return {
-    did: didId,
+    did: requireDidId(prelimEntry.state.id),
     doc: prelimEntry.state,
     meta,
     log: [...log, prelimEntry],
@@ -494,7 +501,7 @@ export const updateDID = async (
 
 export const deactivateDID = async (
   options: DeactivateDIDInterface & { updateKeys?: string[] }
-): Promise<{ did: string; doc: any; meta: DIDResolutionMeta; log: DIDLog }> => {
+): Promise<{ did: string; doc: DIDDoc; meta: DIDResolutionMeta; log: DIDLog }> => {
   const log = options.log;
   const lastEntry = log[log.length - 1];
   const lastMeta = (await resolveDIDFromLog(log, { verifier: options.verifier })).meta;
@@ -549,7 +556,7 @@ export const deactivateDID = async (
   const didId = requireDidId(prelimEntry.state.id);
 
   return {
-    did: didId,
+    did: requireDidId(prelimEntry.state.id),
     doc: prelimEntry.state,
     meta,
     log: [...log, prelimEntry],

--- a/src/method_versions/method.v1.0.ts
+++ b/src/method_versions/method.v1.0.ts
@@ -5,10 +5,12 @@ import type {
   CreateDIDResult,
   DataIntegrityProof,
   DeactivateDIDInterface,
+  DIDDoc,
   DIDLog,
   DIDLogEntry,
   DIDResolutionMeta,
   ResolutionOptions,
+  ServiceEndpoint,
   UpdateDIDInterface,
   UpdateDIDResult,
   WitnessParameterResolution,
@@ -76,7 +78,7 @@ export const createDID = async (options: CreateDIDInterface): Promise<CreateDIDR
     return vm;
   });
 
-  let doc: any;
+  let doc: DIDDoc;
   if (options.didDocument) {
     validateCreateDidDocument(options.didDocument);
     doc = deepClone(options.didDocument);
@@ -169,7 +171,7 @@ export const createDID = async (options: CreateDIDInterface): Promise<CreateDIDR
 export const resolveDIDFromLog = async (
   log: DIDLog,
   options: ResolutionOptions & { witnessProofs?: WitnessProofFileEntry[]; fastResolve?: boolean } = {}
-): Promise<{ did: string; doc: any; meta: DIDResolutionMeta }> => {
+): Promise<{ did: string; doc: DIDDoc; meta: DIDResolutionMeta }> => {
   if (options.verificationMethod && (options.versionNumber || options.versionId)) {
     throw new Error('Cannot specify both verificationMethod and version number/id');
   }
@@ -179,9 +181,9 @@ export const resolveDIDFromLog = async (
     throw new Error(`'${protocol}' is not a supported method version.`);
   }
   let did = '';
-  let doc: any = null;
-  let resolvedDoc: any = null;
-  let lastValidDoc: any = null;
+  let doc: DIDDoc | null = null;
+  let resolvedDoc: DIDDoc | null = null;
+  let lastValidDoc: DIDDoc | null = null;
   const meta: DIDResolutionMeta = {
     versionId: '',
     created: '',
@@ -225,13 +227,13 @@ export const resolveDIDFromLog = async (
       if (version === '1') {
         meta.created = versionTime;
         newDoc = state;
-        host = newDoc.id.split(':').at(-1);
-        meta.scid = parameters.scid;
+        host = requireDidId(newDoc.id).split(':').at(-1) ?? '';
+        meta.scid = parameters.scid as string;
         if (options.scid && options.scid !== meta.scid) {
           throw new Error(`SCID in DID '${options.scid}' does not match SCID in log '${meta.scid}'`);
         }
         meta.portable = parameters.portable ?? meta.portable;
-        meta.updateKeys = parameters.updateKeys;
+        meta.updateKeys = parameters.updateKeys as string[];
         meta.nextKeyHashes = parameters.nextKeyHashes || [];
         meta.prerotation = meta.nextKeyHashes.length > 0;
         meta.witness = parameters.witness || meta.witness;
@@ -269,7 +271,7 @@ export const resolveDIDFromLog = async (
         }
       } else {
         // version number > 1
-        const newHost = newDoc.id.split(':').at(-1);
+        const newHost = requireDidId(newDoc.id).split(':').at(-1) ?? '';
         if (!meta.portable && newHost !== host) {
           throw new Error('Cannot move DID: portability is disabled');
         } else if (newHost !== host) {
@@ -285,7 +287,7 @@ export const resolveDIDFromLog = async (
 
         if (shouldVerifyEntry(i)) {
           // Signature verification — expensive, skipped for middle entries in fast-resolve
-          const keys = meta.prerotation ? parameters.updateKeys : meta.updateKeys;
+          const keys = meta.prerotation ? (parameters.updateKeys as string[]) : meta.updateKeys;
           const verified = await documentStateIsValid(resolutionLog[i], keys, meta.witness, false, options.verifier);
           if (!verified) {
             throw new Error(`version ${meta.versionId} failed verification of the proof.`);
@@ -309,12 +311,17 @@ export const resolveDIDFromLog = async (
           meta.nextKeyHashes = [];
           meta.prerotation = false;
         }
+        const legacyParameters = parameters as typeof parameters & {
+          witnesses?: { id: string }[];
+          witnessThreshold?: string | number;
+        };
+
         if ('witness' in parameters) {
           meta.witness = parameters.witness;
-        } else if (parameters.witnesses) {
+        } else if (legacyParameters.witnesses) {
           meta.witness = {
-            witnesses: parameters.witnesses,
-            threshold: parameters.witnessThreshold || parameters.witnesses.length,
+            witnesses: legacyParameters.witnesses,
+            threshold: legacyParameters.witnessThreshold || legacyParameters.witnesses.length,
           };
         }
         if (meta.witness?.witnesses?.length) {
@@ -336,7 +343,7 @@ export const resolveDIDFromLog = async (
 
       // Optimized: Use efficient cloning instead of clone() function
       doc = deepClone(newDoc);
-      did = doc.id;
+      did = requireDidId(doc.id);
 
       // Only add default services for entries we need to process
       if (shouldVerifyEntry(i) || i === resolutionLog.length - 1) {
@@ -344,7 +351,7 @@ export const resolveDIDFromLog = async (
         doc.service = Array.isArray(doc.service) ? doc.service : [];
         const baseUrl = getBaseUrl(did);
 
-        if (!doc.service.some((s: any) => s.id === '#files')) {
+        if (!doc.service.some((s: ServiceEndpoint) => s.id === '#files')) {
           doc.service.push({
             id: '#files',
             type: 'relativeRef',
@@ -352,7 +359,7 @@ export const resolveDIDFromLog = async (
           });
         }
 
-        if (!doc.service.some((s: any) => s.id === '#whois')) {
+        if (!doc.service.some((s: ServiceEndpoint) => s.id === '#whois')) {
           doc.service.push({
             '@context': 'https://identity.foundation/linked-vp/contexts/v1',
             id: '#whois',
@@ -447,15 +454,19 @@ export const resolveDIDFromLog = async (
     throw new Error('DID resolution failed: No valid metadata found');
   }
 
+  if (!resolvedDoc) {
+    throw new Error('DID resolution failed: No valid document found');
+  }
+
   return {
-    did,
+    did: requireDidId(resolvedDoc.id),
     doc: resolvedDoc,
     meta: resolvedMeta,
   };
 };
 
 export const updateDID = async (
-  options: UpdateDIDInterface & { services?: any[]; domain?: string; updated?: string }
+  options: UpdateDIDInterface & { services?: ServiceEndpoint[]; domain?: string; updated?: string }
 ): Promise<UpdateDIDResult> => {
   const log = options.log;
   const lastEntry = log[log.length - 1];
@@ -555,11 +566,11 @@ export const updateDID = async (
   };
 
   const hasWebAlias = (prelimEntry.state.alsoKnownAs ?? []).some((alias: string) => alias.startsWith('did:web:'));
-  const didId = requireDidId(prelimEntry.state.id);
-  const webDoc = hasWebAlias ? generateParallelDidWeb(didId, prelimEntry.state) : undefined;
+  const updatedDidId = requireDidId(prelimEntry.state.id);
+  const webDoc = hasWebAlias ? generateParallelDidWeb(updatedDidId, prelimEntry.state) : undefined;
 
   return {
-    did: didId,
+    did: updatedDidId,
     doc: prelimEntry.state,
     meta,
     log: [...log, prelimEntry],
@@ -569,7 +580,7 @@ export const updateDID = async (
 
 export const deactivateDID = async (
   options: DeactivateDIDInterface & { updateKeys?: string[] }
-): Promise<{ did: string; doc: any; meta: DIDResolutionMeta; log: DIDLog }> => {
+): Promise<{ did: string; doc: DIDDoc; meta: DIDResolutionMeta; log: DIDLog }> => {
   const log = options.log;
   const lastEntry = log[log.length - 1];
   const lastMeta = (await resolveDIDFromLog(log, { verifier: options.verifier })).meta;
@@ -624,7 +635,7 @@ export const deactivateDID = async (
   const didId = requireDidId(prelimEntry.state.id);
 
   return {
-    did: didId,
+    did: requireDidId(prelimEntry.state.id),
     doc: prelimEntry.state,
     meta,
     log: [...log, prelimEntry],
@@ -642,10 +653,11 @@ const getEntryWitnessParameter = (parameters: DIDLogEntry['parameters']): Witnes
     return parameters.witness ?? {};
   }
 
-  if ((parameters as any).witnesses) {
+  if ((parameters as { witnesses?: { id: string }[]; witnessThreshold?: string | number }).witnesses) {
+    const legacyParameters = parameters as { witnesses: { id: string }[]; witnessThreshold?: string | number };
     return {
-      witnesses: (parameters as any).witnesses,
-      threshold: (parameters as any).witnessThreshold || (parameters as any).witnesses.length,
+      witnesses: legacyParameters.witnesses,
+      threshold: legacyParameters.witnessThreshold || legacyParameters.witnesses.length,
     };
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -24,8 +24,9 @@ function validateDidKeyMultibase(keyMultibase: string): void {
 
   try {
     multibaseDecode(keyMultibase);
-  } catch (error: any) {
-    throw new Error(`Malformed did:key identifier: ${error.message}`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Malformed did:key identifier: ${message}`);
   }
 }
 
@@ -176,9 +177,10 @@ export function parseCanonicalAddress(input: string): ParsedAddress {
         didDomainComponent,
         paths: pathParts.length > 0 ? pathParts : undefined,
       };
-    } catch (e: any) {
-      if (e.message?.includes('not allowed')) throw e;
-      throw new Error(`Invalid URL: ${e.message}`);
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      if (message.includes('not allowed')) throw e;
+      throw new Error(`Invalid URL: ${message}`);
     }
   }
 
@@ -233,20 +235,28 @@ export function parseCanonicalAddress(input: string): ParsedAddress {
   };
 }
 
+type ProcessVersionsLike = { node?: string; bun?: string };
+
 // Environment detection - treat React Native like a browser, but Bun as Node-like
 const isNodeEnvironment =
   typeof process !== 'undefined' &&
   typeof window === 'undefined' &&
-  !!((process.versions && (process.versions as any).node) || (process.versions as any).bun);
+  !!(
+    (process.versions as ProcessVersionsLike | undefined)?.node ||
+    (process.versions as ProcessVersionsLike | undefined)?.bun
+  );
 
 // Avoid bundlers including `fs`: hide the specifier from static analyzers
 const fsModuleSpecifier = ['node', 'fs'].join(':');
 // We'll resolve require dynamically only in Node runtimes; otherwise use dynamic import with a non-literal
 
-let fsModule: any | null = null;
-let fsImportPromise: Promise<any> | null = null;
+type FsModule = typeof import('node:fs');
+type GlobalRequire = (id: string) => FsModule;
 
-const getFS = async (): Promise<any> => {
+let fsModule: FsModule | null = null;
+let fsImportPromise: Promise<FsModule> | null = null;
+
+const getFS = async (): Promise<FsModule> => {
   if (!isNodeEnvironment) {
     throw new Error(
       'Filesystem access is not available in this environment (React Native, browser, or failed Node.js import)'
@@ -263,7 +273,7 @@ const getFS = async (): Promise<any> => {
 
   fsImportPromise = (async () => {
     // Prefer require when present (Node)
-    const maybeRequire = (globalThis as any).require;
+    const maybeRequire = (globalThis as { require?: GlobalRequire }).require;
     if (typeof maybeRequire === 'function') {
       try {
         const module = maybeRequire(fsModuleSpecifier);
@@ -278,14 +288,20 @@ const getFS = async (): Promise<any> => {
     }
     // Fallback to dynamic import (Bun/ESM)
     try {
-      const module = await import(fsModuleSpecifier as any);
-      fsModule = module as any;
-      return module as any;
+      const module = (await import(fsModuleSpecifier)) as FsModule;
+      fsModule = module;
+      return module;
     } catch {}
     try {
-      const module = await import('fs' as any);
-      fsModule = module as any;
-      return module as any;
+      const module = (await import('node:fs')) as FsModule;
+      fsModule = module;
+      return module;
+    } catch {}
+    try {
+      // biome-ignore lint/style/useNodejsImportProtocol: Compatibility fallback for runtimes/bundlers that reject node: builtins.
+      const module = (await import('fs')) as FsModule;
+      fsModule = module;
+      return module;
     } catch {}
     throw new Error('Filesystem access is not available in this environment (unable to load fs)');
   })();
@@ -459,14 +475,15 @@ export const writeVerificationMethodToEnv = async (verificationMethod: Verificat
   const fs = await getFS();
   try {
     let envContent = '';
-    let existingData: any[] = [];
+    let existingData: Array<typeof vmData> = [];
 
     if (fs.existsSync(envFilePath)) {
       envContent = fs.readFileSync(envFilePath, 'utf8');
       const match = envContent.match(/DID_VERIFICATION_METHODS=(.*)/);
       if (match?.[1]) {
         const decodedData = bufferToString(createBuffer(match[1], 'base64'));
-        existingData = JSON.parse(decodedData);
+        const parsedData = JSON.parse(decodedData) as unknown;
+        existingData = Array.isArray(parsedData) ? (parsedData as Array<typeof vmData>) : [];
 
         // Check if verification method with same ID already exists
         const existingIndex = existingData.findIndex((vm) => vm.id === vmData.id);
@@ -504,18 +521,16 @@ export const writeVerificationMethodToEnv = async (verificationMethod: Verificat
   }
 };
 
-export const clone = (input: any) => JSON.parse(JSON.stringify(input));
-
-export function deepClone(obj: any): any {
+export function deepClone<T>(obj: T): T {
   if (obj === null || typeof obj !== 'object') return obj;
-  if (obj instanceof Date) return new Date(obj.getTime());
-  if (Array.isArray(obj)) return obj.map((item) => deepClone(item));
+  if (obj instanceof Date) return new Date(obj.getTime()) as T;
+  if (Array.isArray(obj)) return obj.map((item) => deepClone(item)) as T;
 
-  const cloned: any = {};
-  for (const [key, value] of Object.entries(obj)) {
+  const cloned: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
     cloned[key] = deepClone(value);
   }
-  return cloned;
+  return cloned as T;
 }
 
 export const getBaseUrl = (id: string) => {
@@ -606,7 +621,7 @@ export const createSCID = async (logEntryHash: string): Promise<string> => {
 // Cache for deriveHash operations to avoid redundant computation
 const hashCache = new Map<string, string>();
 
-function getCachedHash(input: any): string | undefined {
+function getCachedHash(input: unknown): string | undefined {
   try {
     const key = JSON.stringify(input);
     return hashCache.get(key);
@@ -615,7 +630,7 @@ function getCachedHash(input: any): string | undefined {
   }
 }
 
-function setCachedHash(input: any, hash: string): void {
+function setCachedHash(input: unknown, hash: string): void {
   try {
     const key = JSON.stringify(input);
     hashCache.set(key, hash);
@@ -625,7 +640,7 @@ function setCachedHash(input: any, hash: string): void {
 }
 
 // Input must be strict JSON-compatible and must not contain explicit undefined values.
-export async function deriveHash(input: any): Promise<string> {
+export async function deriveHash(input: unknown): Promise<string> {
   const cached = getCachedHash(input);
   if (cached) {
     return cached;
@@ -721,8 +736,23 @@ export const createVMID = (vm: VerificationMethod, did: string | null) => {
   return `${did ?? ''}#${vm.publicKeyMultibase?.slice(-8) || generateRandomId(8)}`;
 };
 
-export const normalizeVMs = (verificationMethod: VerificationMethod[] | undefined, did: string | null = null) => {
-  const all: any = {
+type NormalizedVerificationMethods = Required<
+  Pick<
+    DIDDoc,
+    | 'verificationMethod'
+    | 'authentication'
+    | 'assertionMethod'
+    | 'keyAgreement'
+    | 'capabilityDelegation'
+    | 'capabilityInvocation'
+  >
+>;
+
+export const normalizeVMs = (
+  verificationMethod: VerificationMethod[] | undefined,
+  did: string | null = null
+): NormalizedVerificationMethods => {
+  const all: NormalizedVerificationMethods = {
     verificationMethod: [],
     authentication: [],
     assertionMethod: [],
@@ -742,7 +772,7 @@ export const normalizeVMs = (verificationMethod: VerificationMethod[] | undefine
     // Default controller to the DID — required by W3C DID Core §5.2
     controller: vm.controller ?? did,
   }));
-  all.verificationMethod = vms;
+  all.verificationMethod = vms as unknown as VerificationMethod[];
 
   // Then handle relationships - default to authentication if no purpose is specified
   all.authentication = verificationMethod
@@ -789,10 +819,10 @@ export const resolveVM = async (vm: string) => {
   }
 };
 
-export const findVerificationMethod = (doc: any, vmId: string): VerificationMethod | null => {
+export const findVerificationMethod = (doc: DIDDoc, vmId: string): VerificationMethod | null => {
   // Check in the verificationMethod array
-  if (doc.verificationMethod?.some((vm: any) => vm.id === vmId)) {
-    return doc.verificationMethod.find((vm: any) => vm.id === vmId);
+  if (doc.verificationMethod?.some((vm) => vm.id === vmId)) {
+    return doc.verificationMethod.find((vm) => vm.id === vmId) ?? null;
   }
 
   // Check in other verification method relationship arrays
@@ -804,9 +834,22 @@ export const findVerificationMethod = (doc: any, vmId: string): VerificationMeth
     'capabilityDelegation',
   ];
   for (const relationship of vmRelationships) {
-    if (doc[relationship]) {
-      if (doc[relationship].some((item: any) => item.id === vmId)) {
-        return doc[relationship].find((item: any) => item.id === vmId);
+    const relationshipValues = doc[relationship as keyof DIDDoc];
+    if (
+      Array.isArray(relationshipValues) &&
+      relationshipValues.some((item) => {
+        if (typeof item !== 'object' || item === null) return false;
+        const maybeId = (item as { id?: unknown }).id;
+        return maybeId === vmId;
+      })
+    ) {
+      const match = relationshipValues.find((item) => {
+        if (typeof item !== 'object' || item === null) return false;
+        const maybeId = (item as { id?: unknown }).id;
+        return maybeId === vmId;
+      });
+      if (match && typeof match === 'object') {
+        return match as VerificationMethod;
       }
     }
   }
@@ -845,19 +888,19 @@ export async function fetchWitnessProofs(did: string): Promise<WitnessProofFileE
   }
 }
 
-export function replaceValueInObject(obj: any, searchValue: string, replaceValue: string): any {
+export function replaceValueInObject<T>(obj: T, searchValue: string, replaceValue: string): T {
   if (typeof obj === 'string') {
-    return obj.replaceAll(searchValue, replaceValue);
+    return obj.replaceAll(searchValue, replaceValue) as T;
   }
   if (Array.isArray(obj)) {
-    return obj.map((item) => replaceValueInObject(item, searchValue, replaceValue));
+    return obj.map((item) => replaceValueInObject(item, searchValue, replaceValue)) as T;
   }
   if (obj && typeof obj === 'object') {
-    const result: any = {};
-    for (const [key, value] of Object.entries(obj)) {
+    const result: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
       result[key] = replaceValueInObject(value, searchValue, replaceValue);
     }
-    return result;
+    return result as T;
   }
   return obj;
 }

--- a/src/witness.ts
+++ b/src/witness.ts
@@ -75,10 +75,12 @@ export async function createWitnessProof(
   // Strip undefined fields to keep the proof JSON-compatible.
   const sanitizedProof = JSON.parse(JSON.stringify(mergedProof)) as Partial<DataIntegrityProof>;
 
-  if (!sanitizedProof.verificationMethod) {
+  const verificationMethodValue = mergedProof.verificationMethod;
+  if (!verificationMethodValue) {
     throw new Error('Witness proof is missing verificationMethod');
   }
-  if (!sanitizedProof.proofValue) {
+  const proofValue = mergedProof.proofValue;
+  if (!proofValue) {
     throw new Error('Witness proof is missing proofValue');
   }
 
@@ -86,9 +88,9 @@ export async function createWitnessProof(
     id: sanitizedProof.id,
     type: sanitizedProof.type ?? proofTemplate.type,
     cryptosuite: sanitizedProof.cryptosuite ?? proofTemplate.cryptosuite,
-    verificationMethod: sanitizedProof.verificationMethod,
+    verificationMethod: verificationMethodValue,
     created: sanitizedProof.created ?? proofTemplate.created,
-    proofValue: sanitizedProof.proofValue,
+    proofValue,
     proofPurpose: sanitizedProof.proofPurpose ?? proofTemplate.proofPurpose,
   };
 }

--- a/test/canonicalization-parity.test.ts
+++ b/test/canonicalization-parity.test.ts
@@ -17,7 +17,7 @@ describe('canonicalization parity semantics', () => {
   });
 
   test('deriveHash accepts payloads with undefined object fields by stripping them', async () => {
-    await expect(deriveHash({ a: undefined } as any)).resolves.toEqual(await deriveHash({}));
+    await expect(deriveHash({ a: undefined })).resolves.toEqual(await deriveHash({}));
   });
 
   test('still rejects undefined values in arrays', () => {

--- a/test/cli-e2e.test.ts
+++ b/test/cli-e2e.test.ts
@@ -12,7 +12,7 @@ const ENV_FILE = join(process.cwd(), '.env');
 
 // Create a verifier for resolving CLI-created DIDs.
 // TestCryptoImplementation.verify() does generic ed25519 verification
-// using the public key from the proof, so any instance works.
+// using the public key from the proof, so a generic instance works.
 let verifier: TestCryptoImplementation;
 let savedEnv: string | null = null;
 

--- a/test/cryptography.test.ts
+++ b/test/cryptography.test.ts
@@ -1,7 +1,14 @@
 import { beforeAll, describe, expect, test } from 'bun:test';
 import { documentStateIsValid } from '../src/assertions';
 import { AbstractCrypto, createDocumentSigner } from '../src/cryptography';
-import type { SignerOptions, SigningInput, SigningOutput, Verifier } from '../src/interfaces';
+import type {
+  DataIntegrityProofTemplate,
+  DIDLogEntry,
+  SignerOptions,
+  SigningInput,
+  SigningOutput,
+  Verifier,
+} from '../src/interfaces';
 import { MultibaseEncoding, multibaseEncode } from '../src/utils/multiformats';
 import { countVerifiedWitnessApprovals } from '../src/witness';
 
@@ -27,8 +34,8 @@ class MockCryptoImplementation extends AbstractCrypto implements Verifier {
 describe('Injectable Cryptography Tests', () => {
   let mockImplementation: MockCryptoImplementation;
   let failingMockImplementation: MockCryptoImplementation;
-  let testDoc: any;
-  let testProof: any;
+  let testDoc: { id: string; name: string };
+  let testProof: DataIntegrityProofTemplate;
   const updateKey = 'z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK';
 
   beforeAll(() => {
@@ -79,12 +86,17 @@ describe('Injectable Cryptography Tests', () => {
   });
 
   test('Verify document with successful implementation', async () => {
-    const signedDoc = {
-      ...testDoc,
-      proof: {
-        ...testProof,
-        proofValue: 'z4PJ7iFV3syhMEHAfwQJuSqyGCHzTH5kJqAGCKnXyyb7vGCmqzpbCHMjK4SfgGkFrXjzWtGmMmPqXEEZYDvbpjTQH',
-      },
+    const signedDoc: DIDLogEntry = {
+      versionId: '1-test',
+      versionTime: '2024-03-06T00:00:00Z',
+      parameters: {},
+      state: testDoc,
+      proof: [
+        {
+          ...testProof,
+          proofValue: 'z4PJ7iFV3syhMEHAfwQJuSqyGCHzTH5kJqAGCKnXyyb7vGCmqzpbCHMjK4SfgGkFrXjzWtGmMmPqXEEZYDvbpjTQH',
+        },
+      ],
     };
 
     const result = await documentStateIsValid(signedDoc, [updateKey], null, true, mockImplementation);
@@ -93,12 +105,17 @@ describe('Injectable Cryptography Tests', () => {
   });
 
   test('Verify document with failing implementation', async () => {
-    const signedDoc = {
-      ...testDoc,
-      proof: {
-        ...testProof,
-        proofValue: 'z4PJ7iFV3syhMEHAfwQJuSqyGCHzTH5kJqAGCKnXyyb7vGCmqzpbCHMjK4SfgGkFrXjzWtGmMmPqXEEZYDvbpjTQH',
-      },
+    const signedDoc: DIDLogEntry = {
+      versionId: '1-test',
+      versionTime: '2024-03-06T00:00:00Z',
+      parameters: {},
+      state: testDoc,
+      proof: [
+        {
+          ...testProof,
+          proofValue: 'z4PJ7iFV3syhMEHAfwQJuSqyGCHzTH5kJqAGCKnXyyb7vGCmqzpbCHMjK4SfgGkFrXjzWtGmMmPqXEEZYDvbpjTQH',
+        },
+      ],
     };
 
     expect(documentStateIsValid(signedDoc, [updateKey], null, true, failingMockImplementation)).rejects.toThrow(
@@ -190,12 +207,17 @@ describe('Injectable Cryptography Tests', () => {
   });
 
   test('Require verifier implementation', async () => {
-    const signedDoc = {
-      ...testDoc,
-      proof: {
-        ...testProof,
-        proofValue: 'z4PJ7iFV3syhMEHAfwQJuSqyGCHzTH5kJqAGCKnXyyb7vGCmqzpbCHMjK4SfgGkFrXjzWtGmMmPqXEEZYDvbpjTQH',
-      },
+    const signedDoc: DIDLogEntry = {
+      versionId: '1-test',
+      versionTime: '2024-03-06T00:00:00Z',
+      parameters: {},
+      state: testDoc,
+      proof: [
+        {
+          ...testProof,
+          proofValue: 'z4PJ7iFV3syhMEHAfwQJuSqyGCHzTH5kJqAGCKnXyyb7vGCmqzpbCHMjK4SfgGkFrXjzWtGmMmPqXEEZYDvbpjTQH',
+        },
+      ],
     };
 
     expect(documentStateIsValid(signedDoc, [mockImplementation.getVerificationMethodId()], null, true)).rejects.toThrow(

--- a/test/did-document-passthrough.test.ts
+++ b/test/did-document-passthrough.test.ts
@@ -28,7 +28,7 @@ describe('didDocument create pass-through', () => {
       });
 
       expect(warnings.some((msg) => msg.includes('Removing secretKeyMultibase'))).toBe(true);
-      expect((doc.verificationMethod ?? []).every((vm: any) => vm.secretKeyMultibase === undefined)).toBe(true);
+      expect((doc.verificationMethod ?? []).every((vm) => vm.secretKeyMultibase === undefined)).toBe(true);
     } finally {
       console.warn = originalWarn;
     }
@@ -107,7 +107,7 @@ describe('didDocument create pass-through', () => {
         updateKeys: [authKey.publicKeyMultibase!],
         didDocument: {
           id: '{DID}',
-          alsoKnownAs: 'did:example:not-array' as any,
+          alsoKnownAs: 'did:example:not-array' as unknown as string[],
         },
         alsoKnownAsWeb: true,
       })
@@ -140,7 +140,7 @@ describe('didDocument create pass-through', () => {
       });
 
       expect(warnings.some((msg) => msg.includes('Removing secretKeyMultibase'))).toBe(true);
-      expect((updated.doc.verificationMethod ?? []).every((vm: any) => vm.secretKeyMultibase === undefined)).toBe(true);
+      expect((updated.doc.verificationMethod ?? []).every((vm) => vm.secretKeyMultibase === undefined)).toBe(true);
     } finally {
       console.warn = originalWarn;
     }

--- a/test/domain-encoding.test.ts
+++ b/test/domain-encoding.test.ts
@@ -30,7 +30,7 @@ async function createFromInput(kind: InputKind, value: string) {
   return createDID({
     ...baseOptions,
     address: value,
-  } as any);
+  });
 }
 
 describe('Strict address input validation and parsing', () => {

--- a/test/features.test.ts
+++ b/test/features.test.ts
@@ -1,5 +1,5 @@
 import { beforeAll, expect, test } from 'bun:test';
-import type { DIDLog, VerificationMethod } from '../src/interfaces';
+import type { CreateDIDResult, DIDLog, DIDLogEntry, VerificationMethod } from '../src/interfaces';
 import { createDID, resolveDIDFromLog, updateDID } from '../src/method';
 import { createDate, deriveNextKeyHash } from '../src/utils';
 import {
@@ -16,8 +16,8 @@ let authKey1: VerificationMethod,
   authKey4: VerificationMethod;
 let testImplementation: TestCryptoImplementation;
 
-let nonPortableDID: { did: string; doc: any; meta: any; log: DIDLog };
-let portableDID: { did: string; doc: any; meta: any; log: DIDLog };
+let nonPortableDID: CreateDIDResult;
+let portableDID: CreateDIDResult;
 
 beforeAll(async () => {
   authKey1 = await generateTestVerificationMethod();
@@ -237,7 +237,7 @@ test('updateKeys MUST be in nextKeyHashes when reading', async () => {
 });
 
 test('DID log with portable false should not resolve if moved', async () => {
-  let err: any;
+  let err: unknown;
   try {
     const lastEntry = nonPortableDID.log[nonPortableDID.log.length - 1];
     const newTimestamp = createDate(new Date('2021-02-01T08:32:55Z'));
@@ -248,16 +248,16 @@ test('DID log with portable false should not resolve if moved', async () => {
       id: nonPortableDID.did.replace('example.com', 'newdomain.com'),
     };
 
-    const newEntry = {
+    const newEntry: DIDLogEntry = {
       versionId: `${nonPortableDID.log.length + 1}-test`,
       versionTime: newTimestamp,
-      parameters: { updateKeys: [authKey1.publicKeyMultibase] },
+      parameters: { updateKeys: [authKey1.publicKeyMultibase!] },
       state: newDoc,
       proof: [
         {
           type: 'DataIntegrityProof',
           cryptosuite: 'eddsa-jcs-2022',
-          verificationMethod: `did:key:${authKey1.publicKeyMultibase}`,
+          verificationMethod: `did:key:${authKey1.publicKeyMultibase!}`,
           created: newTimestamp,
           proofPurpose: 'authentication',
           proofValue: 'badProofValue',
@@ -265,12 +265,13 @@ test('DID log with portable false should not resolve if moved', async () => {
       ],
     };
 
-    const badLog: DIDLog = [...(nonPortableDID.log as any), newEntry];
+    const badLog: DIDLog = [...nonPortableDID.log, newEntry];
     await resolveDIDFromLog(badLog, { verifier: testImplementation });
   } catch (e) {
     err = e;
   }
 
   expect(err).toBeDefined();
-  expect(err.message).toContain('Cannot move DID: portability is disabled');
+  expect(err).toBeInstanceOf(Error);
+  expect((err as Error).message).toContain('Cannot move DID: portability is disabled');
 });

--- a/test/must.test.ts
+++ b/test/must.test.ts
@@ -1,5 +1,11 @@
 import { beforeAll, describe, expect, test } from 'bun:test';
-import type { DIDLog, VerificationMethod } from '../src/interfaces';
+import type {
+  CreateDIDResult,
+  DataIntegrityProofTemplate,
+  DIDLog,
+  VerificationMethod,
+  WitnessProofFileEntry,
+} from '../src/interfaces';
 import { createDID, deactivateDID, resolveDIDFromLog, updateDID } from '../src/method';
 import { createWitnessProof } from '../src/witness';
 import {
@@ -10,7 +16,7 @@ import {
 } from './utils';
 
 describe('did:webvh normative tests', async () => {
-  let newDoc1: any;
+  let newDoc1: CreateDIDResult['doc'];
   let newLog1: DIDLog;
   let authKey1: VerificationMethod;
   let testImplementation: TestCryptoImplementation;
@@ -41,7 +47,7 @@ describe('did:webvh normative tests', async () => {
     let err: unknown;
     const malformedLog = 'malformed log content';
     try {
-      await resolveDIDFromLog(malformedLog as any, { verifier: testImplementation });
+      await resolveDIDFromLog(malformedLog as unknown as DIDLog, { verifier: testImplementation });
     } catch (e) {
       err = e;
     }
@@ -85,7 +91,7 @@ describe('did:webvh normative tests', async () => {
 describe('did:webvh normative witness tests', async () => {
   let authKey1: VerificationMethod;
   let witness1: VerificationMethod, witness2: VerificationMethod, witness3: VerificationMethod;
-  let initialDID: { did: string; doc: any; meta: any; log: DIDLog };
+  let initialDID: CreateDIDResult;
   let testImplementation: TestCryptoImplementation;
   let witnessImpl1: TestCryptoImplementation,
     witnessImpl2: TestCryptoImplementation,
@@ -96,8 +102,8 @@ describe('did:webvh normative witness tests', async () => {
 
   const createWitnessSigner = (verificationMethod: VerificationMethod) => {
     const signer = createTestSigner(verificationMethod);
-    return async (data: any, proofTemplate?: any) => {
-      const proof = {
+    return async (data: { versionId: string }, proofTemplate?: DataIntegrityProofTemplate) => {
+      const proof: DataIntegrityProofTemplate = {
         type: 'DataIntegrityProof',
         cryptosuite: 'eddsa-jcs-2022',
         verificationMethod: signer.getVerificationMethodId(),
@@ -185,7 +191,7 @@ describe('did:webvh normative witness tests', async () => {
     let err: unknown;
     try {
       await resolveDIDFromLog(initialDID.log, {
-        witnessProofs: mockWitnessProofs as any,
+        witnessProofs: mockWitnessProofs as unknown as WitnessProofFileEntry[],
         verifier: testImplementation,
       });
     } catch (e) {
@@ -227,7 +233,7 @@ describe('did:webvh normative witness tests', async () => {
     let err: unknown;
     try {
       await resolveDIDFromLog(initialDID.log, {
-        witnessProofs: mockWitnessProofs as any,
+        witnessProofs: mockWitnessProofs as unknown as WitnessProofFileEntry[],
         verifier: testImplementation,
       });
     } catch (e) {
@@ -259,7 +265,7 @@ describe('did:webvh normative witness tests', async () => {
     let err: unknown;
     try {
       await resolveDIDFromLog(initialDID.log, {
-        witnessProofs: mockWitnessProofs as any,
+        witnessProofs: mockWitnessProofs as unknown as WitnessProofFileEntry[],
         verifier: testImplementation,
       });
     } catch (e) {

--- a/test/not-so-happy-path.test.ts
+++ b/test/not-so-happy-path.test.ts
@@ -1,5 +1,5 @@
 import { beforeAll, describe, expect, test } from 'bun:test';
-import { type DIDLog, DidResolutionError, type VerificationMethod } from '../src/interfaces';
+import { type CreateDIDResult, type DIDLog, DidResolutionError, type VerificationMethod } from '../src/interfaces';
 import { createDID, resolveDIDFromLog, updateDID } from '../src/method';
 import { resolveDIDFromLog as resolveDIDFromLogV1 } from '../src/method_versions/method.v1.0';
 import {
@@ -12,7 +12,7 @@ import {
 describe('Not So Happy Path Tests', () => {
   let authKey: VerificationMethod;
   let testImplementation: TestCryptoImplementation;
-  let initialDID: { did: string; doc: any; meta: any; log: DIDLog };
+  let initialDID: CreateDIDResult;
 
   beforeAll(async () => {
     authKey = await generateTestVerificationMethod();

--- a/test/resolve-http.test.ts
+++ b/test/resolve-http.test.ts
@@ -72,7 +72,8 @@ describe('resolveDID over HTTPS', () => {
     expect(fetchMock).toHaveBeenCalledWith('https://example.com/.well-known/did.jsonl');
     expect(result.did).toBe(did);
     expect(result.doc).toBeTruthy();
-    expect(result.doc.id).toBe(did);
+    expect(result.doc).not.toBeNull();
+    expect(result.doc!.id).toBe(did);
     expect(result.meta.error).toBeUndefined();
   });
 

--- a/test/resolve.test.ts
+++ b/test/resolve.test.ts
@@ -1,5 +1,5 @@
 import { beforeAll, describe, expect, test } from 'bun:test';
-import type { DIDLog, VerificationMethod } from '../src/interfaces';
+import type { CreateDIDResult, DIDLog, VerificationMethod } from '../src/interfaces';
 import { createDID, resolveDIDFromLog, updateDID } from '../src/method';
 import { getBaseUrl, getFileUrl } from '../src/utils';
 import {
@@ -10,7 +10,7 @@ import {
 } from './utils';
 
 describe('resolveDIDFromLog with verificationMethod', () => {
-  let initialDID: { did: string; doc: any; meta: any; log: DIDLog };
+  let initialDID: CreateDIDResult;
   let fullLog: DIDLog;
   let authKey1: VerificationMethod,
     authKey2: VerificationMethod,
@@ -74,7 +74,7 @@ describe('resolveDIDFromLog with verificationMethod', () => {
     const { doc, meta } = await resolveDIDFromLog(fullLog, { verificationMethod: vmId, verifier: testImplementation });
 
     expect(doc.verificationMethod).toHaveLength(1);
-    expect(doc.verificationMethod[0].publicKeyMultibase).toBe(authKey1.publicKeyMultibase);
+    expect(doc.verificationMethod![0].publicKeyMultibase).toBe(authKey1.publicKeyMultibase);
     expect(meta.versionId.split('-')[0]).toBe('1');
   });
 
@@ -83,7 +83,7 @@ describe('resolveDIDFromLog with verificationMethod', () => {
     const { doc, meta } = await resolveDIDFromLog(fullLog, { verificationMethod: vmId, verifier: testImplementation });
 
     expect(doc.verificationMethod).toHaveLength(2);
-    expect(doc.verificationMethod[1].publicKeyMultibase).toBe(authKey2.publicKeyMultibase);
+    expect(doc.verificationMethod![1].publicKeyMultibase).toBe(authKey2.publicKeyMultibase);
     expect(meta.versionId.split('-')[0]).toBe('2');
   });
 
@@ -92,7 +92,7 @@ describe('resolveDIDFromLog with verificationMethod', () => {
     const { doc, meta } = await resolveDIDFromLog(fullLog, { verificationMethod: vmId, verifier: testImplementation });
 
     expect(doc.verificationMethod).toHaveLength(3);
-    expect(doc.verificationMethod[2].publicKeyMultibase).toBe(keyAgreementKey.publicKeyMultibase);
+    expect(doc.verificationMethod![2].publicKeyMultibase).toBe(keyAgreementKey.publicKeyMultibase);
     expect(meta.versionId.split('-')[0]).toBe('3');
   });
 
@@ -101,8 +101,8 @@ describe('resolveDIDFromLog with verificationMethod', () => {
     const { doc, meta } = await resolveDIDFromLog(fullLog, { verificationMethod: vmId, verifier: testImplementation });
 
     expect(doc.verificationMethod).toHaveLength(4);
-    expect(doc.verificationMethod[3].publicKeyMultibase).toBe(assertionKey.publicKeyMultibase);
-    expect(doc.verificationMethod[3].id).toEndWith('externallyDefinedId');
+    expect(doc.verificationMethod![3].publicKeyMultibase).toBe(assertionKey.publicKeyMultibase);
+    expect(doc.verificationMethod![3].id).toEndWith('externallyDefinedId');
     expect(meta.versionId.split('-')[0]).toBe('4');
   });
 
@@ -125,7 +125,7 @@ describe('resolveDIDFromLog with verificationMethod', () => {
     });
 
     expect(doc.verificationMethod).toHaveLength(2);
-    expect(doc.verificationMethod[1].publicKeyMultibase).toBe(authKey2.publicKeyMultibase);
+    expect(doc.verificationMethod![1].publicKeyMultibase).toBe(authKey2.publicKeyMultibase);
     expect(meta.versionId.split('-')[0]).toBe('2');
   });
 

--- a/test/spec-entry-hash.test.ts
+++ b/test/spec-entry-hash.test.ts
@@ -19,7 +19,7 @@ import {
 // path substitutes the wrong predecessor (e.g. the "{SCID}" placeholder) for
 // entries 2+ — a deviation that round-trips within the library but produces
 // logs no spec-compliant resolver will accept.
-async function specEntryHashForEntry(entry: any, previousVersionId: string): Promise<string> {
+async function specEntryHashForEntry(entry: DIDLog[number], previousVersionId: string): Promise<string> {
   const { proof: _proof, ...entryWithoutProof } = entry;
   return deriveHash({ ...entryWithoutProof, versionId: previousVersionId });
 }

--- a/test/witness.test.ts
+++ b/test/witness.test.ts
@@ -1,5 +1,5 @@
 import { beforeAll, describe, expect, test } from 'bun:test';
-import type { DataIntegrityProofTemplate, DIDLog, Signer, VerificationMethod } from '../src/interfaces';
+import type { CreateDIDResult, DataIntegrityProofTemplate, Signer, VerificationMethod } from '../src/interfaces';
 import { DidResolutionError } from '../src/interfaces';
 import { createDID, resolveDIDFromLog, updateDID } from '../src/method';
 import { deriveHash, parseDidKeyDid, parseDidKeyVerificationMethod } from '../src/utils';
@@ -19,7 +19,7 @@ import {
 describe('Witness Implementation Tests', async () => {
   let authKey: VerificationMethod;
   let witness1: VerificationMethod, witness2: VerificationMethod, witness3: VerificationMethod;
-  let initialDID: { did: string; doc: any; meta: any; log: DIDLog };
+  let initialDID: CreateDIDResult;
   let testImplementation: TestCryptoImplementation;
 
   beforeAll(async () => {
@@ -893,8 +893,8 @@ describe('Witness Implementation Tests', async () => {
 
   const createWitnessSigner = (verificationMethod: VerificationMethod) => {
     const signer = createTestSigner(verificationMethod);
-    return async (data: any, proofTemplate?: any) => {
-      const proof = {
+    return async (data: { versionId: string }, proofTemplate?: DataIntegrityProofTemplate) => {
+      const proof: DataIntegrityProofTemplate = {
         type: 'DataIntegrityProof',
         cryptosuite: 'eddsa-jcs-2022',
         verificationMethod: signer.getVerificationMethodId(),


### PR DESCRIPTION
The big one to clean up all uses of the `any` type and ensure type safety throughout before moving on to further spec alignment work

**Type Safety**

* enforce stricter linting to `error` on use of `any` type
* tighten signer/input/output and DID document typing
* Improve unknown-safe error handling and utility contracts
* Update tests with stricter typing and fewer permissive casts

**Other**

* changed error timing/messages in CLI and resolver fail-fast behaviour
* DID return paths now enforce presence of valid DID id
* v1.0 resolution now fails fast when no valid DID document can be resolved
* CLI fails earlier when required key material is missing
* CLI `update --updateKey` now throws when no matching verification method can be found
* FS loading uses `node:fs` as primary with compatibility fallback for runtimes/bundlers which reject `node:fs`

**witness.ts**

* return object for `createWitnessProof()` uses optional fields from `sanitizedProof` and required validated string fields from `mergedProof`

**legacyParameters**

This is for backwards resolution compatibility with existing log files and is cast during resolution in the `method.v*.ts` files

```ts
legacyParameters: {
  witnesses?: { id: string }[]
  witnessThreshold?: string | number
}
```

```ts
parameters: {
  method?: string
  scid?: string
  updateKeys?: string[]
  nextKeyHashes?: string[]
  portable?: boolean
  witness?: {
    threshold?: number
    witnesses?: { id: string }[]
  }
  watchers?: string[] | null
  deactivated?: boolean
}
```

We could introduce a hard-breaking change + a migration script for old did logs