### PR TITLE
fix(core): add guards to address failing negative tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,11 +199,9 @@ When resolving a requested earlier version (for example with `versionId`, `versi
 
 - `resolveDID(did: string, options?: ResolutionOptions): Promise<{did: string, doc: any, meta: DIDResolutionMeta, controlled: boolean}>`
   Resolves a DID to its DID document.
-  For `v1.0`, `options.fastResolve` is an opt-in mode defaulting to `false` for full log parsing.
 
 - `resolveDIDFromLog(log: DIDLog, options?: ResolutionOptions & { witnessProofs?: WitnessProofFileEntry[] }): Promise<{did: string, doc: any, meta: DIDResolutionMeta}>`
   Resolves directly from an in-memory DID log.
-  For `v1.0`, `options.fastResolve` is an opt-in mode defaulting to `false` for full log parsing.
 
 - `createDID(options: CreateDIDInterface): Promise<{did: string, doc: any, meta: DIDResolutionMeta, log: DIDLog, webDoc?: DIDDoc}>`
   Creates a new DID.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -41,7 +41,7 @@ Commands:
   generate-vm Generate a new verification method keypair
 
 Options:
-  --address [address]       Address for the DID (host, host:port, http://localhost, https://url, or did:webvh form) (required for create)
+  --address [address]       Address for the DID (host, host:port, https://url, or did:webvh form) (required for create)
   --domain [domain]         DEPRECATED: Use --address instead. Domain for the DID (backwards compatibility).
   --log [file]              Path to the DID log file (required for resolve, update, deactivate)
   --output [file]           Path to save the updated DID log (optional for create, update, deactivate)

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -258,7 +258,6 @@ export interface ResolutionOptions {
   verificationMethod?: string;
   verifier?: Verifier;
   scid?: string;
-  fastResolve?: boolean;
 }
 
 export interface WitnessProofFileEntry {

--- a/src/method.ts
+++ b/src/method.ts
@@ -55,9 +55,6 @@ export const createDID = async (options: CreateDIDInterface): Promise<CreateDIDR
 /**
  * Resolves a DID by fetching and validating its DID log.
  *
- * For `did:webvh:1.0`, `fastResolve` is forwarded to the v1 resolver.
- * For `did:webvh:0.5`, `fastResolve` is ignored and not forwarded.
- *
  * @param did The DID to resolve.
  * @param options Optional resolver settings.
  * @returns The resolved DID result with resolution metadata and controlled status.
@@ -75,12 +72,11 @@ export const resolveDID = async (
   try {
     const log = await fetchLogFromIdentifier(did, controlled);
     const version = getWebvhVersionFromLog(log);
-    const { fastResolve, ...baseOptions } = options;
-    const optsWithScid = { ...baseOptions, scid };
+    const optsWithScid = { ...options, scid };
     const result =
       version === '0.5'
         ? await v0_5.resolveDIDFromLog(log, optsWithScid)
-        : await v1.resolveDIDFromLog(log, { ...optsWithScid, fastResolve });
+        : await v1.resolveDIDFromLog(log, optsWithScid);
     maybeWriteTestLog(result.did, log);
 
     return { ...result, controlled };
@@ -115,9 +111,6 @@ export const resolveDID = async (
 /**
  * Resolves a DID from an in-memory DID log.
  *
- * For `did:webvh:1.0`, `fastResolve` is forwarded to the v1 resolver.
- * For `did:webvh:0.5`, `fastResolve` is ignored and not forwarded.
- *
  * @param log In-memory DID log entries.
  * @param options Optional resolver settings.
  * @returns The resolved DID result with resolution metadata.
@@ -127,13 +120,12 @@ export const resolveDIDFromLog = async (
   options: ResolutionOptions & { witnessProofs?: WitnessProofFileEntry[] } = {}
 ) => {
   const version = getWebvhVersionFromLog(log);
-  const { fastResolve, ...baseOptions } = options;
   if (version === '0.5') {
-    const result = await v0_5.resolveDIDFromLog(log, baseOptions);
+    const result = await v0_5.resolveDIDFromLog(log, options);
     maybeWriteTestLog(result.did, log);
     return result;
   }
-  const result = await v1.resolveDIDFromLog(log, { ...baseOptions, fastResolve });
+  const result = await v1.resolveDIDFromLog(log, options);
   maybeWriteTestLog(result.did, log);
   return result;
 };

--- a/src/method_versions/method.v0.5.ts
+++ b/src/method_versions/method.v0.5.ts
@@ -23,6 +23,7 @@ import {
   getBaseUrl,
   parseCanonicalAddress,
   replaceValueInObject,
+  validateMethodSpecificPathSegments,
 } from '../utils';
 import { countVerifiedWitnessApprovals, fetchWitnessProofs, validateWitnessParameter } from '../witness';
 
@@ -56,6 +57,7 @@ export const createDID = async (
   const parsed = parseCanonicalAddress(addressInput);
   const didDomainComponent = parsed.didDomainComponent;
   const allPaths = [...(parsed.paths || []), ...(options.paths || [])];
+  validateMethodSpecificPathSegments(allPaths, 'createDID path segments');
   const path = allPaths.length > 0 ? allPaths.join(':') : undefined;
   const controller = `did:${METHOD}:${PLACEHOLDER}:${didDomainComponent}${path ? `:${path}` : ''}`;
   const createdDate = createDate(options.created);

--- a/src/method_versions/method.v1.0.ts
+++ b/src/method_versions/method.v1.0.ts
@@ -32,6 +32,11 @@ import {
   replaceValueInObject,
   validateCreateDidDocument,
 } from '../utils';
+import {
+  createNextVersionTime,
+  parseUtcIso8601VersionTime,
+  validateUtcIso8601NotInFuture,
+} from '../utils/iso8601-datetime';
 import { countVerifiedWitnessApprovals, fetchWitnessProofs, validateWitnessParameter } from '../witness';
 
 const VERSION = '1.0';
@@ -64,6 +69,9 @@ export const createDID = async (options: CreateDIDInterface): Promise<CreateDIDR
   const allPaths = [...(parsed.paths || []), ...(options.paths || [])];
   const path = allPaths.length > 0 ? allPaths.join(':') : undefined;
   const controller = `did:${METHOD}:${PLACEHOLDER}:${didDomainComponent}${path ? `:${path}` : ''}`;
+  if (options.created) {
+    validateUtcIso8601NotInFuture(options.created, 'createDID created');
+  }
   const createdDate = createDate(options.created);
 
   // Safety guard: Strip secret keys from verification methods before creating DID document
@@ -201,6 +209,8 @@ export const resolveDIDFromLog = async (
   let lastValidMeta: DIDResolutionMeta | null = null;
   let i = 0;
   let host = '';
+  let previousVersionTime: Date | undefined;
+  const resolutionNow = new Date();
   const requiredWitnessChecks: RequiredWitnessCheck[] = [];
 
   // Fast resolution is opt-in; full verification is the default conformant path.
@@ -218,9 +228,15 @@ export const resolveDIDFromLog = async (
         throw new Error(`version '${version}' in log doesn't match expected '${i + 1}'.`);
       }
       meta.versionId = versionId;
