### PR TITLE
fix(versionTime): trim ms, update tests

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -45,6 +45,7 @@ Options:
   --domain [domain]         DEPRECATED: Use --address instead. Domain for the DID (backwards compatibility).
   --log [file]              Path to the DID log file (required for resolve, update, deactivate)
   --output [file]           Path to save the updated DID log (optional for create, update, deactivate)
+  --updated [timestamp]     Explicit update timestamp in UTC ISO8601 (e.g. 2026-01-01T12:00:00Z)
   --portable                Make the DID portable (optional for create)
   --witness [witness]       Add a witness (can be used multiple times)
   --witness-threshold [n]   Set witness threshold (optional, defaults to number of witnesses)
@@ -69,6 +70,7 @@ Examples:
   bun run cli resolve --did did:webvh:123456:example.com
   bun run cli resolve --log ./did.jsonl --witness-file ./did-witness.json
   bun run cli update --log ./did.jsonl --output ./updated-did.jsonl --add-vm keyAgreement --service LinkedDomains,https://example.com
+  bun run cli update --log ./did.jsonl --output ./updated-did.jsonl --updated 2026-01-01T12:00:00Z
   bun run cli deactivate --log ./did.jsonl --output ./deactivated-did.jsonl
   bun run cli generate-witness-proof --version-id 1-abc123 --witness-did did:key:z6Mk... --witness-secret z1A... --output did-witness.json
   bun run cli generate-witness-proof --version-id 1-abc123 --version-id 2-def456 --witness-did did:key:z6Mk... --witness-secret z1A... --output did-witness.json
