### PR TITLE
Fix host extraction for path-based did:webvh identifiers

### DIFF
--- a/src/method_versions/method.v0.5.ts
+++ b/src/method_versions/method.v0.5.ts
@@ -21,6 +21,8 @@ import {
   deriveHash,
   findVerificationMethod,
   getBaseUrl,
+  getWebvhHost,
+  getWebvhLocation,
   parseCanonicalAddress,
   replaceValueInObject,
 } from '../utils';
@@ -197,7 +199,7 @@ export const resolveDIDFromLog = async (
       if (version === '1') {
         meta.created = versionTime;
         newDoc = state;
-        host = requireDidId(newDoc.id).split(':').at(-1) ?? '';
+        host = getWebvhLocation(requireDidId(newDoc.id));
         meta.scid = parameters.scid as string;
         meta.portable = parameters.portable ?? meta.portable;
         meta.updateKeys = parameters.updateKeys as string[];
@@ -235,7 +237,7 @@ export const resolveDIDFromLog = async (
         }
       } else {
         // version number > 1
-        const newHost = requireDidId(newDoc.id).split(':').at(-1) ?? '';
+        const newHost = getWebvhLocation(requireDidId(newDoc.id));
         if (!meta.portable && newHost !== host) {
           throw new Error('Cannot move DID: portability is disabled');
         } else if (newHost !== host) {
@@ -430,7 +432,7 @@ export const updateDID = async (
     ...options,
     controller: options.controller || lastEntry.state.id || '',
     context: options.context || lastEntry.state['@context'],
-    domain: options.domain ?? lastEntry.state.id?.split(':').at(-1) ?? '',
+    domain: options.domain ?? (lastEntry.state.id ? getWebvhHost(lastEntry.state.id) : ''),
     updateKeys: options.updateKeys ?? [],
     verificationMethods: safeVerificationMethods ?? [],
   });

--- a/src/method_versions/method.v1.0.ts
+++ b/src/method_versions/method.v1.0.ts
@@ -27,6 +27,8 @@ import {
   findVerificationMethod,
   generateParallelDidWeb,
   getBaseUrl,
+  getWebvhHost,
+  getWebvhLocation,
   parseCanonicalAddress,
   replaceCreateDidPlaceholders,
   replaceValueInObject,
@@ -227,7 +229,7 @@ export const resolveDIDFromLog = async (
       if (version === '1') {
         meta.created = versionTime;
         newDoc = state;
-        host = requireDidId(newDoc.id).split(':').at(-1) ?? '';
+        host = getWebvhLocation(requireDidId(newDoc.id));
         meta.scid = parameters.scid as string;
         if (options.scid && options.scid !== meta.scid) {
           throw new Error(`SCID in DID '${options.scid}' does not match SCID in log '${meta.scid}'`);
@@ -271,7 +273,7 @@ export const resolveDIDFromLog = async (
         }
       } else {
         // version number > 1
-        const newHost = requireDidId(newDoc.id).split(':').at(-1) ?? '';
+        const newHost = getWebvhLocation(requireDidId(newDoc.id));
         if (!meta.portable && newHost !== host) {
           throw new Error('Cannot move DID: portability is disabled');
         } else if (newHost !== host) {
@@ -512,7 +514,7 @@ export const updateDID = async (
     ...options,
     controller: options.controller || lastEntry.state.id || '',
     context: options.context || lastEntry.state['@context'],
-    domain: options.domain ?? lastEntry.state.id?.split(':').at(-1) ?? '',
+    domain: options.domain ?? (lastEntry.state.id ? getWebvhHost(lastEntry.state.id) : ''),
     updateKeys: options.updateKeys ?? [],
     verificationMethods: safeVerificationMethods ?? [],
   });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -345,6 +345,31 @@ export function convertWebvhIdToWebId(id: string): string {
   return `did:web:${parts.slice(3).join(':')}`;
 }
 
+/**
+ * Returns the host/domain segment of a did:webvh identifier — the segment
+ * immediately following the SCID (`did:webvh:{scid}:{domain}...`).
+ */
+export function getWebvhHost(id: string): string {
+  const parts = id.split(':');
+  if (parts.length < 4 || parts[0] !== 'did' || parts[1] !== 'webvh') {
+    throw new Error(`Invalid did:webvh id '${id}'`);
+  }
+  return parts[3];
+}
+
+/**
+ * Returns the full location of a did:webvh identifier — domain plus any path
+ * segments (`did:webvh:{scid}:{domain}:{path}...`), i.e. everything after the
+ * SCID. Used to detect whether a DID has moved when portability is disabled.
+ */
+export function getWebvhLocation(id: string): string {
+  const parts = id.split(':');
+  if (parts.length < 4 || parts[0] !== 'did' || parts[1] !== 'webvh') {
+    throw new Error(`Invalid did:webvh id '${id}'`);
+  }
+  return parts.slice(3).join(':');
+}
+
 export function enrichAlsoKnownAs(doc: DIDDoc, did: string, opts: { alsoKnownAsWeb?: boolean }): DIDDoc {
   if (doc.alsoKnownAs !== undefined && !Array.isArray(doc.alsoKnownAs)) {
     throw new Error('alsoKnownAs is not an array');

--- a/test/features.test.ts
+++ b/test/features.test.ts
@@ -275,3 +275,56 @@ test('DID log with portable false should not resolve if moved', async () => {
   expect(err).toBeInstanceOf(Error);
   expect((err as Error).message).toContain('Cannot move DID: portability is disabled');
 });
+
+test('DID log with portable false and a path should not resolve if domain moved', async () => {
+  // Regression: host comparison must use the full location (domain + path), not
+  // just the last ':'-separated segment. A path-based DID moved to a new domain
+  // while keeping the same final path segment would slip past a `.at(-1)` check.
+  const pathDID = await createDID({
+    domain: 'example.com',
+    paths: ['dids', 'abc'],
+    signer: createTestSigner(authKey1),
+    updateKeys: [authKey1.publicKeyMultibase!],
+    verificationMethods: asPublicVerificationMethods(authKey1),
+    created: createDate(new Date('2021-01-01T08:32:55Z')),
+    portable: false,
+    verifier: testImplementation,
+  });
+
+  let err: unknown;
+  try {
+    const newTimestamp = createDate(new Date('2021-02-01T08:32:55Z'));
+
+    // Move only the domain; the trailing path segment ('abc') stays the same.
+    const newDoc = {
+      ...pathDID.doc,
+      id: pathDID.did.replace('example.com', 'newdomain.com'),
+    };
+
+    const newEntry: DIDLogEntry = {
+      versionId: `${pathDID.log.length + 1}-test`,
+      versionTime: newTimestamp,
+      parameters: { updateKeys: [authKey1.publicKeyMultibase!] },
+      state: newDoc,
+      proof: [
+        {
+          type: 'DataIntegrityProof',
+          cryptosuite: 'eddsa-jcs-2022',
+          verificationMethod: `did:key:${authKey1.publicKeyMultibase!}`,
+          created: newTimestamp,
+          proofPurpose: 'authentication',
+          proofValue: 'badProofValue',
+        },
+      ],
+    };
+
+    const badLog: DIDLog = [...pathDID.log, newEntry];
+    await resolveDIDFromLog(badLog, { verifier: testImplementation });
+  } catch (e) {
+    err = e;
+  }
+
+  expect(err).toBeDefined();
+  expect(err).toBeInstanceOf(Error);
+  expect((err as Error).message).toContain('Cannot move DID: portability is disabled');
+});


### PR DESCRIPTION
## Problem

Host extraction used `requireDidId(id).split(':').at(-1)`, which returns the **last** `:`-separated segment of a `did:webvh` identifier. That equals the host only when the DID has no path. For path-based DIDs (`did:webvh:{scid}:{domain}:{path}…`) it returns a path segment instead.

The most serious consequence is a hole in the **portability check** (`Cannot move DID: portability is disabled`): a non-portable DID with a path could be moved to a different domain undetected, as long as the trailing path segment matched — e.g. `…:example.com:dids:abc` → `…:evil.com:dids:abc` both reduce to `abc`.

This predates the recently-merged type-safety PR (#119), which only wrapped the existing `.at(-1)` logic — it didn't introduce it.

## Fix

- Add two helpers in `src/utils.ts` (both validate the `did:webvh:` prefix):
  - `getWebvhLocation(id)` → everything after the SCID (domain + path), for "has the DID moved?" comparisons.
  - `getWebvhHost(id)` → just the domain (`parts[3]`).
- `method.v1.0.ts` and `method.v0.5.ts`: portability/host comparisons now use `getWebvhLocation` (full location — domain *and* path), and the `domain` field uses `getWebvhHost`.

## Tests

The existing portability test used a path-less DID, so `.at(-1)` happened to return the right value and the bug was invisible; `paths.test.ts` only exercised `createDID`, never an update/resolve cycle.

Added a regression test — *DID log with portable false and a path should not resolve if domain moved* — that moves the domain while keeping the final path segment. Verified it **fails** against the old `.at(-1)` logic and **passes** with the fix.

Full suite: 185 pass / 0 fail. Build type-checks cleanly.