### PR TITLE
fix: rebuild controller from new location on portable move

### DIFF
--- a/src/method.ts
+++ b/src/method.ts
@@ -137,7 +137,13 @@ export const resolveDIDFromLog = async (
  * @returns The updated DID, resolved document, and DID log.
  */
 export const updateDID = async (
-  options: UpdateDIDInterface & { services?: ServiceEndpoint[]; domain?: string; updated?: string }
+  options: UpdateDIDInterface & {
+    services?: ServiceEndpoint[];
+    domain?: string;
+    address?: string;
+    paths?: string[];
+    updated?: string;
+  }
 ): Promise<UpdateDIDResult> => {
   const version = options.log ? getWebvhVersionFromLog(options.log) : getWebvhVersionFromOptions(options);
   const result = version === '0.5' ? await v0_5.updateDID(options) : await v1.updateDID(options);

--- a/src/method_versions/method.v1.0.ts
+++ b/src/method_versions/method.v1.0.ts
@@ -644,7 +644,16 @@ export const updateDID = async (
     controller = options.controller;
   } else if (requestedAddress) {
     const parsedNewAddress = parseCanonicalAddress(requestedAddress);
-    const newLocationPaths = [...(parsedNewAddress.paths || []), ...(options.paths || [])];
+    // Paths: explicit options.paths (combined with any address-embedded paths) take
+    // precedence; otherwise use address-embedded paths; otherwise inherit the prior
+    // paths so re-passing a bare domain on a pathed DID doesn't silently drop them.
+    const addressPaths = parsedNewAddress.paths || [];
+    const newLocationPaths =
+      options.paths !== undefined
+        ? [...addressPaths, ...options.paths]
+        : addressPaths.length
+          ? addressPaths
+          : parsedLastEntryDid.paths ?? [];
     const newLocationKey = newLocationPaths.length
       ? `${parsedNewAddress.didDomainComponent}:${newLocationPaths.join(':')}`
       : parsedNewAddress.didDomainComponent;

--- a/src/method_versions/method.v1.0.ts
+++ b/src/method_versions/method.v1.0.ts
@@ -579,7 +579,13 @@ export const resolveDIDFromLog = async (
 };
 
 export const updateDID = async (
-  options: UpdateDIDInterface & { services?: ServiceEndpoint[]; domain?: string; updated?: string }
+  options: UpdateDIDInterface & {
+    services?: ServiceEndpoint[];
+    domain?: string;
+    address?: string;
+    paths?: string[];
+    updated?: string;
+  }
 ): Promise<UpdateDIDResult> => {
   const log = options.log;
   const lastEntry = log[log.length - 1];
@@ -630,12 +636,36 @@ export const updateDID = async (
     return vm;
   });
 
+  // Determine the controller (the DID id) for this update. When a new location
+  // (address/domain) is supplied, rebuild the controller from that location while
+  // preserving the SCID, so a portable DID can actually move. The SCID is the
+  // stable part of the identifier; only the location component changes.
+  const requestedAddress = options.address || options.domain;
+  let controller: string;
+  let controllerPaths = parsedLastEntryDid.paths;
+  if (options.controller) {
+    controller = options.controller;
+  } else if (requestedAddress) {
+    const parsedNewAddress = parseCanonicalAddress(requestedAddress);
+    const newLocationPaths = [...(parsedNewAddress.paths || []), ...(options.paths || [])];
+    const newLocationKey = newLocationPaths.length
+      ? `${parsedNewAddress.didDomainComponent}:${newLocationPaths.join(':')}`
+      : parsedNewAddress.didDomainComponent;
+    controller = `did:${METHOD}:${parsedLastEntryDid.scid}:${newLocationKey}`;
+    controllerPaths = newLocationPaths.length ? newLocationPaths : undefined;
+    if (controller !== lastEntryDid && !lastMeta.portable) {
+      throw new Error('Cannot move DID: portability is disabled');
+    }
+  } else {
+    controller = lastEntryDid;
+  }
+
   const { doc: normalizedUpdateDoc } = await createDIDDoc({
     ...options,
-    controller: options.controller || lastEntryDid,
+    controller,
     context: options.context || lastEntry.state['@context'],
-    domain: options.domain ?? parsedLastEntryDid.didDomainComponent,
-    paths: parsedLastEntryDid.paths,
+    domain: requestedAddress ?? parsedLastEntryDid.didDomainComponent,
+    paths: controllerPaths,
     updateKeys: options.updateKeys ?? [],
     verificationMethods: safeVerificationMethods ?? [],
   });

--- a/src/method_versions/method.v1.0.ts
+++ b/src/method_versions/method.v1.0.ts
@@ -636,10 +636,7 @@ export const updateDID = async (
     return vm;
   });
 
-  // Determine the controller (the DID id) for this update. When a new location
-  // (address/domain) is supplied, rebuild the controller from that location while
-  // preserving the SCID, so a portable DID can actually move. The SCID is the
-  // stable part of the identifier; only the location component changes.
+  // Compute controller DID id; rebuild with new address if moving, keep SCID stable.
   const requestedAddress = options.address || options.domain;
   let controller: string;
   let controllerPaths = parsedLastEntryDid.paths;

--- a/test/portability.test.ts
+++ b/test/portability.test.ts
@@ -116,4 +116,40 @@ describe('Portability', () => {
       'does not match SCID in log'
     );
   });
+
+  test('Portable DID moves to a new domain via the domain option (#101)', async () => {
+    const updateResult = await updateDID({
+      log: portableDID.log,
+      domain: 'example.org',
+      signer: createTestSigner(authKey),
+      updateKeys: [authKey.publicKeyMultibase!],
+      verificationMethods: asPublicVerificationMethods(authKey),
+      verifier: testImplementation,
+    });
+
+    const originalDid = portableDID.log[0].state.id as string;
+    const scid = originalDid.split(':')[2];
+
+    // The new entry's state.id must reflect the new location, same SCID
+    expect(updateResult.log[1].state.id).toBe(`did:webvh:${scid}:example.org`);
+
+    // And it must resolve to the moved DID
+    const resolved = await resolveDIDFromLog(updateResult.log, { verifier: testImplementation });
+    expect(resolved.did).toBe(`did:webvh:${scid}:example.org`);
+    expect(resolved.doc?.id).toBe(`did:webvh:${scid}:example.org`);
+  });
+
+  test('Non-portable DID rejects a move to a new domain (#101)', async () => {
+    await expect(
+      updateDID({
+        log: nonPortableDID.log,
+        domain: 'example.org',
+        signer: createTestSigner(authKey),
+        updateKeys: [authKey.publicKeyMultibase!],
+        verificationMethods: asPublicVerificationMethods(authKey),
+        verifier: testImplementation,
+      })
+    ).rejects.toThrow('Cannot move DID: portability is disabled');
+  });
+
 });