@@ -300,6 +302,7 @@ export async function handleUpdate(args: string[]) {
   const options = parseOptions(args);
   const logFile = options.log as string;
   const output = options.output as string | undefined;
+  const updated = options.updated as string | undefined;
   const witnesses = options.witness as string[] | undefined;
   const witnessThreshold = options['witness-threshold']
     ? parseInt(options['witness-threshold'] as string, 10)
@@ -392,6 +395,7 @@ export async function handleUpdate(args: string[]) {
     const crypto = createCustomCrypto(vm);
     const result = await updateDID({
       log,
+      updated,
       signer: crypto,
       verifier: crypto,
       updateKeys: [vmPublicKeyMultibase],

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -717,7 +717,8 @@ export async function fetchLogFromIdentifier(identifier: string, controlled: boo
   }
 }
 
-export const createDate = (created?: Date | string) => new Date(created ?? Date.now()).toISOString();
+export const createDate = (created?: Date | string) =>
+  new Date(created ?? Date.now()).toISOString().replace(/\.\d{1,3}Z$/, 'Z');
 
 export function bytesToHex(bytes: Uint8Array): string {
   return Array.from(bytes)

--- a/src/utils/iso8601-datetime.ts
+++ b/src/utils/iso8601-datetime.ts
@@ -128,10 +128,5 @@ export function createNextVersionTime(
     return formatDate(requestedVersionTime);
   }
 
-  const now = new Date();
-  if (now.getTime() <= previous.getTime()) {
-    return formatDate(new Date(previous.getTime() + 1));
-  }
-
-  return formatDate(now);
+  return formatDate(new Date());
 }

--- a/test/cli-e2e.test.ts
+++ b/test/cli-e2e.test.ts
@@ -56,6 +56,19 @@ async function createTempVerificationMethod(vm: VerificationMethod): Promise<str
   return tempFile;
 }
 
+async function nextUpdatedTimestamp(logFile: string): Promise<string> {
+  const log = await readLogFromDisk(logFile);
+  const lastVersionTime = new Date(log[log.length - 1].versionTime);
+  return new Date(lastVersionTime.getTime() + 1000).toISOString().replace(/\.\d{1,3}Z$/, 'Z');
+}
+
+async function waitForNextSecondBoundary(): Promise<void> {
+  const startSecond = Math.floor(Date.now() / 1000);
+  while (Math.floor(Date.now() / 1000) === startSecond) {
+    await Bun.sleep(20);
+  }
+}
+
 describe('CLI End-to-End Tests', async () => {
   test('Create DID using CLI', async () => {
     const proc =
@@ -72,7 +85,8 @@ describe('CLI End-to-End Tests', async () => {
     expect(createProc.exitCode).toBe(0);
 
     // Update the DID — reads authKey from .env so signer matches updateKeys
-    const updateProc = await $`bun run cli update --log ${logFile} --output ${logFile}`.quiet();
+    const updated = await nextUpdatedTimestamp(logFile);
+    const updateProc = await $`bun run cli update --log ${logFile} --output ${logFile} --updated ${updated}`.quiet();
     expect(updateProc.exitCode).toBe(0);
 
     // Verify the update was successful
@@ -88,11 +102,13 @@ describe('CLI End-to-End Tests', async () => {
     expect(createProc.exitCode).toBe(0);
 
     // First update
-    const update1Proc = await $`bun run cli update --log ${logFile} --output ${logFile}`.quiet();
+    const updated1 = await nextUpdatedTimestamp(logFile);
+    const update1Proc = await $`bun run cli update --log ${logFile} --output ${logFile} --updated ${updated1}`.quiet();
     expect(update1Proc.exitCode).toBe(0);
 
     // Second update
-    const update2Proc = await $`bun run cli update --log ${logFile} --output ${logFile}`.quiet();
+    const updated2 = await nextUpdatedTimestamp(logFile);
+    const update2Proc = await $`bun run cli update --log ${logFile} --output ${logFile} --updated ${updated2}`.quiet();
     expect(update2Proc.exitCode).toBe(0);
 
     // Verify the updates were successful
@@ -108,6 +124,7 @@ describe('CLI End-to-End Tests', async () => {
     expect(createProc.exitCode).toBe(0);
 
     // Deactivate the DID — reads authKey from .env so signer matches updateKeys
+    await waitForNextSecondBoundary();
     const deactivateProc = await $`bun run cli deactivate --log ${logFile} --output ${logFile}`.quiet();
     expect(deactivateProc.exitCode).toBe(0);
 
@@ -152,8 +169,9 @@ describe('CLI End-to-End Tests', async () => {
     const { did } = await resolveDIDFromLog(initialLog, { verifier });
 
     // Add all VM types in a single update — reads authKey from .env
+    const updated = await nextUpdatedTimestamp(vmLogFile);
     const proc =
-      await $`bun run cli update --log ${vmLogFile} --output ${vmLogFile} --add-vm authentication --add-vm assertionMethod --add-vm keyAgreement --add-vm capabilityInvocation --add-vm capabilityDelegation`.quiet();
+      await $`bun run cli update --log ${vmLogFile} --output ${vmLogFile} --updated ${updated} --add-vm authentication --add-vm assertionMethod --add-vm keyAgreement --add-vm capabilityInvocation --add-vm capabilityDelegation`.quiet();
     expect(proc.exitCode).toBe(0);
 
     // Verify all VM types were added
@@ -189,7 +207,9 @@ describe('CLI End-to-End Tests', async () => {
 
     // Update with alsoKnownAs — reads authKey from .env
     const alias = 'https://example.com/users/123';
-    const proc = await $`bun run cli update --log ${akLogFile} --output ${akLogFile} --also-known-as ${alias}`.quiet();
+    const updated = await nextUpdatedTimestamp(akLogFile);
+    const proc =
+      await $`bun run cli update --log ${akLogFile} --output ${akLogFile} --updated ${updated} --also-known-as ${alias}`.quiet();
     expect(proc.exitCode).toBe(0);
 
     // Verify alsoKnownAs was added

--- a/test/did-document-passthrough.test.ts
+++ b/test/did-document-passthrough.test.ts
@@ -6,6 +6,7 @@ import {
   createTestSigner,
   createTestVerifier,
   generateTestVerificationMethod,
+  nextSecond,
 } from './utils';
 
 describe('didDocument create pass-through', () => {
@@ -150,6 +151,7 @@ describe('didDocument create pass-through', () => {
     try {
       const updated = await updateDID({
         log: created.log,
+        updated: nextSecond(created.log),
         signer: createTestSigner(authKey),
         verifier: createTestVerifier(authKey),
         updateKeys: [authKey.publicKeyMultibase!],
@@ -333,6 +335,7 @@ describe('generateParallelDidWeb', () => {
 
     const updated = await updateDID({
       log: created.log,
+      updated: nextSecond(created.log),
       signer: createTestSigner(authKey),
       verifier: createTestVerifier(authKey),
       updateKeys: [authKey.publicKeyMultibase!],

--- a/test/features.test.ts
+++ b/test/features.test.ts
@@ -7,6 +7,7 @@ import {
   asPublicVerificationMethods,
   createTestSigner,
   generateTestVerificationMethod,
+  nextSecond,
   TestCryptoImplementation,
 } from './utils';
 
@@ -171,6 +172,7 @@ test('Empty nextKeyHashes array should not enable prerotation', async () => {
   // Update with different updateKeys — no prerotation constraint
   const { log: log2 } = await updateDID({
     log: log1,
+    updated: nextSecond(log1),
     signer: createTestSigner(authKey1),
     updateKeys: [authKey2.publicKeyMultibase!],
     verificationMethods: asPublicVerificationMethods(authKey2),
@@ -196,6 +198,7 @@ test('Omitted nextKeyHashes inherits previous pre-rotation state', async () => {
 
   const { log: log2 } = await updateDID({
     log: log1,
+    updated: nextSecond(log1),
     signer: createTestSigner(authKey2),
     updateKeys: [authKey2.publicKeyMultibase!],
     verificationMethods: asPublicVerificationMethods(authKey2),
@@ -243,6 +246,7 @@ test('Explicit empty nextKeyHashes disables pre-rotation', async () => {
 
   const { log: log2 } = await updateDID({
     log: log1,
+    updated: nextSecond(log1),
     signer: createTestSigner(authKey2),
     updateKeys: [authKey2.publicKeyMultibase!],
     nextKeyHashes: [],

--- a/test/happy-path.test.ts
+++ b/test/happy-path.test.ts
@@ -4,6 +4,7 @@ import {
   asPublicVerificationMethods,
   createTestSigner,
   generateTestVerificationMethod,
+  nextSecond,
   TestCryptoImplementation,
 } from './utils';
 
@@ -61,6 +62,7 @@ describe('Happy Path Tests', () => {
     const authKey2 = await generateTestVerificationMethod();
     const { doc: updatedDoc } = await updateDID({
       log: initialLog,
+      updated: nextSecond(initialLog),
       signer: createTestSigner(authKey1),
       updateKeys: [authKey2.publicKeyMultibase!],
       verificationMethods: asPublicVerificationMethods(authKey2),
@@ -88,6 +90,7 @@ describe('Happy Path Tests', () => {
     const authKey3 = await generateTestVerificationMethod();
     const { doc: updatedDoc } = await updateDID({
       log: initialLog,
+      updated: nextSecond(initialLog),
       signer: createTestSigner(authKey1),
       updateKeys: [authKey2.publicKeyMultibase!, authKey3.publicKeyMultibase!],
       verificationMethods: asPublicVerificationMethods(authKey2, authKey3),
@@ -115,6 +118,7 @@ describe('Happy Path Tests', () => {
     const externalDID = 'did:example:123#key-1';
     const { doc: updatedDoc } = await updateDID({
       log: initialLog,
+      updated: nextSecond(initialLog),
       signer: createTestSigner(authKey1),
       updateKeys: [authKey1.publicKeyMultibase!],
       authentication: [externalDID],
@@ -146,6 +150,7 @@ describe('Happy Path Tests', () => {
     // Update the DID with the new verification methods
     const { doc: updatedDoc } = await updateDID({
       log: initialLog,
+      updated: nextSecond(initialLog),
       signer: createTestSigner(authKey1),
       updateKeys: [authKey1.publicKeyMultibase!],
       verificationMethods: asPublicVerificationMethods(assertionKey, keyAgreementKey),
@@ -178,6 +183,7 @@ describe('Happy Path Tests', () => {
 
     const { doc: updatedDoc } = await updateDID({
       log: initialLog,
+      updated: nextSecond(initialLog),
       signer: createTestSigner(authKey1),
       updateKeys: [authKey1.publicKeyMultibase!],
       services: [service],
@@ -203,6 +209,7 @@ describe('Happy Path Tests', () => {
     const alias = 'did:web:example.com';
     const { doc: updatedDoc } = await updateDID({
       log: initialLog,
+      updated: nextSecond(initialLog),
       signer: createTestSigner(authKey1),
       updateKeys: [authKey1.publicKeyMultibase!],
       alsoKnownAs: [alias],
@@ -228,6 +235,7 @@ describe('Happy Path Tests', () => {
     const controller = 'did:example:123';
     const { doc: updatedDoc } = await updateDID({
       log: initialLog,
+      updated: nextSecond(initialLog),
       signer: createTestSigner(authKey1),
       updateKeys: [authKey1.publicKeyMultibase!],
       controller,
@@ -252,6 +260,7 @@ describe('Happy Path Tests', () => {
     const nextKeyHash = 'z6MkgYGF3thn8k1Qz9P4c3mKthZXNhUgkdwBwE5hbWFJktGH';
     const { doc: updatedDoc, meta } = await updateDID({
       log: initialLog,
+      updated: nextSecond(initialLog),
       signer: createTestSigner(authKey1),
       updateKeys: [authKey1.publicKeyMultibase!],
       nextKeyHashes: [nextKeyHash],
@@ -284,6 +293,7 @@ describe('Happy Path Tests', () => {
 
     const { doc: updatedDoc } = await updateDID({
       log: initialLog,
+      updated: nextSecond(initialLog),
       signer: createTestSigner(authKey1),
       verificationMethods: asPublicVerificationMethods(authKey1),
       verifier,
@@ -313,6 +323,7 @@ describe('Happy Path Tests', () => {
 
     const { log: updatedLog, meta } = await updateDID({
       log: initialLog,
+      updated: nextSecond(initialLog),
       signer: createTestSigner(authKey1),
       verificationMethods: asPublicVerificationMethods(authKey1),
       verifier,

--- a/test/not-so-happy-path.test.ts
+++ b/test/not-so-happy-path.test.ts
@@ -17,6 +17,13 @@ describe('Not So Happy Path Tests', () => {
   let testImplementation: TestCryptoImplementation;
   let initialDID: CreateDIDResult;
 
+  const waitForNextSecondBoundary = async () => {
+    const startSecond = Math.floor(Date.now() / 1000);
+    while (Math.floor(Date.now() / 1000) === startSecond) {
+      await Bun.sleep(20);
+    }
+  };
+
   beforeAll(async () => {
     authKey = await generateTestVerificationMethod();
     testImplementation = new TestCryptoImplementation({ verificationMethod: authKey });
@@ -591,6 +598,8 @@ describe('Not So Happy Path Tests', () => {
   });
 
   test('updateDID rejects when the DID is already deactivated', async () => {
+    await waitForNextSecondBoundary();
+
     const { log: deactivatedLog } = await deactivateDID({
       log: initialDID.log,
       signer: createTestSigner(authKey),
@@ -616,6 +625,9 @@ describe('Not So Happy Path Tests', () => {
       verificationMethods: asPublicVerificationMethods(authKey),
       verifier: testImplementation,
     });
+
+    await waitForNextSecondBoundary();
+
     const { log: deactivatedLog } = await deactivateDID({
       log: log1,
       signer: createTestSigner(authKey),

--- a/test/not-so-happy-path.test.ts
+++ b/test/not-so-happy-path.test.ts
@@ -8,6 +8,7 @@ import {
   createFutureDIDLog,
   createTestSigner,
   generateTestVerificationMethod,
+  nextSecond,
   TestCryptoImplementation,
 } from './utils';
 
@@ -89,6 +90,7 @@ describe('Not So Happy Path Tests', () => {
 
     const { log: log2 } = await updateDID({
       log: log1,
+      updated: nextSecond(log1),
       signer: createTestSigner(authKey),
       updateKeys: [authKey.publicKeyMultibase!],
       verificationMethods: asPublicVerificationMethods(authKey),
@@ -117,6 +119,7 @@ describe('Not So Happy Path Tests', () => {
     for (let j = 0; j < 12; j++) {
       const { log: nextLog } = await updateDID({
         log: currentLog,
+        updated: nextSecond(currentLog),
         signer: createTestSigner(authKey),
         updateKeys: [authKey.publicKeyMultibase!],
         verificationMethods: asPublicVerificationMethods(authKey),
@@ -148,6 +151,7 @@ describe('Not So Happy Path Tests', () => {
     for (let j = 0; j < 12; j++) {
       const { log: nextLog } = await updateDID({
         log: currentLog,
+        updated: nextSecond(currentLog),
         signer: createTestSigner(authKey),
         updateKeys: [authKey.publicKeyMultibase!],
         verificationMethods: asPublicVerificationMethods(authKey),
@@ -173,6 +177,7 @@ describe('Not So Happy Path Tests', () => {
 
     const { log: log2 } = await updateDID({
       log: log1,
+      updated: nextSecond(log1),
       signer: createTestSigner(authKey),
       updateKeys: [authKey.publicKeyMultibase!],
       verificationMethods: asPublicVerificationMethods(authKey),
@@ -181,6 +186,7 @@ describe('Not So Happy Path Tests', () => {
 
     const { log: log3 } = await updateDID({
       log: log2,
+      updated: nextSecond(log2),
       signer: createTestSigner(authKey),
       updateKeys: [authKey.publicKeyMultibase!],
       verificationMethods: asPublicVerificationMethods(authKey),
@@ -215,6 +221,7 @@ describe('Not So Happy Path Tests', () => {
 
     const { log: log2 } = await updateDID({
       log: log1,
+      updated: nextSecond(log1),
       signer: createTestSigner(authKey),
       updateKeys: [authKey.publicKeyMultibase!],
       verificationMethods: asPublicVerificationMethods(authKey),
@@ -223,6 +230,7 @@ describe('Not So Happy Path Tests', () => {
 
     const { log: log3 } = await updateDID({
       log: log2,
+      updated: nextSecond(log2),
       signer: createTestSigner(authKey),
       updateKeys: [authKey.publicKeyMultibase!],
       verificationMethods: asPublicVerificationMethods(authKey),
@@ -254,6 +262,7 @@ describe('Not So Happy Path Tests', () => {
 
     const { log: log2 } = await updateDID({
       log: log1,
+      updated: nextSecond(log1),
       signer: createTestSigner(authKey),
       updateKeys: [authKey.publicKeyMultibase!],
       verificationMethods: asPublicVerificationMethods(authKey),
@@ -262,6 +271,7 @@ describe('Not So Happy Path Tests', () => {
 
     const { log: log3 } = await updateDID({
       log: log2,
+      updated: nextSecond(log2),
       signer: createTestSigner(authKey),
       updateKeys: [authKey.publicKeyMultibase!],
       verificationMethods: asPublicVerificationMethods(authKey),
@@ -406,6 +416,7 @@ describe('Not So Happy Path Tests', () => {
     const { log } = initialDID;
     const updateResult = await updateDID({
       log,
+      updated: nextSecond(log),
       domain: 'example.com',
       signer: createTestSigner(authKey),
       updateKeys: [authKey.publicKeyMultibase!],
@@ -424,6 +435,7 @@ describe('Not So Happy Path Tests', () => {
     const { log } = initialDID;
     const updateResult = await updateDID({
       log,
+      updated: nextSecond(log),
       domain: 'example.com',
       signer: createTestSigner(authKey),
       updateKeys: [authKey.publicKeyMultibase!],
@@ -442,6 +454,7 @@ describe('Not So Happy Path Tests', () => {
     const { log } = initialDID;
     const updateResult = await updateDID({
       log,
+      updated: nextSecond(log),
       domain: 'example.com',
       signer: createTestSigner(authKey),
       updateKeys: [authKey.publicKeyMultibase!],

--- a/test/portability.test.ts
+++ b/test/portability.test.ts
@@ -5,6 +5,7 @@ import {
   asPublicVerificationMethods,
   createTestSigner,
   generateTestVerificationMethod,
+  nextSecond,
   TestCryptoImplementation,
 } from './utils';
 
@@ -39,6 +40,7 @@ describe('Portability', () => {
   test('Rejects setting portable: true in a later entry', async () => {
     const updateResult = await updateDID({
       log: nonPortableDID.log,
+      updated: nextSecond(nonPortableDID.log),
       domain: 'example.com',
       signer: createTestSigner(authKey),
       updateKeys: [authKey.publicKeyMultibase!],
@@ -66,6 +68,7 @@ describe('Portability', () => {
 
     const updateResult = await updateDID({
       log: did.log,
+      updated: nextSecond(did.log),
       domain: 'example.com',
       signer: createTestSigner(authKey),
       updateKeys: [authKey.publicKeyMultibase!],
@@ -85,6 +88,7 @@ describe('Portability', () => {
     // Use the proper API to produce a legitimately signed update that sets portable: false
     const updateResult = await updateDID({
       log: portableDID.log,
+      updated: nextSecond(portableDID.log),
       domain: 'example.com',
       portable: false,
       signer: createTestSigner(authKey),
@@ -99,6 +103,7 @@ describe('Portability', () => {
   test('Rejects SCID change in state.id during portable rename', async () => {
     const updateResult = await updateDID({
       log: portableDID.log,
+      updated: nextSecond(portableDID.log),
       domain: 'example.com',
       signer: createTestSigner(authKey),
       updateKeys: [authKey.publicKeyMultibase!],
@@ -120,6 +125,7 @@ describe('Portability', () => {
   test('Portable DID moves to a new domain via the domain option', async () => {
     const updateResult = await updateDID({
       log: portableDID.log,
+      updated: nextSecond(portableDID.log),
       domain: 'example.org',
       signer: createTestSigner(authKey),
       updateKeys: [authKey.publicKeyMultibase!],
@@ -143,6 +149,7 @@ describe('Portability', () => {
     await expect(
       updateDID({
         log: nonPortableDID.log,
+        updated: nextSecond(nonPortableDID.log),
         domain: 'example.org',
         signer: createTestSigner(authKey),
         updateKeys: [authKey.publicKeyMultibase!],
@@ -165,6 +172,7 @@ describe('Portability', () => {
     // Caller threads the same domain through the update but omits paths.
     const updateResult = await updateDID({
       log: pathedDID.log,
+      updated: nextSecond(pathedDID.log),
       domain: 'example.com',
       signer: createTestSigner(authKey),
       updateKeys: [authKey.publicKeyMultibase!],
@@ -180,6 +188,7 @@ describe('Portability', () => {
   test('Portable DID moves to a pathed location via the address option', async () => {
     const updateResult = await updateDID({
       log: portableDID.log,
+      updated: nextSecond(portableDID.log),
       address: 'https://example.org/dids/alice',
       signer: createTestSigner(authKey),
       updateKeys: [authKey.publicKeyMultibase!],

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -11,8 +11,12 @@ import type {
   VerificationMethod,
   Verifier,
 } from '../src/interfaces';
-import { createDIDDoc, createSCID, deriveHash, replaceCreateDidPlaceholders } from '../src/utils';
+import { createDate, createDIDDoc, createSCID, deriveHash, replaceCreateDidPlaceholders } from '../src/utils';
 import { MultibaseEncoding, multibaseDecode, multibaseEncode } from '../src/utils/multiformats';
+
+/** Returns the versionTime one second after the last entry in a DID log. Use in tests when chaining rapid create/update/deactivate calls. */
+export const nextSecond = (log: DIDLog): string =>
+  createDate(new Date(new Date(log[log.length - 1].versionTime).getTime() + 1000));
 
 export function createMockDIDLog(entries: Partial<DIDLogEntry>[]): DIDLog {
   return entries.map((entry, index) => {

--- a/test/watchers.test.ts
+++ b/test/watchers.test.ts
@@ -4,6 +4,7 @@ import {
   asPublicVerificationMethods,
   createTestSigner,
   generateTestVerificationMethod,
+  nextSecond,
   TestCryptoImplementation,
 } from './utils';
 
@@ -42,6 +43,7 @@ describe('Watcher Handling', () => {
 
     const updated = await updateDID({
       log: initial.log,
+      updated: nextSecond(initial.log),
       signer: createTestSigner(authKey),
       updateKeys: [authKey.publicKeyMultibase!],
       verificationMethods: asPublicVerificationMethods(authKey),
@@ -68,6 +70,7 @@ describe('Watcher Handling', () => {
 
     const updated = await updateDID({
       log: initial.log,
+      updated: nextSecond(initial.log),
       signer: createTestSigner(authKey),
       updateKeys: [authKey.publicKeyMultibase!],
       verificationMethods: asPublicVerificationMethods(authKey),

--- a/test/witness.test.ts
+++ b/test/witness.test.ts
@@ -14,6 +14,7 @@ import {
   asPublicVerificationMethods,
   createTestSigner,
   generateTestVerificationMethod,
+  nextSecond,
   TestCryptoImplementation,
 } from './utils';
 
@@ -95,6 +96,7 @@ describe('Witness Implementation Tests', async () => {
 
     const updatedDID = await updateDID({
       log: noWitnessDID.log,
+      updated: nextSecond(noWitnessDID.log),
       signer: createTestSigner(authKey),
       updateKeys: [newAuthKey.publicKeyMultibase!],
       verificationMethods: asPublicVerificationMethods(newAuthKey),
@@ -145,6 +147,7 @@ describe('Witness Implementation Tests', async () => {
 
     const updatedDID = await updateDID({
       log: noWitnessDID.log,
+      updated: nextSecond(noWitnessDID.log),
       signer: createTestSigner(authKey),
       updateKeys: [newAuthKey.publicKeyMultibase!],
       verificationMethods: asPublicVerificationMethods(newAuthKey),
@@ -230,6 +233,7 @@ describe('Witness Implementation Tests', async () => {
 
     const updated = await updateDID({
       log: created.log,
+      updated: nextSecond(created.log),
       signer: createTestSigner(authKey),
       updateKeys: [authKey2.publicKeyMultibase!],
       verificationMethods: asPublicVerificationMethods(authKey2),
@@ -290,6 +294,7 @@ describe('Witness Implementation Tests', async () => {
 
     const firstUpdate = await updateDID({
       log: created.log,
+      updated: nextSecond(created.log),
       signer: createTestSigner(authKey),
       updateKeys: [`did:key:${authKey2.publicKeyMultibase}`],
       verificationMethods: asPublicVerificationMethods(authKey2),
@@ -311,6 +316,7 @@ describe('Witness Implementation Tests', async () => {
     await expect(
       updateDID({
         log: firstUpdate.log,
+        updated: nextSecond(firstUpdate.log),
         signer: createTestSigner(authKey2),
         updateKeys: [authKey3.publicKeyMultibase!],
         verificationMethods: asPublicVerificationMethods(authKey3),
@@ -349,6 +355,7 @@ describe('Witness Implementation Tests', async () => {
     await expect(
       updateDID({
         log: created.log,
+        updated: nextSecond(created.log),
         signer: nonCompliantSigner,
         updateKeys: [authKey2.publicKeyMultibase!],
         verificationMethods: asPublicVerificationMethods(authKey2),
@@ -372,6 +379,7 @@ describe('Witness Implementation Tests', async () => {
 
     const updatedDID = await updateDID({
       log: initialDID.log,
+      updated: nextSecond(initialDID.log),
       signer: createTestSigner(authKey),
       updateKeys: [authKey.publicKeyMultibase!],
       verificationMethods: asPublicVerificationMethods(authKey),
@@ -415,6 +423,7 @@ describe('Witness Implementation Tests', async () => {
 
     const updatedDID = await updateDID({
       log: initialDID.log,
+      updated: nextSecond(initialDID.log),
       signer: createTestSigner(authKey),
       updateKeys: [authKey.publicKeyMultibase!],
       verificationMethods: asPublicVerificationMethods(authKey),
@@ -671,6 +680,7 @@ describe('Witness Implementation Tests', async () => {
 
     const updatedDid = await updateDID({
       log: didWithWitness.log,
+      updated: nextSecond(didWithWitness.log),
       signer: createTestSigner(authKey),
       updateKeys: [authKey.publicKeyMultibase!],
       verificationMethods: asPublicVerificationMethods(authKey),
@@ -724,6 +734,7 @@ describe('Witness Implementation Tests', async () => {
 
     const updatedDid = await updateDID({
       log: didWithWitness.log,
+      updated: nextSecond(didWithWitness.log),
       signer: createTestSigner(authKey),
       updateKeys: [authKey.publicKeyMultibase!],
       verificationMethods: asPublicVerificationMethods(authKey),
@@ -826,6 +837,7 @@ describe('Witness Implementation Tests', async () => {
 
     const updatedDid = await updateDID({
       log: didWithWitness.log,
+      updated: nextSecond(didWithWitness.log),
       signer: createTestSigner(authKey),
       updateKeys: [authKey.publicKeyMultibase!],
       verificationMethods: asPublicVerificationMethods(authKey),
@@ -884,6 +896,7 @@ describe('Witness Implementation Tests', async () => {
     expect(
       updateDID({
         log: noWitnessDID.log,
+        updated: nextSecond(noWitnessDID.log),
         signer: createTestSigner(authKey),
         updateKeys: [authKey.publicKeyMultibase!],
         verificationMethods: asPublicVerificationMethods(authKey),
@@ -907,6 +920,7 @@ describe('Witness Implementation Tests', async () => {
 
     const updatedDID = await updateDID({
       log: noWitnessDID.log,
+      updated: nextSecond(noWitnessDID.log),
       signer: createTestSigner(authKey),
       updateKeys: [authKey.publicKeyMultibase!],
       verificationMethods: asPublicVerificationMethods(authKey),


### PR DESCRIPTION
Trimmed `versionTime` to second precision

This change was a lot more extensive than anticipated because previously in the runtime we automatically bumped every log creation by 1 msec to help the tests pass

I stripped this out so that creation uses the actual wall clock time

This meant:
* we needed a new test helper (`nextSecond`) to bump each log entry by 1 second in chained tests
* we needed to support `--updated` pass-through in the CLI (mirroring the API) and use this in tests
* use a delay in `deactivateDID` tests because we cannot pass through `versionTime` (`--updated`) to this method - I can add this as well if we want users to be able to set deactivation time

Using Bun's mock timers was much more ugly than the single `nextSecond` helper, and because the CLI e2e tests execute as a sub-process, these weren't available in the `cli-e2e` test suite

NB the test suite now takes about 3+ seconds longer to run which is annoying

 