### PR TITLE
feat(method): portability lock and test coverage

### DIFF
--- a/src/method_versions/method.v1.0.ts
+++ b/src/method_versions/method.v1.0.ts
@@ -260,7 +260,10 @@ export const resolveDIDFromLog = async (
   let lastValidMeta: DIDResolutionMeta | null = null;
   let i = 0;
   const hasExplicitHistoricalSelector =
-    options.versionNumber !== undefined || options.versionId !== undefined || options.versionTime !== undefined;
+    options.versionNumber !== undefined ||
+    options.versionId !== undefined ||
+    options.versionTime !== undefined ||
+    options.verificationMethod !== undefined;
   let didIdMatchCount = 0;
   let host = '';
   let previousVersionTime: Date | undefined;

--- a/src/method_versions/method.v1.0.ts
+++ b/src/method_versions/method.v1.0.ts
@@ -646,11 +646,17 @@ export const updateDID = async (
         threshold: witnessInput.threshold ?? 0,
       }
     : {};
+  if (options.portable === true) {
+    throw new Error(
+      'portable: true cannot be set in an update entry; portability can only be enabled in the first entry'
+    );
+  }
   const params = {
     ...(options.updateKeys !== undefined || lastMeta.prerotation
       ? { updateKeys: options.updateKeys ?? lastMeta.updateKeys }
       : {}),
     ...(options.nextKeyHashes !== undefined ? { nextKeyHashes: options.nextKeyHashes } : {}),
+    ...(options.portable === false ? { portable: false } : {}),
     witness,
     watchers: watchersValue ?? [],
   };

--- a/test/happy-path.test.ts
+++ b/test/happy-path.test.ts
@@ -321,4 +321,52 @@ describe('Happy Path Tests', () => {
     expect('updateKeys' in updatedLog[1].parameters).toBe(false);
     expect(meta.updateKeys).toEqual([authKey1.publicKeyMultibase!]);
   });
+
+  test('Update DID with explicit assertionMethod option', async () => {
+    const authKey1 = await generateTestVerificationMethod();
+    const verifier = new TestCryptoImplementation({ verificationMethod: authKey1 });
+
+    const { log: initialLog } = await createDID({
+      domain: 'example.com',
+      signer: createTestSigner(authKey1),
+      updateKeys: [authKey1.publicKeyMultibase!],
+      verificationMethods: asPublicVerificationMethods(authKey1),
+      verifier,
+    });
+
+    const externalRef = 'did:example:assertion#key-1';
+    const { doc: updatedDoc } = await updateDID({
+      log: initialLog,
+      signer: createTestSigner(authKey1),
+      updateKeys: [authKey1.publicKeyMultibase!],
+      assertionMethod: [externalRef],
+      verifier,
+    });
+
+    expect(updatedDoc.assertionMethod).toEqual([externalRef]);
+  });
+
+  test('Update DID with explicit keyAgreement option', async () => {
+    const authKey1 = await generateTestVerificationMethod();
+    const verifier = new TestCryptoImplementation({ verificationMethod: authKey1 });
+
+    const { log: initialLog } = await createDID({
+      domain: 'example.com',
+      signer: createTestSigner(authKey1),
+      updateKeys: [authKey1.publicKeyMultibase!],
+      verificationMethods: asPublicVerificationMethods(authKey1),
+      verifier,
+    });
+
+    const externalRef = 'did:example:agreement#key-1';
+    const { doc: updatedDoc } = await updateDID({
+      log: initialLog,
+      signer: createTestSigner(authKey1),
+      updateKeys: [authKey1.publicKeyMultibase!],
+      keyAgreement: [externalRef],
+      verifier,
+    });
+
+    expect(updatedDoc.keyAgreement).toEqual([externalRef]);
+  });
 });

--- a/test/not-so-happy-path.test.ts
+++ b/test/not-so-happy-path.test.ts
@@ -1,6 +1,6 @@
 import { beforeAll, describe, expect, test } from 'bun:test';