--- a/test/portability.test.ts
+++ b/test/portability.test.ts
@@ -151,5 +151,4 @@ describe('Portability', () => {
       })
     ).rejects.toThrow('Cannot move DID: portability is disabled');
   });
-
 });

--- a/test/portability.test.ts
+++ b/test/portability.test.ts
@@ -151,4 +151,45 @@ describe('Portability', () => {
       })
     ).rejects.toThrow('Cannot move DID: portability is disabled');
   });
+
+  test('Re-passing a bare domain on a pathed DID preserves the paths (#101)', async () => {
+    const pathedDID = await createDID({
+      domain: 'example.com',
+      paths: ['dids', 'alice'],
+      signer: createTestSigner(authKey),
+      updateKeys: [authKey.publicKeyMultibase!],
+      verificationMethods: asPublicVerificationMethods(authKey),
+      verifier: testImplementation,
+    });
+
+    // Caller threads the same domain through the update but omits paths.
+    const updateResult = await updateDID({
+      log: pathedDID.log,
+      domain: 'example.com',
+      signer: createTestSigner(authKey),
+      updateKeys: [authKey.publicKeyMultibase!],
+      verificationMethods: asPublicVerificationMethods(authKey),
+      verifier: testImplementation,
+    });
+
+    expect(updateResult.log[1].state.id).toBe(pathedDID.did);
+    const resolved = await resolveDIDFromLog(updateResult.log, { verifier: testImplementation });
+    expect(resolved.did).toBe(pathedDID.did);
+  });
+
+  test('Portable DID moves to a pathed location via the address option (#101)', async () => {
+    const updateResult = await updateDID({
+      log: portableDID.log,
+      address: 'https://example.org/dids/alice',
+      signer: createTestSigner(authKey),
+      updateKeys: [authKey.publicKeyMultibase!],
+      verificationMethods: asPublicVerificationMethods(authKey),
+      verifier: testImplementation,
+    });
+
+    const scid = (portableDID.log[0].state.id as string).split(':')[2];
+    expect(updateResult.log[1].state.id).toBe(`did:webvh:${scid}:example.org:dids:alice`);
+    const resolved = await resolveDIDFromLog(updateResult.log, { verifier: testImplementation });
+    expect(resolved.did).toBe(`did:webvh:${scid}:example.org:dids:alice`);
+  });
 });


### PR DESCRIPTION
updateDID ignored the domain/address option when deriving the new entry's identifier: createDIDDoc builds the document as `id: controller`, and the controller defaulted to the previous entry's state.id, so a requested move was silently dropped and the DID stayed at its old location.

Derive the controller from the requested location (address/domain/paths) while preserving the SCID, so a portable DID can actually move. Moving a non-portable DID now fails fast with a clear error instead of producing an entry that only fails later at resolution. Also accept `address` and `paths` on updateDID for parity with createDID.

Adds regression tests covering a successful portable move and rejection of a move on a non-portable DID.

Closes #101