### PR TITLE
fix(portability): populate alsoKnownAs on move

### DIFF
--- a/src/method_versions/method.v1.0.ts
+++ b/src/method_versions/method.v1.0.ts
@@ -758,13 +758,13 @@ export const updateDID = async (
     doc.alsoKnownAs = options.alsoKnownAs;
   }
 
-    if (controller !== lastEntryDid) {
-      const aliases = Array.isArray(doc.alsoKnownAs) ? [...doc.alsoKnownAs] : [];
-      if (!aliases.includes(lastEntryDid)) {
-        aliases.push(lastEntryDid);
-      }
-      doc.alsoKnownAs = aliases;
+  if (controller !== lastEntryDid) {
+    const aliases = Array.isArray(doc.alsoKnownAs) ? [...doc.alsoKnownAs] : [];
+    if (!aliases.includes(lastEntryDid)) {
+      aliases.push(lastEntryDid);
     }
+    doc.alsoKnownAs = aliases;
+  }
 
   const logEntry: DIDLogEntry = {
     versionId: lastEntry.versionId,

--- a/src/method_versions/method.v1.0.ts
+++ b/src/method_versions/method.v1.0.ts
@@ -758,6 +758,14 @@ export const updateDID = async (
     doc.alsoKnownAs = options.alsoKnownAs;
   }
 
+    if (controller !== lastEntryDid) {
+      const aliases = Array.isArray(doc.alsoKnownAs) ? [...doc.alsoKnownAs] : [];
+      if (!aliases.includes(lastEntryDid)) {
+        aliases.push(lastEntryDid);
+      }
+      doc.alsoKnownAs = aliases;
+    }
+
   const logEntry: DIDLogEntry = {
     versionId: lastEntry.versionId,
     versionTime: createdDate,

--- a/test/portability.test.ts
+++ b/test/portability.test.ts
@@ -160,11 +160,13 @@ describe('Portability', () => {
 
     // The new entry's state.id must reflect the new location, same SCID
     expect(updateResult.log[1].state.id).toBe(`did:webvh:${scid}:example.org`);
+    expect(updateResult.log[1].state.alsoKnownAs).toContain(originalDid);
 
     // And it must resolve to the moved DID
     const resolved = await resolveDIDFromLog(updateResult.log, { verifier: testImplementation });
     expect(resolved.did).toBe(`did:webvh:${scid}:example.org`);
     expect(resolved.doc?.id).toBe(`did:webvh:${scid}:example.org`);
+    expect(resolved.doc?.alsoKnownAs).toContain(originalDid);
   });
 
   test('Non-portable DID rejects a move to a new domain', async () => {


### PR DESCRIPTION
Fix rust interop test around `portable-move`

TS implementation wasn't populating `alsoKnownAs` with previous DID on move, now spec aligned with `DIFF` not `FAIL`

Remaining mismatch is in resolved output shape (implementation-specific, not spec misalignment):
* Rust returns absolute implicit service IDs like `did:webvh:...#files` and `did:webvh:...#whois`while TS expects `#files` and `#whois`.
* Rust includes extra metadata fields such as `deactivated`, `portable`, `scid`, `watchers` and `witness`
* Rust returns `didResolutionMetadata.contentType` where some expected outputs omit or differ on that shape.