-      if (versionTime) {
-        // TODO check timestamps make sense
+      if (!versionTime) {
+        throw new Error(`version '${version}' is missing versionTime`);
       }
+
+      const currentVersionTime = parseUtcIso8601VersionTime(versionTime, `version '${version}' versionTime`);
+      if (previousVersionTime && currentVersionTime.getTime() <= previousVersionTime.getTime()) {
+        throw new Error(`versionTime for version '${version}' must be greater than previous entry time`);
+      }
+      previousVersionTime = currentVersionTime;
       meta.updated = versionTime;
       let newDoc = state;
 
@@ -402,6 +418,10 @@ export const resolveDIDFromLog = async (
       i++;
     }
 
+    if (previousVersionTime && previousVersionTime.getTime() >= resolutionNow.getTime()) {
+      throw new Error('versionTime of the last entry must be earlier than current time');
+    }
+
     if (requiredWitnessChecks.length > 0) {
       if (!options.witnessProofs) {
         options.witnessProofs = await fetchWitnessProofs(did);
@@ -476,7 +496,7 @@ export const updateDID = async (
     throw new Error('Cannot update deactivated DID');
   }
   const versionNumber = log.length + 1;
-  const createdDate = createDate(options.updated);
+  const createdDate = createNextVersionTime(lastMeta.updated, options.updated, createDate);
   const watchersValue = options.watchers !== undefined ? options.watchers : lastMeta.watchers;
   const witnessInput = options.witness;
   const witness = witnessInput?.witnesses?.length
@@ -588,7 +608,7 @@ export const deactivateDID = async (
     throw new Error('DID already deactivated');
   }
   const versionNumber = log.length + 1;
-  const createdDate = createDate();
+  const createdDate = createNextVersionTime(lastMeta.updated, undefined, createDate);
   const params = {
     updateKeys: options.updateKeys ?? lastMeta.updateKeys,
     deactivated: true,

--- a/src/method_versions/method.v1.0.ts
+++ b/src/method_versions/method.v1.0.ts
@@ -181,7 +181,7 @@ export const createDID = async (options: CreateDIDInterface): Promise<CreateDIDR
 
 export const resolveDIDFromLog = async (
   log: DIDLog,
-  options: ResolutionOptions & { witnessProofs?: WitnessProofFileEntry[]; fastResolve?: boolean } = {}
+  options: ResolutionOptions & { witnessProofs?: WitnessProofFileEntry[] } = {}
 ): Promise<{ did: string; doc: DIDDoc; meta: DIDResolutionMeta }> => {
   if (options.verificationMethod && (options.versionNumber || options.versionId)) {
     throw new Error('Cannot specify both verificationMethod and version number/id');
@@ -215,12 +215,6 @@ export const resolveDIDFromLog = async (
   let previousVersionTime: Date | undefined;
   const resolutionNow = new Date();
   const requiredWitnessChecks: RequiredWitnessCheck[] = [];
-
-  // Fast resolution is opt-in; full verification is the default conformant path.
-  const fastResolve = options.fastResolve ?? false;
-  const isFirstEntry = (idx: number) => idx === 0;
-  const isLastFewEntries = (idx: number) => idx >= resolutionLog.length - 10; // Verify last 10 entries
-  const shouldVerifyEntry = (idx: number) => !fastResolve || isFirstEntry(idx) || isLastFewEntries(idx);
 
   try {
     while (i < resolutionLog.length) {
@@ -259,39 +253,37 @@ export const resolveDIDFromLog = async (
         meta.witness = parameters.witness || meta.witness;
         meta.watchers = parameters.watchers ?? null;
 
-        if (shouldVerifyEntry(i)) {
-          // Optimized: Use efficient object manipulation instead of JSON stringify/parse
-          const logEntry = {
-            versionId: PLACEHOLDER,
-            versionTime: meta.created,
-            parameters: replaceValueInObject(parameters, meta.scid, PLACEHOLDER),
-            state: replaceValueInObject(newDoc, meta.scid, PLACEHOLDER),
-          };
+        // Optimized: Use efficient object manipulation instead of JSON stringify/parse
+        const logEntry = {
+          versionId: PLACEHOLDER,
+          versionTime: meta.created,
+          parameters: replaceValueInObject(parameters, meta.scid, PLACEHOLDER),
+          state: replaceValueInObject(newDoc, meta.scid, PLACEHOLDER),
+        };
 
-          const logEntryHash = await deriveHash(logEntry);
-          meta.previousLogEntryHash = logEntryHash;
-          if (!(await scidIsFromHash(meta.scid, logEntryHash))) {
-            throw new Error(`SCID '${meta.scid}' not derived from logEntryHash '${logEntryHash}'`);
-          }
+        const logEntryHash = await deriveHash(logEntry);
+        meta.previousLogEntryHash = logEntryHash;
+        if (!(await scidIsFromHash(meta.scid, logEntryHash))) {
+          throw new Error(`SCID '${meta.scid}' not derived from logEntryHash '${logEntryHash}'`);
+        }
 
-          if (parsedStateDid.scid !== meta.scid) {
-            throw new Error(`SCID in state.id '${parsedStateDid.scid}' does not match SCID in log '${meta.scid}'`);
-          }
+        if (parsedStateDid.scid !== meta.scid) {
+          throw new Error(`SCID in state.id '${parsedStateDid.scid}' does not match SCID in log '${meta.scid}'`);
+        }
 
-          // Optimized: Direct object manipulation instead of JSON stringify/parse
-          const prelimEntry = replaceValueInObject(logEntry, PLACEHOLDER, meta.scid);
+        // Optimized: Direct object manipulation instead of JSON stringify/parse
+        const prelimEntry = replaceValueInObject(logEntry, PLACEHOLDER, meta.scid);
 
-          const logEntryHash2 = await deriveHash(prelimEntry);
-          const verified = await documentStateIsValid(
-            { ...prelimEntry, versionId: `1-${logEntryHash2}`, proof },
-            meta.updateKeys,
-            meta.witness,
-            false,
-            options.verifier
-          );
-          if (!verified) {
-            throw new Error(`version ${meta.versionId} failed verification of the proof.`);
-          }
+        const logEntryHash2 = await deriveHash(prelimEntry);
+        const verified = await documentStateIsValid(
+          { ...prelimEntry, versionId: `1-${logEntryHash2}`, proof },
+          meta.updateKeys,
+          meta.witness,
+          false,
+          options.verifier
+        );
+        if (!verified) {
+          throw new Error(`version ${meta.versionId} failed verification of the proof.`);
         }
       } else {
         // version number > 1
@@ -313,17 +305,15 @@ export const resolveDIDFromLog = async (
           throw new Error(`Hash chain broken at '${meta.versionId}'`);
         }
 
-        if (shouldVerifyEntry(i)) {
-          // Signature verification — expensive, skipped for middle entries in fast-resolve
-          const keys = meta.prerotation ? (parameters.updateKeys as string[]) : meta.updateKeys;
-          const verified = await documentStateIsValid(resolutionLog[i], keys, meta.witness, false, options.verifier);
-          if (!verified) {
-            throw new Error(`version ${meta.versionId} failed verification of the proof.`);
-          }
+        // Signature verification
+        const keys = meta.prerotation ? (parameters.updateKeys as string[]) : meta.updateKeys;
+        const verified = await documentStateIsValid(resolutionLog[i], keys, meta.witness, false, options.verifier);
+        if (!verified) {
+          throw new Error(`version ${meta.versionId} failed verification of the proof.`);
+        }
 
-          if (meta.prerotation) {
-            await newKeysAreInNextKeys(parameters.updateKeys ?? [], meta.nextKeyHashes ?? []);
-          }
+        if (meta.prerotation) {
+          await newKeysAreInNextKeys(parameters.updateKeys ?? [], meta.nextKeyHashes ?? []);
         }
 
         if (parameters.updateKeys) {
@@ -373,28 +363,25 @@ export const resolveDIDFromLog = async (
       doc = deepClone(newDoc);
       did = requireDidId(doc.id);
 
-      // Only add default services for entries we need to process
-      if (shouldVerifyEntry(i) || i === resolutionLog.length - 1) {
-        // Add default services if they don't exist
-        doc.service = Array.isArray(doc.service) ? doc.service : [];
-        const baseUrl = getBaseUrl(did);
+      // Add default services if they don't exist
+      doc.service = Array.isArray(doc.service) ? doc.service : [];
+      const baseUrl = getBaseUrl(did);
 
-        if (!doc.service.some((s: ServiceEndpoint) => s.id === '#files')) {
-          doc.service.push({
-            id: '#files',
-            type: 'relativeRef',
-            serviceEndpoint: baseUrl,
-          });
-        }
+      if (!doc.service.some((s: ServiceEndpoint) => s.id === '#files')) {
+        doc.service.push({
+          id: '#files',
+          type: 'relativeRef',
+          serviceEndpoint: baseUrl,
+        });
+      }
 
-        if (!doc.service.some((s: ServiceEndpoint) => s.id === '#whois')) {
-          doc.service.push({
-            '@context': 'https://identity.foundation/linked-vp/contexts/v1',
-            id: '#whois',
-            type: 'LinkedVerifiablePresentation',
-            serviceEndpoint: `${baseUrl}/whois.vp`,
-          });
-        }
+      if (!doc.service.some((s: ServiceEndpoint) => s.id === '#whois')) {
+        doc.service.push({
+          '@context': 'https://identity.foundation/linked-vp/contexts/v1',
+          id: '#whois',
+          type: 'LinkedVerifiablePresentation',
+          serviceEndpoint: `${baseUrl}/whois.vp`,
+        });
       }
 
       if (options.verificationMethod && findVerificationMethod(doc, options.verificationMethod)) {

--- a/src/method_versions/method.v1.0.ts
+++ b/src/method_versions/method.v1.0.ts
@@ -43,6 +43,7 @@ import { countVerifiedWitnessApprovals, fetchWitnessProofs, validateWitnessParam
 
 const VERSION = '1.0';
 const PROTOCOL = `did:${METHOD}:${VERSION}`;
+const MAX_FUTURE_SKEW_MS = 5 * 60 * 1000;
 
 const requireDidId = (id: string | undefined): string => {
   if (!id) {
@@ -75,7 +76,7 @@ export const createDID = async (options: CreateDIDInterface): Promise<CreateDIDR
   if (options.created) {
     validateUtcIso8601NotInFuture(options.created, 'createDID created');
   }
-  const createdDate = createDate(options.created);
+  const createdDate = options.created ?? createDate();
 
   // Safety guard: Strip secret keys from verification methods before creating DID document
   const safeVerificationMethods = options.verificationMethods?.map((vm) => {
@@ -213,7 +214,6 @@ export const resolveDIDFromLog = async (
   let i = 0;
   let host = '';
   let previousVersionTime: Date | undefined;
-  const resolutionNow = new Date();
   const requiredWitnessChecks: RequiredWitnessCheck[] = [];
 
   try {
@@ -232,6 +232,11 @@ export const resolveDIDFromLog = async (
       const currentVersionTime = parseUtcIso8601VersionTime(versionTime, `version '${version}' versionTime`);
       if (previousVersionTime && currentVersionTime.getTime() <= previousVersionTime.getTime()) {
         throw new Error(`versionTime for version '${version}' must be greater than previous entry time`);
+      }
+      // Check against resolver's current time for each entry per spec normative language
+      const maxAllowedFutureTime = Date.now() + MAX_FUTURE_SKEW_MS;
+      if (currentVersionTime.getTime() > maxAllowedFutureTime) {
+        throw new Error(`versionTime for version '${version}' must not be more than 5 minutes in the future`);
       }
       previousVersionTime = currentVersionTime;
       meta.updated = versionTime;
@@ -417,10 +422,6 @@ export const resolveDIDFromLog = async (
       i++;
     }
 
-    if (previousVersionTime && previousVersionTime.getTime() >= resolutionNow.getTime()) {
-      throw new Error('versionTime of the last entry must be earlier than current time');
-    }
-
     if (requiredWitnessChecks.length > 0) {
       if (!options.witnessProofs) {
         options.witnessProofs = await fetchWitnessProofs(did);
@@ -497,6 +498,10 @@ export const updateDID = async (
     throw new Error('Cannot update deactivated DID');
   }
   const versionNumber = log.length + 1;
+  // Validate user-provided timestamp with skew tolerance before creating the versionTime
+  if (options.updated) {
+    validateUtcIso8601NotInFuture(options.updated, 'updateDID updated', MAX_FUTURE_SKEW_MS);
+  }
   const createdDate = createNextVersionTime(lastMeta.updated, options.updated, createDate);
   const watchersValue = options.watchers !== undefined ? options.watchers : lastMeta.watchers;
   const witnessInput = options.witness;

--- a/src/method_versions/method.v1.0.ts
+++ b/src/method_versions/method.v1.0.ts
@@ -28,6 +28,7 @@ import {
   generateParallelDidWeb,
   getBaseUrl,
   parseCanonicalAddress,
+  parseDidWebvhIdentifier,
   replaceCreateDidPlaceholders,
   replaceValueInObject,
   validateCreateDidDocument,
@@ -239,11 +240,12 @@ export const resolveDIDFromLog = async (
       previousVersionTime = currentVersionTime;
       meta.updated = versionTime;
       let newDoc = state;
+      const parsedStateDid = parseDidWebvhIdentifier(requireDidId(newDoc.id), `version '${version}' state.id`);
 
       if (version === '1') {
         meta.created = versionTime;
         newDoc = state;
-        host = requireDidId(newDoc.id).split(':').at(-1) ?? '';
+        host = parsedStateDid.locationKey;
         meta.scid = parameters.scid as string;
         if (options.scid && options.scid !== meta.scid) {
           throw new Error(`SCID in DID '${options.scid}' does not match SCID in log '${meta.scid}'`);
@@ -270,6 +272,10 @@ export const resolveDIDFromLog = async (
             throw new Error(`SCID '${meta.scid}' not derived from logEntryHash '${logEntryHash}'`);
           }
 
+          if (parsedStateDid.scid !== meta.scid) {
+            throw new Error(`SCID in state.id '${parsedStateDid.scid}' does not match SCID in log '${meta.scid}'`);
+          }
+
           // Optimized: Direct object manipulation instead of JSON stringify/parse
           const prelimEntry = replaceValueInObject(logEntry, PLACEHOLDER, meta.scid);
 
@@ -287,11 +293,15 @@ export const resolveDIDFromLog = async (
         }
       } else {
         // version number > 1
-        const newHost = requireDidId(newDoc.id).split(':').at(-1) ?? '';
-        if (!meta.portable && newHost !== host) {
+        if (parsedStateDid.scid !== meta.scid) {
+          throw new Error(`SCID in state.id '${parsedStateDid.scid}' does not match SCID in log '${meta.scid}'`);
+        }
+
+        const newLocation = parsedStateDid.locationKey;
+        if (!meta.portable && newLocation !== host) {
           throw new Error('Cannot move DID: portability is disabled');
-        } else if (newHost !== host) {
-          host = newHost;
+        } else if (newLocation !== host) {
+          host = newLocation;
         }
 
         // Hash chain — ALWAYS runs (cheap), even in fast-resolve
@@ -490,6 +500,8 @@ export const updateDID = async (
 ): Promise<UpdateDIDResult> => {
   const log = options.log;
   const lastEntry = log[log.length - 1];
+  const lastEntryDid = requireDidId(lastEntry.state.id);
+  const parsedLastEntryDid = parseDidWebvhIdentifier(lastEntryDid, 'last entry state.id');
   const lastMeta = (await resolveDIDFromLog(log, { verifier: options.verifier, witnessProofs: options.witnessProofs }))
     .meta;
   if (lastMeta.deactivated) {
@@ -530,9 +542,10 @@ export const updateDID = async (
 
   const { doc } = await createDIDDoc({
     ...options,
-    controller: options.controller || lastEntry.state.id || '',
+    controller: options.controller || lastEntryDid,
     context: options.context || lastEntry.state['@context'],
-    domain: options.domain ?? lastEntry.state.id?.split(':').at(-1) ?? '',
+    domain: options.domain ?? parsedLastEntryDid.didDomainComponent,
+    paths: parsedLastEntryDid.paths,
     updateKeys: options.updateKeys ?? [],
     verificationMethods: safeVerificationMethods ?? [],
   });

--- a/src/method_versions/method.v1.0.ts
+++ b/src/method_versions/method.v1.0.ts
@@ -32,6 +32,7 @@ import {
   replaceCreateDidPlaceholders,
   replaceValueInObject,
   validateCreateDidDocument,
+  validateMethodSpecificPathSegments,
 } from '../utils';
 import {
   createNextVersionTime,
@@ -68,6 +69,7 @@ export const createDID = async (options: CreateDIDInterface): Promise<CreateDIDR
   const parsed = parseCanonicalAddress(addressInput);
   const didDomainComponent = parsed.didDomainComponent;
   const allPaths = [...(parsed.paths || []), ...(options.paths || [])];
+  validateMethodSpecificPathSegments(allPaths, 'createDID path segments');
   const path = allPaths.length > 0 ? allPaths.join(':') : undefined;
   const controller = `did:${METHOD}:${PLACEHOLDER}:${didDomainComponent}${path ? `:${path}` : ''}`;
   if (options.created) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -188,6 +188,18 @@ export function validateMethodSpecificPathSegments(pathSegments: string[], conte
     if (decodedSegment.includes('/')) {
       throw new Error(`${context} must not contain decoded slash within a single path segment`);
     }
+
+    if (decodedSegment.includes('\\')) {
+      throw new Error(`${context} must not contain decoded backslash within a path segment`);
+    }
+
+    if (decodedSegment.includes('\u0000')) {
+      throw new Error(`${context} must not contain decoded NUL character within a path segment`);
+    }
+
+    if (decodedSegment !== decodedSegment.trim()) {
+      throw new Error(`${context} must not contain leading or trailing whitespace in decoded path segment`);
+    }
   }
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -134,6 +134,25 @@ function parseEncodedPortComponent(value: string): { host: string; port?: number
   return { host, port: portNum };
 }
 
+export function validateMethodSpecificPathSegments(pathSegments: string[], context: string): void {
+  for (const segment of pathSegments) {
+    let decodedSegment: string;
+    try {
+      decodedSegment = decodeURIComponent(segment);
+    } catch {
+      throw new Error(`${context} contains invalid percent-encoding in path segment '${segment}'`);
+    }
+
+    if (decodedSegment === '.' || decodedSegment === '..') {
+      throw new Error(`${context} must not contain dot-segments`);
+    }
+
+    if (decodedSegment.includes('/')) {
+      throw new Error(`${context} must not contain decoded slash within a single path segment`);
+    }
+  }
+}
+
 export function parseCanonicalAddress(input: string): ParsedAddress {
   if (!input || typeof input !== 'string') {
     throw new Error('Address input must be a non-empty string');
@@ -157,6 +176,8 @@ export function parseCanonicalAddress(input: string): ParsedAddress {
     if (hasFragmentOrQuery(domainPart) || pathParts.some((segment) => hasFragmentOrQuery(segment))) {
       throw new Error('did:webvh identifier must not include query or fragment components');
     }
+
+    validateMethodSpecificPathSegments(pathParts, 'did:webvh identifier');
 
     // Detect double encoding
     if (isDoubleEncoded(domainPart)) {
@@ -213,6 +234,8 @@ export function parseCanonicalAddress(input: string): ParsedAddress {
             pathParts.push(p);
           });
       }
+
+      validateMethodSpecificPathSegments(pathParts, 'URL pathname');
 
       return {
         canonicalHost: host,
@@ -605,21 +628,11 @@ export const getBaseUrl = (id: string) => {
     throw new Error('did:webvh identifier must not include query or fragment components');
   }
 
-  const parts = id.split(':');
-  if (!id.startsWith('did:webvh:') || parts.length < 4) {
-    throw new Error(`${id} is not a valid did:webvh identifier`);
-  }
-
-  const remainder = decodeURIComponent(parts.slice(3).join('/'));
-  const protocol = remainder.includes('localhost') ? 'http' : 'https';
-
-  const [hostPart, ...pathParts] = remainder.split('/');
-  let [host, port] = decodeURIComponent(hostPart).split(':');
-
-  host = toASCII(host.normalize('NFC'));
-
-  const normalizedHost = port ? `${host}:${port}` : host;
-  const path = pathParts.join('/');
+  const parsed = parseCanonicalAddress(id);
+  const protocol = parsed.canonicalHost === 'localhost' ? 'http' : 'https';
+  const host = toASCII(parsed.canonicalHost.normalize('NFC'));
+  const normalizedHost = parsed.canonicalPort ? `${host}:${parsed.canonicalPort}` : host;
+  const path = parsed.paths?.join('/') ?? '';
 
   return `${protocol}://${normalizedHost}${path ? `/${path}` : ''}`;
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 import { config } from './config';
-import { BASE_CONTEXT } from './constants';
+import { BASE_CONTEXT, METHOD } from './constants';
 import type {
   CreateDIDInterface,
   DIDDoc,
@@ -79,6 +79,13 @@ interface ParsedAddress {
   canonicalPort?: number;
   didDomainComponent: string;
   paths?: string[];
+}
+
+export interface ParsedDidWebvhIdentifier {
+  scid: string;
+  didDomainComponent: string;
+  paths?: string[];
+  locationKey: string;
 }
 
 function isIPAddress(host: string): boolean {
@@ -232,6 +239,31 @@ export function parseCanonicalAddress(input: string): ParsedAddress {
     canonicalHost: host,
     canonicalPort: port,
     didDomainComponent,
+  };
+}
+
+export function parseDidWebvhIdentifier(did: string, context: string): ParsedDidWebvhIdentifier {
+  const parsedAddress = parseCanonicalAddress(did);
+  const didParts = did.split(':');
+
+  if (didParts.length < 4 || didParts[0] !== 'did' || didParts[1] !== METHOD) {
+    throw new Error(`${context} must be a valid did:webvh identifier`);
+  }
+
+  const scid = didParts[2];
+  if (!scid) {
+    throw new Error(`${context} must include SCID segment`);
+  }
+
+  const locationKey = parsedAddress.paths?.length
+    ? `${parsedAddress.didDomainComponent}:${parsedAddress.paths.join(':')}`
+    : parsedAddress.didDomainComponent;
+
+  return {
+    scid,
+    didDomainComponent: parsedAddress.didDomainComponent,
+    paths: parsedAddress.paths,
+    locationKey,
   };
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -17,6 +17,8 @@ import { createMultihash, encodeBase58Btc, MultihashAlgorithm, multibaseDecode }
 
 const DID_KEY_PREFIX = 'did:key:';
 
+// did:key parsing helpers
+
 function validateDidKeyMultibase(keyMultibase: string): void {
   if (!keyMultibase) {
     throw new Error('Malformed did:key identifier');
@@ -114,6 +116,47 @@ function decodeHostComponent(host: string): string {
   }
 }
 
+function parsePortNumber(rawPort: string): number {
+  const portNum = parseInt(rawPort, 10);
+  if (Number.isNaN(portNum) || portNum <= 0 || portNum > 65535) {
+    throw new Error(`Invalid port number: ${rawPort}`);
+  }
+  return portNum;
+}
+
+function toOptionalPaths(pathSegments: string[]): string[] | undefined {
+  return pathSegments.length > 0 ? pathSegments : undefined;
+}
+
+function toDidDomainComponent(host: string, port?: number): string {
+  return port ? `${host}%3A${port}` : host;
+}
+
+function toParsedAddress(host: string, port?: number, paths: string[] = []): ParsedAddress {
+  return {
+    canonicalHost: host,
+    canonicalPort: port,
+    didDomainComponent: toDidDomainComponent(host, port),
+    paths: toOptionalPaths(paths),
+  };
+}
+
+function parseRawHostPort(input: string): { host: string; port?: number } {
+  if (!input.includes(':')) {
+    return { host: input };
+  }
+
+  const parts = input.split(':');
+  if (parts.length !== 2) {
+    throw new Error('Invalid host:port format');
+  }
+
+  return {
+    host: parts[0],
+    port: parsePortNumber(parts[1]),
+  };
+}
+
 function parseEncodedPortComponent(value: string): { host: string; port?: number } {
   const encodedSeparator = /%3a/i;
   if (!encodedSeparator.test(value)) {
@@ -126,12 +169,7 @@ function parseEncodedPortComponent(value: string): { host: string; port?: number
   }
 
   const [host, rawPort] = parts;
-  const portNum = parseInt(rawPort, 10);
-  if (Number.isNaN(portNum) || portNum <= 0 || portNum > 65535) {
-    throw new Error(`Invalid port number: ${rawPort}`);
-  }
-
-  return { host, port: portNum };
+  return { host, port: parsePortNumber(rawPort) };
 }
 
 export function validateMethodSpecificPathSegments(pathSegments: string[], context: string): void {
@@ -169,7 +207,6 @@ export function parseCanonicalAddress(input: string): ParsedAddress {
       throw new Error('Invalid did:webvh identifier: must contain SCID (or {SCID} placeholder) and domain');
     }
 
-    const scid = parts[0];
     const domainPart = parts[1];
     const pathParts = parts.slice(2);
 
@@ -193,22 +230,15 @@ export function parseCanonicalAddress(input: string): ParsedAddress {
       throw new Error('IP addresses are not allowed as hosts');
     }
 
-    const canonicalDomainPart = port ? `${host}%3A${port}` : host;
-
-    return {
-      canonicalHost: host,
-      canonicalPort: port,
-      didDomainComponent: canonicalDomainPart,
-      paths: pathParts.length > 0 ? pathParts : undefined,
-    };
+    return toParsedAddress(host, port, pathParts);
   }
 
-  // Parse URL form: HTTPS everywhere, with localhost-only HTTP for local testing.
+  // Parse URL form: HTTPS everywhere.
   if (input.startsWith('https://') || input.startsWith('http://')) {
     try {
       const url = new URL(input);
-      if (url.protocol === 'http:' && url.hostname !== 'localhost') {
-        throw new Error('HTTP is only allowed for localhost; use HTTPS for non-local hosts');
+      if (url.protocol === 'http:') {
+        throw new Error('HTTP is not allowed; use HTTPS');
       }
       if (url.hash || url.search) {
         throw new Error('URL input must not include query or fragment components');
@@ -220,29 +250,11 @@ export function parseCanonicalAddress(input: string): ParsedAddress {
         throw new Error('IP addresses are not allowed as hosts');
       }
 
-      let didDomainComponent = host;
-      if (port) {
-        didDomainComponent += `%3A${port}`;
-      }
-
-      const pathParts: string[] = [];
-      if (url.pathname && url.pathname !== '/') {
-        url.pathname
-          .split('/')
-          .filter((p) => p.length > 0)
-          .forEach((p) => {
-            pathParts.push(p);
-          });
-      }
+      const pathParts = url.pathname && url.pathname !== '/' ? url.pathname.split('/').filter((p) => p.length > 0) : [];
 
       validateMethodSpecificPathSegments(pathParts, 'URL pathname');
 
-      return {
-        canonicalHost: host,
-        canonicalPort: port,
-        didDomainComponent,
-        paths: pathParts.length > 0 ? pathParts : undefined,
-      };
+      return toParsedAddress(host, port, pathParts);
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
       if (message.includes('not allowed')) throw e;
@@ -256,48 +268,19 @@ export function parseCanonicalAddress(input: string): ParsedAddress {
     throw new Error('Domain is double-encoded (detected %25)');
   }
 
-  let host = input;
-  let port: number | undefined;
-
   if (hasFragmentOrQuery(input)) {
     throw new Error('Domain input must not include query or fragment components');
   }
 
-  // Check if pre-encoded with %3A
-  if (/%3a/i.test(input)) {
-    const parsedPort = parseEncodedPortComponent(input);
-    host = parsedPort.host;
-    port = parsedPort.port;
-  } else if (input.includes(':')) {
-    // Raw host:port form
-    const parts = input.split(':');
-    if (parts.length !== 2) {
-      throw new Error('Invalid host:port format');
-    }
-    host = parts[0];
-    const portNum = parseInt(parts[1], 10);
-    if (Number.isNaN(portNum) || portNum <= 0 || portNum > 65535) {
-      throw new Error(`Invalid port number: ${parts[1]}`);
-    }
-    port = portNum;
-  }
-
-  host = decodeHostComponent(host);
+  const hostAndPort = /%3a/i.test(input) ? parseEncodedPortComponent(input) : parseRawHostPort(input);
+  const host = decodeHostComponent(hostAndPort.host);
+  const port = hostAndPort.port;
 
   if (isIPAddress(host)) {
     throw new Error('IP addresses are not allowed as hosts');
   }
 
-  let didDomainComponent = host;
-  if (port) {
-    didDomainComponent += `%3A${port}`;
-  }
-
-  return {
-    canonicalHost: host,
-    canonicalPort: port,
-    didDomainComponent,
-  };
+  return toParsedAddress(host, port);
 }
 
 export function parseDidWebvhIdentifier(did: string, context: string): ParsedDidWebvhIdentifier {
@@ -324,6 +307,40 @@ export function parseDidWebvhIdentifier(did: string, context: string): ParsedDid
     locationKey,
   };
 }
+
+// URL and DID document helper utilities
+
+const toASCII = (domain: string): string => {
+  try {
+    return new URL(`https://${domain}`).hostname;
+  } catch {
+    return domain;
+  }
+};
+
+export const getBaseUrl = (id: string) => {
+  if (hasFragmentOrQuery(id)) {
+    throw new Error('did:webvh identifier must not include query or fragment components');
+  }
+
+  const parsed = parseCanonicalAddress(id);
+  const protocol = 'https';
+  const host = toASCII(parsed.canonicalHost.normalize('NFC'));
+  const normalizedHost = parsed.canonicalPort ? `${host}:${parsed.canonicalPort}` : host;
+  const path = parsed.paths?.join('/') ?? '';
+
+  return `${protocol}://${normalizedHost}${path ? `/${path}` : ''}`;
+};
+
+export const getFileUrl = (id: string) => {
+  const baseUrl = getBaseUrl(id);
+  const domainEndIndex = baseUrl.indexOf('/', baseUrl.indexOf('://') + 3);
+
+  if (domainEndIndex !== -1) {
+    return `${baseUrl}/did.jsonl`;
+  }
+  return `${baseUrl}/.well-known/did.jsonl`;
+};
 
 type ProcessVersionsLike = { node?: string; bun?: string };
 
@@ -397,15 +414,6 @@ const getFS = async (): Promise<FsModule> => {
   })();
 
   return fsImportPromise;
-};
-
-const toASCII = (domain: string): string => {
-  try {
-    const scheme = domain.includes('localhost') ? 'http' : 'https';
-    return new URL(`${scheme}://${domain}`).hostname;
-  } catch {
-    return domain;
-  }
 };
 
 export const DID_PLACEHOLDER = '{DID}';
@@ -509,16 +517,19 @@ export function generateParallelDidWeb(didwebvhDid: string, didwebvhDoc: DIDDoc)
   };
 }
 
+// Filesystem and log IO helpers
+
+function parseDidLogText(text: string): DIDLog {
+  return text.split('\n').map((line) => JSON.parse(line));
+}
+
 export const readLogFromDisk = async (path: string): Promise<DIDLog> => {
   const fs = await getFS();
   return readLogFromString(fs.readFileSync(path, 'utf8'));
 };
 
 export const readLogFromString = (str: string): DIDLog => {
-  return str
-    .trim()
-    .split('\n')
-    .map((l) => JSON.parse(l));
+  return parseDidLogText(str.trim());
 };
 
 export const writeLogToDisk = async (path: string, log: DIDLog) => {
@@ -623,30 +634,6 @@ export function deepClone<T>(obj: T): T {
   return cloned as T;
 }
 
-export const getBaseUrl = (id: string) => {
-  if (hasFragmentOrQuery(id)) {
-    throw new Error('did:webvh identifier must not include query or fragment components');
-  }
-
-  const parsed = parseCanonicalAddress(id);
-  const protocol = parsed.canonicalHost === 'localhost' ? 'http' : 'https';
-  const host = toASCII(parsed.canonicalHost.normalize('NFC'));
-  const normalizedHost = parsed.canonicalPort ? `${host}:${parsed.canonicalPort}` : host;
-  const path = parsed.paths?.join('/') ?? '';
-
-  return `${protocol}://${normalizedHost}${path ? `/${path}` : ''}`;
-};
-
-export const getFileUrl = (id: string) => {
-  const baseUrl = getBaseUrl(id);
-  const domainEndIndex = baseUrl.indexOf('/', baseUrl.indexOf('://') + 3);
-
-  if (domainEndIndex !== -1) {
-    return `${baseUrl}/did.jsonl`;
-  }
-  return `${baseUrl}/.well-known/did.jsonl`;
-};
-
 export async function fetchLogFromIdentifier(identifier: string, controlled: boolean = false): Promise<DIDLog> {
   try {
     if (controlled) {
@@ -667,7 +654,7 @@ export async function fetchLogFromIdentifier(identifier: string, controlled: boo
         if (!text) {
           return [];
         }
-        return text.split('\n').map((line) => JSON.parse(line));
+        return parseDidLogText(text);
       } catch (error) {
         throw new Error(`Error reading local DID log: ${error}`);
       }
@@ -683,7 +670,7 @@ export async function fetchLogFromIdentifier(identifier: string, controlled: boo
     if (!text) {
       throw new Error(`DID log not found for ${identifier}`);
     }
-    return text.split('\n').map((line) => JSON.parse(line));
+    return parseDidLogText(text);
   } catch (error) {
     console.error('Error fetching DID log:', error);
     throw error;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -606,7 +606,7 @@ export async function fetchLogFromIdentifier(identifier: string, controlled: boo
   }
 }
 
-export const createDate = (created?: Date | string) => `${new Date(created ?? Date.now()).toISOString().slice(0, -5)}Z`;
+export const createDate = (created?: Date | string) => new Date(created ?? Date.now()).toISOString();
 
 export function bytesToHex(bytes: Uint8Array): string {
   return Array.from(bytes)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -102,9 +102,45 @@ function isDoubleEncoded(value: string): boolean {
   return value.includes('%25');
 }
 
+function hasFragmentOrQuery(value: string): boolean {
+  return value.includes('#') || value.includes('?');
+}
+
+function decodeHostComponent(host: string): string {
+  try {
+    return decodeURIComponent(host);
+  } catch {
+    throw new Error(`Invalid percent-encoding in host: ${host}`);
+  }
+}
+
+function parseEncodedPortComponent(value: string): { host: string; port?: number } {
+  const encodedSeparator = /%3a/i;
+  if (!encodedSeparator.test(value)) {
+    return { host: value };
+  }
+
+  const parts = value.split(encodedSeparator);
+  if (parts.length !== 2) {
+    throw new Error('Invalid pre-encoded port separator');
+  }
+
+  const [host, rawPort] = parts;
+  const portNum = parseInt(rawPort, 10);
+  if (Number.isNaN(portNum) || portNum <= 0 || portNum > 65535) {
+    throw new Error(`Invalid port number: ${rawPort}`);
+  }
+
+  return { host, port: portNum };
+}
+
 export function parseCanonicalAddress(input: string): ParsedAddress {
   if (!input || typeof input !== 'string') {
     throw new Error('Address input must be a non-empty string');
+  }
+
+  if (hasFragmentOrQuery(input) && !input.startsWith('http://') && !input.startsWith('https://')) {
+    throw new Error('Address input must not include query or fragment components');
   }
 
   // Parse did:webvh form
@@ -118,33 +154,30 @@ export function parseCanonicalAddress(input: string): ParsedAddress {
     const domainPart = parts[1];
     const pathParts = parts.slice(2);
 
+    if (hasFragmentOrQuery(domainPart) || pathParts.some((segment) => hasFragmentOrQuery(segment))) {
+      throw new Error('did:webvh identifier must not include query or fragment components');
+    }
+
     // Detect double encoding
     if (isDoubleEncoded(domainPart)) {
       throw new Error('Domain is double-encoded (detected %25)');
     }
 
     // Extract port from domain if %3A-encoded
-    let host = domainPart;
-    let port: number | undefined;
-
-    if (domainPart.includes('%3A')) {
-      const [h, p] = domainPart.split('%3A');
-      host = h;
-      const portNum = parseInt(p, 10);
-      if (Number.isNaN(portNum) || portNum <= 0 || portNum > 65535) {
-        throw new Error(`Invalid port number: ${p}`);
-      }
-      port = portNum;
-    }
+    const parsedPort = parseEncodedPortComponent(domainPart);
+    const host = decodeHostComponent(parsedPort.host);
+    const port = parsedPort.port;
 
     if (isIPAddress(host)) {
       throw new Error('IP addresses are not allowed as hosts');
     }
 
+    const canonicalDomainPart = port ? `${host}%3A${port}` : host;
+
     return {
       canonicalHost: host,
       canonicalPort: port,
-      didDomainComponent: domainPart,
+      didDomainComponent: canonicalDomainPart,
       paths: pathParts.length > 0 ? pathParts : undefined,
     };
   }
@@ -155,6 +188,9 @@ export function parseCanonicalAddress(input: string): ParsedAddress {
       const url = new URL(input);
       if (url.protocol === 'http:' && url.hostname !== 'localhost') {
         throw new Error('HTTP is only allowed for localhost; use HTTPS for non-local hosts');
+      }
+      if (url.hash || url.search) {
+        throw new Error('URL input must not include query or fragment components');
       }
       const host = url.hostname;
       const port = url.port ? parseInt(url.port, 10) : undefined;
@@ -200,18 +236,15 @@ export function parseCanonicalAddress(input: string): ParsedAddress {
   let host = input;
   let port: number | undefined;
 
+  if (hasFragmentOrQuery(input)) {
+    throw new Error('Domain input must not include query or fragment components');
+  }
+
   // Check if pre-encoded with %3A
-  if (input.includes('%3A')) {
-    const parts = input.split('%3A');
-    if (parts.length !== 2) {
-      throw new Error('Invalid pre-encoded port separator');
-    }
-    host = parts[0];
-    const portNum = parseInt(parts[1], 10);
-    if (Number.isNaN(portNum) || portNum <= 0 || portNum > 65535) {
-      throw new Error(`Invalid port number: ${parts[1]}`);
-    }
-    port = portNum;
+  if (/%3a/i.test(input)) {
+    const parsedPort = parseEncodedPortComponent(input);
+    host = parsedPort.host;
+    port = parsedPort.port;
   } else if (input.includes(':')) {
     // Raw host:port form
     const parts = input.split(':');
@@ -225,6 +258,8 @@ export function parseCanonicalAddress(input: string): ParsedAddress {
     }
     port = portNum;
   }
+
+  host = decodeHostComponent(host);
 
   if (isIPAddress(host)) {
     throw new Error('IP addresses are not allowed as hosts');
@@ -566,6 +601,10 @@ export function deepClone<T>(obj: T): T {
 }
 
 export const getBaseUrl = (id: string) => {
+  if (hasFragmentOrQuery(id)) {
+    throw new Error('did:webvh identifier must not include query or fragment components');
+  }
+
   const parts = id.split(':');
   if (!id.startsWith('did:webvh:') || parts.length < 4) {
     throw new Error(`${id} is not a valid did:webvh identifier`);

--- a/src/utils/iso8601-datetime.ts
+++ b/src/utils/iso8601-datetime.ts
@@ -1,0 +1,132 @@
+/**
+ * ISO 8601 DateTime Validation
+ *
+ * Inlined from iso-8601-regex (https://github.com/lightningspirit/iso-8601-regex-ts)
+ * Licensed under MIT by lightningspirit
+ *
+ * Enforces strict calendar correctness including leap-year rules and valid day ranges.
+ */
+
+/**
+ * Strict ISO 8601 datetime regex with full calendar validation.
+ *
+ * Enforces:
+ * - Year: 0000–9999
+ * - Month: 01–12
+ * - Day: per month (01–31, 30-day months restricted, Feb 29 allowed only on leap years)
+ * - Hour: 00–23
+ * - Minute: 00–59
+ * - Second: 00–59
+ * - Milliseconds: optional, 1–3 digits
+ * - Timezone: "Z" (UTC) or ±HH:MM (offset -12:00…+14:00)
+ *
+ * Leap-year logic (Gregorian calendar):
+ * - Divisible by 4 → leap year
+ * - Divisible by 100 → not a leap year
+ * - Divisible by 400 → leap year again
+ *
+ * Format: YYYY-MM-DDTHH:mm:ss(.SSS)?(Z|±HH:MM)
+ *
+ * Valid examples:
+ * - "2025-11-02T10:20:30Z"           // UTC
+ * - "2025-11-02T10:20:30.123Z"       // With milliseconds
+ * - "2025-11-02T10:20:30+01:00"      // With positive offset
+ * - "2024-02-29T12:00:00Z"           // Leap year (Feb 29 allowed)
+ *
+ * Invalid examples:
+ * - "2025-11-02T10:20:30"            // Missing timezone
+ * - "2025-04-31T12:00:00Z"           // Invalid day for April
+ * - "1900-02-29T00:00:00Z"           // 1900 not a leap year
+ * - "2025-11-02T24:00:00Z"           // Invalid hour
+ */
+export const ISO8601_DATETIME_REGEX = new RegExp(
+  '^' +
+    '(?<year>\\d{4})-' +
+    '(?<month>(?:0[1-9]|1[0-2]))-' +
+    '(?<day>' +
+    '(?:' +
+    '(?<=\\d{4}-(?:01|03|05|07|08|10|12)-)(?:0[1-9]|[12]\\d|3[01])|' + // 31-day months
+    '(?<=\\d{4}-(?:04|06|09|11)-)(?:0[1-9]|[12]\\d|30)|' + // 30-day months
+    '(?<=\\d{4}-02-)(?:0[1-9]|1\\d|2[0-8])|' + // Feb 01-28
+    '(?<=(' +
+    '(?:\\d{2}(?:0[48]|[2468][048]|[13579][26]))' + // yy % 4 == 0 (leap year non-century)
+    '|(?:(?:[02468][048]|[13579][26])00)' + // centuries % 400 == 0 (leap year century)
+    ')-02-)29' + // Feb 29 only if preceding matches leap year
+    ')' +
+    ')' +
+    'T' +
+    '(?<hour>(?:[01]\\d|2[0-3])):' +
+    '(?<minute>[0-5]\\d):' +
+    '(?<second>[0-5]\\d)' +
+    '(?:\\.(?<millisecond>\\d{1,3}))?' + // optional .sss
+    '(?<timezone>' +
+    'Z|' + // UTC
+    '(?:' +
+    '\\+(?:(?:0\\d|1[0-3]):[0-5]\\d|14:00)|' + // +00:00…+13:59 or +14:00
+    '-(?:(?:0\\d|1[01]):[0-5]\\d|12:00)' + // -00:00…-11:59 or -12:00
+    ')' +
+    ')' +
+    '$'
+);
+
+/**
+ * Validate XSD dateTimeStamp format per W3C XMLSCHEMA11-2.
+ *
+ * Requires timezone component (Z or ±HH:MM offset) with full calendar validation.
+ * Falls back to Date.parse() for semantic correctness.
+ *
+ * Spec reference: did:webvh v1.0 §3.5 and §3.6.2 (`versionTime` in UTC ISO8601)
+ * https://identity.foundation/didwebvh/v1.0/
+ */
+export function isXsdDateTimeStamp(value: string): boolean {
+  if (!ISO8601_DATETIME_REGEX.test(value)) {
+    return false;
+  }
+
+  return !Number.isNaN(Date.parse(value));
+}
+
+export function parseUtcIso8601VersionTime(value: string, context: string): Date {
+  if (!isXsdDateTimeStamp(value) || !value.endsWith('Z')) {
+    throw new Error(`${context} must be a valid UTC ISO8601 timestamp`);
+  }
+
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error(`${context} must be a valid UTC ISO8601 timestamp`);
+  }
+
+  return parsed;
+}
+
+export function validateUtcIso8601NotInFuture(value: string, context: string, now: Date = new Date()): Date {
+  const parsed = parseUtcIso8601VersionTime(value, context);
+  if (parsed.getTime() > now.getTime()) {
+    throw new Error(`${context} must not be in the future`);
+  }
+
+  return parsed;
+}
+
+export function createNextVersionTime(
+  previousVersionTime: string,
+  requestedVersionTime: string | undefined,
+  formatDate: (value: string | Date) => string
+): string {
+  const previous = parseUtcIso8601VersionTime(previousVersionTime, 'previous versionTime');
+
+  if (requestedVersionTime) {
+    const requested = validateUtcIso8601NotInFuture(requestedVersionTime, 'updateDID updated');
+    if (requested.getTime() <= previous.getTime()) {
+      throw new Error('updateDID updated must be greater than previous versionTime');
+    }
+    return formatDate(requestedVersionTime);
+  }
+
+  const now = new Date();
+  if (now.getTime() <= previous.getTime()) {
+    return formatDate(new Date(previous.getTime() + 1));
+  }
+
+  return formatDate(now);
+}

--- a/src/utils/iso8601-datetime.ts
+++ b/src/utils/iso8601-datetime.ts
@@ -70,32 +70,22 @@ export const ISO8601_DATETIME_REGEX = new RegExp(
 );
 
 /**
- * Validate XSD dateTimeStamp format per W3C XMLSCHEMA11-2.
+ * Parse and validate UTC ISO8601 versionTime per did:webvh spec.
  *
- * Requires timezone component (Z or ±HH:MM offset) with full calendar validation.
- * Falls back to Date.parse() for semantic correctness.
+ * Enforces:
+ * - Strict ISO 8601 format with calendar correctness (via regex)
+ * - Timezone component required (Z or ±HH:MM offset)
+ * - Semantic date validity (via Date.parse)
  *
  * Spec reference: did:webvh v1.0 §3.5 and §3.6.2 (`versionTime` in UTC ISO8601)
  * https://identity.foundation/didwebvh/v1.0/
  */
-export function isXsdDateTimeStamp(value: string): boolean {
-  if (!ISO8601_DATETIME_REGEX.test(value)) {
-    return false;
-  }
-
-  return !Number.isNaN(Date.parse(value));
-}
-
 export function parseUtcIso8601VersionTime(value: string, context: string): Date {
-  if (!isXsdDateTimeStamp(value) || !value.endsWith('Z')) {
-    throw new Error(`${context} must be a valid UTC ISO8601 timestamp`);
-  }
-
+  const match = ISO8601_DATETIME_REGEX.exec(value);
   const parsed = new Date(value);
-  if (Number.isNaN(parsed.getTime())) {
+  if (!match || Number.isNaN(parsed.getTime())) {
     throw new Error(`${context} must be a valid UTC ISO8601 timestamp`);
   }
-
   return parsed;
 }
 

--- a/src/utils/iso8601-datetime.ts
+++ b/src/utils/iso8601-datetime.ts
@@ -89,9 +89,17 @@ export function parseUtcIso8601VersionTime(value: string, context: string): Date
   return parsed;
 }
 
-export function validateUtcIso8601NotInFuture(value: string, context: string, now: Date = new Date()): Date {
+export function validateUtcIso8601NotInFuture(
+  value: string,
+  context: string,
+  maxFutureSkewMs: number = 0,
+  now: Date = new Date()
+): Date {
   const parsed = parseUtcIso8601VersionTime(value, context);
-  if (parsed.getTime() > now.getTime()) {
+  if (parsed.getTime() > now.getTime() + maxFutureSkewMs) {
+    if (maxFutureSkewMs > 0) {
+      throw new Error(`${context} must not be more than ${maxFutureSkewMs / 60000} minutes in the future`);
+    }
     throw new Error(`${context} must not be in the future`);
   }
 
@@ -106,9 +114,9 @@ export function createNextVersionTime(
   const previous = parseUtcIso8601VersionTime(previousVersionTime, 'previous versionTime');
 
   if (requestedVersionTime) {
-    const requested = validateUtcIso8601NotInFuture(requestedVersionTime, 'updateDID updated');
+    const requested = parseUtcIso8601VersionTime(requestedVersionTime, 'requested versionTime');
     if (requested.getTime() <= previous.getTime()) {
-      throw new Error('updateDID updated must be greater than previous versionTime');
+      throw new Error('versionTime must be greater than previous versionTime');
     }
     return formatDate(requestedVersionTime);
   }

--- a/src/utils/iso8601-datetime.ts
+++ b/src/utils/iso8601-datetime.ts
@@ -74,7 +74,7 @@ export const ISO8601_DATETIME_REGEX = new RegExp(
  *
  * Enforces:
  * - Strict ISO 8601 format with calendar correctness (via regex)
- * - Timezone component required (Z or ±HH:MM offset)
+ * - Timezone MUST be explicit Z or +00:00 (per normative spec language)
  * - Semantic date validity (via Date.parse)
  *
  * Spec reference: did:webvh v1.0 §3.5 and §3.6.2 (`versionTime` in UTC ISO8601)
@@ -86,6 +86,13 @@ export function parseUtcIso8601VersionTime(value: string, context: string): Date
   if (!match || Number.isNaN(parsed.getTime())) {
     throw new Error(`${context} must be a valid UTC ISO8601 timestamp`);
   }
+
+  // Per spec, only Z or +00:00 (explicit UTC) are allowed
+  const timezone = match.groups?.timezone;
+  if (timezone && timezone !== 'Z' && timezone !== '+00:00') {
+    throw new Error(`${context} must be in UTC (Z or +00:00), found ${timezone}`);
+  }
+
   return parsed;
 }
 

--- a/test/domain-encoding.test.ts
+++ b/test/domain-encoding.test.ts
@@ -148,4 +148,28 @@ describe('Strict address input validation and parsing', () => {
   test('Rejects mangled URL input', async () => {
     expect(createFromInput('address', 'https://%%%bad host%%%::notaport::/%%%')).rejects.toThrow();
   });
+
+  test('Rejects decoded backslash in path segment', async () => {
+    expect(createFromInput('address', 'did:webvh:{SCID}:example.com:test%5Csecret')).rejects.toThrow(
+      'did:webvh identifier must not contain decoded backslash within a path segment'
+    );
+  });
+
+  test('Rejects decoded NUL in path segment', async () => {
+    expect(createFromInput('address', 'did:webvh:{SCID}:example.com:test%00secret')).rejects.toThrow(
+      'did:webvh identifier must not contain decoded NUL character within a path segment'
+    );
+  });
+
+  test('Rejects leading whitespace in decoded path segment', async () => {
+    expect(createFromInput('address', 'did:webvh:{SCID}:example.com:%20test')).rejects.toThrow(
+      'did:webvh identifier must not contain leading or trailing whitespace in decoded path segment'
+    );
+  });
+
+  test('Rejects trailing whitespace in decoded path segment', async () => {
+    expect(createFromInput('address', 'did:webvh:{SCID}:example.com:test%20')).rejects.toThrow(
+      'did:webvh identifier must not contain leading or trailing whitespace in decoded path segment'
+    );
+  });
 });

--- a/test/domain-encoding.test.ts
+++ b/test/domain-encoding.test.ts
@@ -69,9 +69,8 @@ describe('Strict address input validation and parsing', () => {
     expect(doc.id).toMatch(/^did:webvh:[^:]+:example\.com:custom:path$/);
   });
 
-  test('Accepts localhost HTTP URL with path and port', async () => {
-    const { doc } = await createFromInput('address', 'http://localhost:8000/test');
-    expect(doc.id).toMatch(/^did:webvh:[^:]+:localhost%3A8000:test$/);
+  test('Rejects localhost HTTP URL with path and port', async () => {
+    expect(createFromInput('address', 'http://localhost:8000/test')).rejects.toThrow('HTTP is not allowed; use HTTPS');
   });
 
   test('Accepts localhost HTTPS URL with path and port', async () => {

--- a/test/domain-encoding.test.ts
+++ b/test/domain-encoding.test.ts
@@ -49,6 +49,11 @@ describe('Strict address input validation and parsing', () => {
     expect(doc.id).toMatch(/^did:webvh:[^:]+:localhost%3A8000$/);
   });
 
+  test('Accepts pre-encoded host%3aport with lowercase separator and canonicalizes output', async () => {
+    const { doc } = await createFromInput('domain', 'localhost%3a8000');
+    expect(doc.id).toMatch(/^did:webvh:[^:]+:localhost%3A8000$/);
+  });
+
   test('Accepts https URL address input', async () => {
     const { doc } = await createFromInput('address', 'https://example.com/');
     expect(doc.id).toMatch(/^did:webvh:[^:]+:example\.com$/);
@@ -93,6 +98,26 @@ describe('Strict address input validation and parsing', () => {
 
   test('Rejects IPv4 host input', async () => {
     expect(createFromInput('domain', '192.168.1.10')).rejects.toThrow();
+  });
+
+  test('Rejects encoded IPv4 host input', async () => {
+    expect(createFromInput('domain', '127%2E0%2E0%2E1')).rejects.toThrow('IP addresses are not allowed as hosts');
+  });
+
+  test('Rejects lowercase encoded-port IP host input', async () => {
+    expect(createFromInput('domain', '127.0.0.1%3a8080')).rejects.toThrow('IP addresses are not allowed as hosts');
+  });
+
+  test('Rejects did:webvh input containing fragment contamination', async () => {
+    expect(createFromInput('address', 'did:webvh:{SCID}:example.com#frag')).rejects.toThrow(
+      'Address input must not include query or fragment components'
+    );
+  });
+
+  test('Rejects did:webvh input containing query contamination', async () => {
+    expect(createFromInput('address', 'did:webvh:{SCID}:example.com?query=1')).rejects.toThrow(
+      'Address input must not include query or fragment components'
+    );
   });
 
   test('Rejects double-encoded separator', async () => {

--- a/test/domain-encoding.test.ts
+++ b/test/domain-encoding.test.ts
@@ -120,6 +120,24 @@ describe('Strict address input validation and parsing', () => {
     );
   });
 
+  test('Rejects did:webvh input containing dot-segment path traversal', async () => {
+    expect(createFromInput('address', 'did:webvh:{SCID}:example.com:..:secrets')).rejects.toThrow(
+      'did:webvh identifier must not contain dot-segments'
+    );
+  });
+
+  test('Rejects did:webvh input containing percent-encoded traversal segment', async () => {
+    expect(createFromInput('address', 'did:webvh:{SCID}:example.com:%2E%2E:secrets')).rejects.toThrow(
+      'did:webvh identifier must not contain dot-segments'
+    );
+  });
+
+  test('Rejects did:webvh input containing decoded slash within one path segment', async () => {
+    expect(createFromInput('address', 'did:webvh:{SCID}:example.com:a%2Fb')).rejects.toThrow(
+      'did:webvh identifier must not contain decoded slash within a single path segment'
+    );
+  });
+
   test('Rejects double-encoded separator', async () => {
     expect(createFromInput('domain', 'example.com%253A8080')).rejects.toThrow();
   });

--- a/test/iso8601-datetime.test.ts
+++ b/test/iso8601-datetime.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from 'bun:test';
+import { parseUtcIso8601VersionTime } from '../src/utils/iso8601-datetime';
+
+describe('ISO8601 DateTime Validation', () => {
+  test('Accepts Z timezone', () => {
+    const result = parseUtcIso8601VersionTime('2025-11-02T10:20:30Z', 'test');
+    expect(result).toBeInstanceOf(Date);
+  });
+
+  test('Rejects non-00:00 UTC offset', () => {
+    expect(() => {
+      parseUtcIso8601VersionTime('2025-11-02T10:20:30+01:00', 'test');
+    }).toThrow('must be in UTC (Z or +00:00), found +01:00');
+  });
+});

--- a/test/not-so-happy-path.test.ts
+++ b/test/not-so-happy-path.test.ts
@@ -4,6 +4,7 @@ import { createDID, resolveDIDFromLog, updateDID } from '../src/method';
 import { resolveDIDFromLog as resolveDIDFromLogV1 } from '../src/method_versions/method.v1.0';
 import {
   asPublicVerificationMethods,
+  createFutureDIDLog,
   createTestSigner,
   generateTestVerificationMethod,
   TestCryptoImplementation,
@@ -41,6 +42,20 @@ describe('Not So Happy Path Tests', () => {
         verifier: testImplementation,
       })
     ).rejects.toThrow(`SCID '${originalSCID}tampered' not derived from logEntryHash`);
+  });
+
+  test('Accepts a versionTime up to 5 minutes in the future', async () => {
+    const futureLog = await createFutureDIDLog(authKey, 4);
+
+    await expect(resolveDIDFromLog(futureLog, { verifier: testImplementation })).resolves.toBeDefined();
+  });
+
+  test('Rejects a versionTime more than 5 minutes in the future', async () => {
+    const futureLog = await createFutureDIDLog(authKey, 6);
+
+    await expect(resolveDIDFromLog(futureLog, { verifier: testImplementation })).rejects.toThrow(
+      'must not be more than 5 minutes in the future'
+    );
   });
 
   test('Hash chain tampering is detected', async () => {

--- a/test/not-so-happy-path.test.ts
+++ b/test/not-so-happy-path.test.ts
@@ -68,7 +68,7 @@ describe('Not So Happy Path Tests', () => {
     await expect(resolveDIDFromLog(tamperedLog, { verifier: testImplementation })).rejects.toThrow('Hash chain broken');
   });
 
-  test('Fast-resolve catches hash chain break on middle entries', async () => {
+  test('Resolve catches hash chain break on middle entries', async () => {
     // Build a log with 12+ entries
     let currentLog: DIDLog;
     const { log: log0 } = await createDID({
@@ -97,10 +97,7 @@ describe('Not So Happy Path Tests', () => {
     const tamperedLog: DIDLog = JSON.parse(JSON.stringify(currentLog));
     tamperedLog[3].state.alsoKnownAs = ['did:example:tampered'];
 
-    // Hash chain validation remains active even when fastResolve is opted in.
-    await expect(resolveDIDFromLog(tamperedLog, { verifier: testImplementation, fastResolve: true })).rejects.toThrow(
-      'Hash chain broken'
-    );
+    await expect(resolveDIDFromLog(tamperedLog, { verifier: testImplementation })).rejects.toThrow('Hash chain broken');
   });
 
   test('Default resolve verifies every log entry proof', async () => {
@@ -126,14 +123,8 @@ describe('Not So Happy Path Tests', () => {
     }
 
     const tamperedLog: DIDLog = JSON.parse(JSON.stringify(currentLog));
-    // With 13 entries, index 1 is outside the fastResolve verification window
-    // (first entry + last 10 entries), but still checked in default full mode.
     tamperedLog[1]!.proof![0]!.proofValue = 'zinvalid-proof';
     await expect(resolveDIDFromLog(tamperedLog, { verifier: testImplementation })).rejects.toThrow();
-
-    await expect(
-      resolveDIDFromLog(tamperedLog, { verifier: testImplementation, fastResolve: true })
-    ).resolves.toBeDefined();
   });
 
   test('Error metadata on later-entry failure', async () => {

--- a/test/paths.test.ts
+++ b/test/paths.test.ts
@@ -158,4 +158,36 @@ describe('Paths feature', () => {
     // Verify the ID starts with the correct DID prefix
     expect(doc.verificationMethod![0]!.id).toStartWith(`${doc.id!}#`);
   });
+
+  test('rejects dot-segment in explicit paths array', async () => {
+    const authKey = await generateTestVerificationMethod();
+    const verifier = new TestCryptoImplementation({ verificationMethod: authKey });
+
+    await expect(
+      createDID({
+        domain: 'example.com',
+        paths: ['api', '..', 'secrets'],
+        signer: createTestSigner(authKey),
+        updateKeys: [authKey.publicKeyMultibase!],
+        verificationMethods: asPublicVerificationMethods(authKey),
+        verifier,
+      })
+    ).rejects.toThrow('createDID path segments must not contain dot-segments');
+  });
+
+  test('rejects encoded slash inside a single explicit path segment', async () => {
+    const authKey = await generateTestVerificationMethod();
+    const verifier = new TestCryptoImplementation({ verificationMethod: authKey });
+
+    await expect(
+      createDID({
+        domain: 'example.com',
+        paths: ['api', 'a%2Fb'],
+        signer: createTestSigner(authKey),
+        updateKeys: [authKey.publicKeyMultibase!],
+        verificationMethods: asPublicVerificationMethods(authKey),
+        verifier,
+      })
+    ).rejects.toThrow('createDID path segments must not contain decoded slash within a single path segment');
+  });
 });

--- a/test/resolve.test.ts
+++ b/test/resolve.test.ts
@@ -167,4 +167,13 @@ describe('Resolver URL derivation', () => {
     expect(getBaseUrl(did)).toBe('https://example.com');
     expect(getFileUrl(did)).toBe('https://example.com/.well-known/did.jsonl');
   });
+
+  test('Rejects DID identifier containing fragment or query contamination', () => {
+    expect(() => getBaseUrl('did:webvh:scid:example.com#frag')).toThrow(
+      'did:webvh identifier must not include query or fragment components'
+    );
+    expect(() => getBaseUrl('did:webvh:scid:example.com?query=1')).toThrow(
+      'did:webvh identifier must not include query or fragment components'
+    );
+  });
 });

--- a/test/resolve.test.ts
+++ b/test/resolve.test.ts
@@ -30,6 +30,7 @@ describe('resolveDIDFromLog with verificationMethod', () => {
       domain: 'example.com',
       signer: createTestSigner(authKey1),
       updateKeys: [authKey1.publicKeyMultibase!],
+      created: '2023-01-01T00:00:00Z',
       verificationMethods: asPublicVerificationMethods(authKey1),
       verifier: testImplementation,
     });
@@ -41,7 +42,7 @@ describe('resolveDIDFromLog with verificationMethod', () => {
       signer: createTestSigner(authKey1),
       updateKeys: [authKey1.publicKeyMultibase!],
       verificationMethods: asPublicVerificationMethods(authKey1, authKey2),
-      updated: '2023-02-01T00:00:00Z',
+      updated: '2023-02-01T00:00:01Z',
       verifier: testImplementation,
     });
     fullLog = updateResult1.log;
@@ -52,7 +53,7 @@ describe('resolveDIDFromLog with verificationMethod', () => {
       signer: createTestSigner(authKey1),
       updateKeys: [authKey1.publicKeyMultibase!],
       verificationMethods: asPublicVerificationMethods(authKey1, authKey2, keyAgreementKey),
-      updated: '2023-03-01T00:00:00Z',
+      updated: '2023-03-01T00:00:02Z',
       verifier: testImplementation,
     });
     fullLog = updateResult2.log;
@@ -63,7 +64,7 @@ describe('resolveDIDFromLog with verificationMethod', () => {
       signer: createTestSigner(authKey1),
       updateKeys: [authKey1.publicKeyMultibase!],
       verificationMethods: asPublicVerificationMethods(authKey1, authKey2, keyAgreementKey, assertionKey),
-      updated: '2023-03-01T00:00:00Z',
+      updated: '2023-03-01T00:00:03Z',
       verifier: testImplementation,
     });
     fullLog = updateResult3.log;

--- a/test/resolve.test.ts
+++ b/test/resolve.test.ts
@@ -176,4 +176,16 @@ describe('Resolver URL derivation', () => {
       'did:webvh identifier must not include query or fragment components'
     );
   });
+
+  test('Rejects DID identifier containing traversal-style path segments', () => {
+    expect(() => getBaseUrl('did:webvh:scid:example.com:..:secret')).toThrow(
+      'did:webvh identifier must not contain dot-segments'
+    );
+    expect(() => getBaseUrl('did:webvh:scid:example.com:%2E%2E:secret')).toThrow(
+      'did:webvh identifier must not contain dot-segments'
+    );
+    expect(() => getBaseUrl('did:webvh:scid:example.com:a%2Fb')).toThrow(
+      'did:webvh identifier must not contain decoded slash within a single path segment'
+    );
+  });
 });

--- a/test/resolve.test.ts
+++ b/test/resolve.test.ts
@@ -150,10 +150,10 @@ describe('resolveDIDFromLog with verificationMethod', () => {
 });
 
 describe('Resolver URL derivation', () => {
-  test('Uses http for localhost DID host', () => {
+  test('Uses https for localhost DID host', () => {
     const did = 'did:webvh:scid:localhost%3A8000:test:path';
-    expect(getBaseUrl(did)).toBe('http://localhost:8000/test/path');
-    expect(getFileUrl(did)).toBe('http://localhost:8000/test/path/did.jsonl');
+    expect(getBaseUrl(did)).toBe('https://localhost:8000/test/path');
+    expect(getFileUrl(did)).toBe('https://localhost:8000/test/path/did.jsonl');
   });
 
   test('Uses https for non-localhost DID host', () => {

--- a/test/spec-entry-hash.test.ts
+++ b/test/spec-entry-hash.test.ts
@@ -96,7 +96,7 @@ describe('didwebvh v1.0 entryHash spec compliance', () => {
   });
 
   test('log is resolvable end-to-end (hash chain + signatures)', async () => {
-    const resolved = await resolveDIDFromLog(log, { verifier, fastResolve: false });
+    const resolved = await resolveDIDFromLog(log, { verifier });
     expect(resolved.meta.versionId).toBe(log[log.length - 1].versionId);
   });
 });

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,4 +1,5 @@
 import * as crypto from '@stablelib/ed25519';
+import { METHOD, PLACEHOLDER } from '../src/constants';
 import { AbstractCrypto, prepareDataForSigning } from '../src/cryptography';
 import type {
   DIDLog,
@@ -10,7 +11,7 @@ import type {
   VerificationMethod,
   Verifier,
 } from '../src/interfaces';
-import { deriveHash } from '../src/utils';
+import { createDIDDoc, createSCID, deriveHash, replaceCreateDidPlaceholders } from '../src/utils';
 import { MultibaseEncoding, multibaseDecode, multibaseEncode } from '../src/utils/multiformats';
 
 export function createMockDIDLog(entries: Partial<DIDLogEntry>[]): DIDLog {
@@ -26,6 +27,54 @@ export function createMockDIDLog(entries: Partial<DIDLogEntry>[]): DIDLog {
     return mockEntry;
   });
 }
+
+export const createFutureDIDLog = async (authKey: VerificationMethod, minutesAhead: number): Promise<DIDLog> => {
+  const futureCreated = new Date(Date.now() + minutesAhead * 60 * 1000).toISOString();
+  const signer = createTestSigner(authKey);
+  const controller = `did:${METHOD}:${PLACEHOLDER}:example.com`;
+
+  const { doc } = await createDIDDoc({
+    controller,
+    verificationMethods: asPublicVerificationMethods(authKey),
+    signer,
+    updateKeys: [authKey.publicKeyMultibase!],
+  });
+
+  const initialLogEntry: DIDLog[0] = {
+    versionId: PLACEHOLDER,
+    versionTime: futureCreated,
+    parameters: {
+      method: `did:${METHOD}:1.0`,
+      scid: PLACEHOLDER,
+      updateKeys: [authKey.publicKeyMultibase!],
+      portable: false,
+      nextKeyHashes: [],
+      watchers: [],
+      witness: {},
+      deactivated: false,
+    },
+    state: doc,
+  };
+
+  const initialLogEntryHash = await deriveHash(initialLogEntry);
+  const scid = await createSCID(initialLogEntryHash);
+  const did = `did:${METHOD}:${scid}:example.com`;
+  const prelimEntry = replaceCreateDidPlaceholders(initialLogEntry, scid, did);
+  const logEntryHash2 = await deriveHash(prelimEntry);
+  prelimEntry.versionId = `1-${logEntryHash2}`;
+
+  const proofTemplate = {
+    type: 'DataIntegrityProof' as const,
+    cryptosuite: 'eddsa-jcs-2022' as const,
+    verificationMethod: signer.getVerificationMethodId(),
+    created: futureCreated,
+    proofPurpose: 'assertionMethod' as const,
+  };
+  const signedProof = await signer.sign({ document: prelimEntry, proof: proofTemplate });
+  prelimEntry.proof = [{ ...proofTemplate, proofValue: signedProof.proofValue }];
+
+  return [prelimEntry];
+};
 
 // Test crypto implementation
 export class TestCryptoImplementation extends AbstractCrypto implements Verifier {


### PR DESCRIPTION
Following @swcurran's report of failing negative test cases in `didwebvh-test-suite` and reviewed against the `webvh` spec.

Normative fixes:

* Added ISO8601 utility & enforce `versionTime` validity and monotonic progression in logs
* Support only `Z` or `+00:00` for versionTime
* Permit 5 minute skew
* Enforced `SCID` immutability in portability updates and absence from non-initial logs
* Implemented structured DID identifier parsing for `did:webvh`
* Normalise/decode host before IP checks
* Do not ignore encoding case for IP rejection
* Removed `fastResolve` functionality
* Removed `localhost` special-casing for HTTPS

Security hardening

* Reject dot-segments and encoded traversal semantics in DID path segments
* Reject decoded slash inside a single DID path segment