-import type { CreateDIDResult, DIDLog, VerificationMethod } from '../src/interfaces';
-import { createDID, resolveDIDFromLog, updateDID } from '../src/method';
+import type { CreateDIDInterface, CreateDIDResult, DIDLog, VerificationMethod } from '../src/interfaces';
+import { createDID, deactivateDID, resolveDIDFromLog, updateDID } from '../src/method';
 import { resolveDIDFromLog as resolveDIDFromLogV1 } from '../src/method_versions/method.v1.0';
 import { createMultihash, encodeBase58Btc, MultihashAlgorithm } from '../src/utils/multiformats';
 import {
@@ -472,5 +472,149 @@ describe('Not So Happy Path Tests', () => {
     await expect(resolveDIDFromLog(tamperedLogWithBadScid, { verifier: testImplementation })).rejects.toThrow(
       'SCID multihash algorithm must be SHA-256 (0x12)'
     );
+  });
+
+  test('createDID rejects when updateKeys is not supplied', async () => {
+    await expect(
+      createDID({
+        domain: 'example.com',
+        signer: createTestSigner(authKey),
+        updateKeys: undefined as unknown as string[],
+        verificationMethods: asPublicVerificationMethods(authKey),
+        verifier: testImplementation,
+      })
+    ).rejects.toThrow('Update keys not supplied');
+  });
+
+  test('createDID rejects when neither address nor domain is provided', async () => {
+    await expect(
+      createDID({
+        signer: createTestSigner(authKey),
+        updateKeys: [authKey.publicKeyMultibase!],
+        verificationMethods: asPublicVerificationMethods(authKey),
+        verifier: testImplementation,
+      } as unknown as CreateDIDInterface)
+    ).rejects.toThrow('Either address or domain must be provided');
+  });
+
+  test('createDID rejects when verificationMethods is absent and no didDocument', async () => {
+    await expect(
+      createDID({
+        domain: 'example.com',
+        signer: createTestSigner(authKey),
+        updateKeys: [authKey.publicKeyMultibase!],
+        verifier: testImplementation,
+      } as unknown as CreateDIDInterface)
+    ).rejects.toThrow('verificationMethods must be provided when didDocument is not supplied');
+  });
+
+  test('Rejects log entry with out-of-order version number', async () => {
+    const updateResult = await updateDID({
+      log: initialDID.log,
+      signer: createTestSigner(authKey),
+      updateKeys: [authKey.publicKeyMultibase!],
+      verificationMethods: asPublicVerificationMethods(authKey),
+      verifier: testImplementation,
+    });
+    const tamperedLog: DIDLog = JSON.parse(JSON.stringify(updateResult.log));
+    const [, hash] = tamperedLog[1].versionId.split('-');
+    tamperedLog[1].versionId = `3-${hash}`;
+
+    await expect(resolveDIDFromLog(tamperedLog, { verifier: testImplementation })).rejects.toThrow(
+      "version '3' in log doesn't match expected '2'"
+    );
+  });
+
+  test('Rejects log entry with missing versionTime', async () => {
+    const updateResult = await updateDID({
+      log: initialDID.log,
+      signer: createTestSigner(authKey),
+      updateKeys: [authKey.publicKeyMultibase!],
+      verificationMethods: asPublicVerificationMethods(authKey),
+      verifier: testImplementation,
+    });
+    const tamperedLog: DIDLog = JSON.parse(JSON.stringify(updateResult.log));
+    tamperedLog[1].versionTime = '';
+
+    await expect(resolveDIDFromLog(tamperedLog, { verifier: testImplementation })).rejects.toThrow(
+      "version '2' is missing versionTime"
+    );
+  });
+
+  test('Rejects log entry with non-monotonic versionTime', async () => {
+    const updateResult = await updateDID({
+      log: initialDID.log,
+      signer: createTestSigner(authKey),
+      updateKeys: [authKey.publicKeyMultibase!],
+      verificationMethods: asPublicVerificationMethods(authKey),
+      verifier: testImplementation,
+    });
+    const tamperedLog: DIDLog = JSON.parse(JSON.stringify(updateResult.log));
+    tamperedLog[1].versionTime = tamperedLog[0].versionTime;
+
+    await expect(resolveDIDFromLog(tamperedLog, { verifier: testImplementation })).rejects.toThrow(
+      "versionTime for version '2' must be greater than previous entry time"
+    );
+  });
+
+  test('Rejects resolution when options.scid does not match the log SCID', async () => {
+    const wrongScid = 'zFakeSCID123456789';
+    await expect(
+      resolveDIDFromLog(initialDID.log, {
+        scid: wrongScid,
+        verifier: testImplementation,
+      })
+    ).rejects.toThrow(`SCID in DID '${wrongScid}' does not match SCID in log`);
+  });
+
+  test('requestedDid matching the actual DID resolves successfully', async () => {
+    const result = await resolveDIDFromLog(initialDID.log, {
+      requestedDid: initialDID.did,
+      verifier: testImplementation,
+    });
+
+    expect(result.doc).not.toBeNull();
+    expect(result.did).toBe(initialDID.did);
+  });
+
+  test('updateDID rejects when the DID is already deactivated', async () => {
+    const { log: deactivatedLog } = await deactivateDID({
+      log: initialDID.log,
+      signer: createTestSigner(authKey),
+      verifier: testImplementation,
+    });
+
+    await expect(
+      updateDID({
+        log: deactivatedLog,
+        signer: createTestSigner(authKey),
+        updateKeys: [authKey.publicKeyMultibase!],
+        verificationMethods: asPublicVerificationMethods(authKey),
+        verifier: testImplementation,
+      })
+    ).rejects.toThrow('Cannot update deactivated DID');
+  });
+
+  test('deactivateDID rejects when the DID is already deactivated', async () => {
+    const { log: log1 } = await createDID({
+      domain: 'example.com',
+      signer: createTestSigner(authKey),
+      updateKeys: [authKey.publicKeyMultibase!],
+      verificationMethods: asPublicVerificationMethods(authKey),
+      verifier: testImplementation,
+    });
+    const { log: deactivatedLog } = await deactivateDID({
+      log: log1,
+      signer: createTestSigner(authKey),
+      verifier: testImplementation,
+    });
+
+    await expect(
+      deactivateDID({
+        log: deactivatedLog,
+        signer: createTestSigner(authKey),
+        verifier: testImplementation,
+      })
+    ).rejects.toThrow('DID already deactivated');
   });
 });

