### PR TITLE
feat: export deriveNextKeyHash for consumers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 export { AbstractCrypto, createDocumentSigner, createProof, createSigner, prepareDataForSigning } from './cryptography';
 export * from './interfaces';
 export { createDID, deactivateDID, resolveDID, resolveDIDFromLog, updateDID } from './method';
-export { generateParallelDidWeb, parseDidKeyDid, parseDidKeyVerificationMethod } from './utils';
+export { deriveNextKeyHash, generateParallelDidWeb, parseDidKeyDid, parseDidKeyVerificationMethod } from './utils';
 export { MultibaseEncoding, multibaseDecode, multibaseEncode } from './utils/multiformats';
 export {
   createWitnessProof,


### PR DESCRIPTION
## Summary

`deriveNextKeyHash` already existed in `src/utils.ts` but was never re-exported from the public barrel (`src/index.ts`), so consumers of the published package could not import it.

This adds it to the top-level exports so consumers can compute `nextKeyHashes` using the exact same hashing the library uses internally for validation — avoiding misalignment between a consumer's key-hash generation and the library's checks.

## Changes

- `src/index.ts`: re-export `deriveNextKeyHash` from `./utils`

## Notes

One-line public-API addition; no behavior change. Type-checks and the full test suite pass locally.

Closes #100