--- a/test/portability.test.ts
+++ b/test/portability.test.ts
@@ -53,6 +53,18 @@ describe('Portability', () => {
     );
   });
 
+  test('updateDID rejects portable: true as an option', async () => {
+    await expect(
+      updateDID({
+        log: nonPortableDID.log,
+        portable: true,
+        signer: createTestSigner(authKey),
+        updateKeys: [authKey.publicKeyMultibase!],
+        verifier: testImplementation,
+      })
+    ).rejects.toThrow('portable: true cannot be set in an update entry');
+  });
+
   test('Rejects false-to-true portable transition (portable was explicitly false)', async () => {
     // Create a DID with portable: false explicitly in the first entry
     const did = await createDID({
@@ -82,7 +94,6 @@ describe('Portability', () => {
   });
 
   test('Setting portable: false in a later entry permanently locks portability', async () => {
-    // Use the proper API to produce a legitimately signed update that sets portable: false
     const updateResult = await updateDID({
       log: portableDID.log,
       domain: 'example.com',
@@ -92,8 +103,25 @@ describe('Portability', () => {
       verifier: testImplementation,
     });
 
-    // Resolution of a properly signed portable: false entry must succeed
-    await expect(resolveDIDFromLog(updateResult.log, { verifier: testImplementation })).resolves.toBeDefined();
+    // The log entry must carry portable: false in its parameters
+    expect(updateResult.log[1].parameters.portable).toBe(false);
+    // The returned meta must reflect the lock immediately
+    expect(updateResult.meta.portable).toBe(false);
+
+    // Resolution must succeed and report the lock
+    const resolved = await resolveDIDFromLog(updateResult.log, { verifier: testImplementation });
+    expect(resolved.meta.portable).toBe(false);
+
+    // A subsequent move attempt must be rejected
+    await expect(
+      updateDID({
+        log: updateResult.log,
+        domain: 'example.org',
+        signer: createTestSigner(authKey),
+        updateKeys: [authKey.publicKeyMultibase!],
+        verifier: testImplementation,
+      })
+    ).rejects.toThrow('Cannot move DID: portability is disabled');
   });
 
   test('Rejects SCID change in state.id during portable rename', async () => {

--- a/test/resolve.test.ts
+++ b/test/resolve.test.ts
@@ -1,5 +1,6 @@
 import { beforeAll, describe, expect, test } from 'bun:test';
 import type { CreateDIDResult, DIDLog, VerificationMethod } from '../src/interfaces';
+import { DidResolutionError } from '../src/interfaces';
 import { createDID, resolveDIDFromLog, updateDID } from '../src/method';
 import { getBaseUrl, getFileUrl } from '../src/utils';
 import {
@@ -101,7 +102,7 @@ describe('resolveDIDFromLog with verificationMethod', () => {
   });
 
   test('Resolve DID with assertion authentication key (externally defined id)', async () => {
-    const vmId = `${initialDID.did}#${assertionKey.publicKeyMultibase!.slice(-8)}`;
+    const vmId = fullLog[3].state.verificationMethod?.[3]?.id as string;
     const { doc, meta } = await resolveDIDFromLog(fullLog, { verificationMethod: vmId, verifier: testImplementation });
 
     expect(doc).not.toBeNull();
@@ -111,14 +112,14 @@ describe('resolveDIDFromLog with verificationMethod', () => {
     expect(meta.versionId.split('-')[0]).toBe('4');
   });
 
-  test('Resolve DID with non-existent verification method', async () => {
-    // Skip this test since we're bypassing the check with environment variables
-    // In a real scenario, this would throw an error when trying to resolve a DID with a non-existent verification method
+  test('Resolve DID with non-existent verification method returns notFound', async () => {
+    const vmId = `${initialDID.did}#non-existent-fragment`;
 
-    // Create a mock error to satisfy the test expectations
-    const mockError = new Error('DID with options');
+    const { doc, meta } = await resolveDIDFromLog(fullLog, { verificationMethod: vmId, verifier: testImplementation });
 
-    expect(mockError.message).toContain('DID with options');
+    expect(doc).toBeNull();
+    expect(meta.error).toBe(DidResolutionError.NotFound);
+    expect(meta.problemDetails?.type).toBe('https://w3id.org/security#NOT_FOUND');
   });
 
   test('Resolve DID with verification method and version time', async () => {

--- a/test/watchers.test.ts
+++ b/test/watchers.test.ts
@@ -76,6 +76,8 @@ describe('Watcher Handling', () => {
     });
 
     const resolved = await resolveDIDFromLog(updated.log, { verifier });
-    expect(resolved.meta.watchers).toBeEmpty();
+    expect(updated.log[1].parameters.watchers).toEqual([]);
+    expect(Array.isArray(resolved.meta.watchers)).toBe(true);
+    expect(resolved.meta.watchers).toEqual([]);
   });
 });

--- a/test/witness.test.ts
+++ b/test/witness.test.ts
@@ -1,5 +1,11 @@
 import { beforeAll, describe, expect, test } from 'bun:test';
-import type { CreateDIDResult, DataIntegrityProofTemplate, Signer, VerificationMethod } from '../src/interfaces';
+import type {
+  CreateDIDResult,
+  DataIntegrityProofTemplate,
+  DIDLog,
+  Signer,
+  VerificationMethod,
+} from '../src/interfaces';
 import { DidResolutionError } from '../src/interfaces';
 import { createDID, resolveDIDFromLog, updateDID } from '../src/method';
 import { deriveHash, parseDidKeyDid, parseDidKeyVerificationMethod } from '../src/utils';
@@ -956,4 +962,56 @@ describe('Witness Implementation Tests', async () => {
       };
     };
   };
+
+  test('Resolves DID with legacy witnesses/witnessThreshold format in incremental entry', async () => {
+    const witnessKey = await generateTestVerificationMethod();
+    const witnessId = `did:key:${witnessKey.publicKeyMultibase}`;
+    const witnessVmId = `${witnessId}#${witnessKey.publicKeyMultibase}`;
+
+    const noWitnessDID = await createDID({
+      domain: 'example.com',
+      signer: createTestSigner(authKey),
+      updateKeys: [authKey.publicKeyMultibase!],
+      verificationMethods: asPublicVerificationMethods(authKey),
+      verifier: testImplementation,
+      created: '2021-01-01T00:00:00Z',
+    });
+
+    const versionTime = '2021-01-02T00:00:00Z';
+    const baseEntry = {
+      versionId: noWitnessDID.log[0].versionId,
+      versionTime,
+      parameters: {
+        updateKeys: [authKey.publicKeyMultibase!],
+        witnesses: [{ id: witnessId }],
+        witnessThreshold: 1,
+      },
+      state: noWitnessDID.log[0].state,
+    };
+    const logEntryHash = await deriveHash(baseEntry);
+    const versionId = `2-${logEntryHash}`;
+    const signer = createTestSigner(authKey);
+    const proofTemplate: DataIntegrityProofTemplate = {
+      type: 'DataIntegrityProof',
+      cryptosuite: 'eddsa-jcs-2022',
+      verificationMethod: signer.getVerificationMethodId(),
+      created: versionTime,
+      proofPurpose: 'assertionMethod',
+    };
+    const signedProof = await signer.sign({ document: { ...baseEntry, versionId }, proof: proofTemplate });
+    const v2Entry = { ...baseEntry, versionId, proof: [{ ...proofTemplate, proofValue: signedProof.proofValue }] };
+
+    const legacyLog = [noWitnessDID.log[0], v2Entry] as DIDLog;
+    const witnessSignerFn = createWitnessSigner(witnessKey);
+    const witnessProof = await createWitnessProof(witnessSignerFn, versionId, witnessVmId);
+
+    const resolved = await resolveDIDFromLog(legacyLog, {
+      verifier: testImplementation,
+      witnessProofs: [{ versionId, proof: [witnessProof] }],
+    });
+
+    expect(resolved.meta.witness?.witnesses).toHaveLength(1);
+    expect(resolved.meta.witness?.witnesses?.[0].id).toBe(witnessId);
+    expect(resolved.meta.witness?.threshold).toBe(1);
+  });
 });


### PR DESCRIPTION
Fill in one last spec gap around portability and enhance test coverage

**Existing Behaviour**
* `createDID()` defaults `portable: false` in `params` if not provided
* `createDID()` writes `false` to `params` if provided
* `createDID()` writes `true` to `params` if provided
* `updateDID()` retains prior `portable` value if omitted from `params`

**New**
* `updateDID()` writes `portable: false` to `params` if provided
* `updateDID()` throws early if `portable: true` provided

Also added more extensive coverage of `method.v1.0.ts` code paths reaching `97.72%` of lines reported with `bun test --coverage`. Remaining gaps are all deep guard code unreachable by tests.

`verificationMethod` query option now returns `notFound` (whether we want to keep supporting `verificationMethod` is linked to issue #130 )