### PR TITLE
fix(versionTime): guarantee strict monotonicity at second precision

### DIFF
--- a/src/utils/iso8601-datetime.ts
+++ b/src/utils/iso8601-datetime.ts
@@ -120,13 +120,21 @@ export function createNextVersionTime(
 ): string {
   const previous = parseUtcIso8601VersionTime(previousVersionTime, 'previous versionTime');
 
+  // versionTime is stored at second precision, so compare the formatted (trimmed) value to
+  // guarantee strict monotonicity — sub-second differences vanish once persisted.
   if (requestedVersionTime) {
-    const requested = parseUtcIso8601VersionTime(requestedVersionTime, 'requested versionTime');
-    if (requested.getTime() <= previous.getTime()) {
+    parseUtcIso8601VersionTime(requestedVersionTime, 'requested versionTime');
+    const formatted = formatDate(requestedVersionTime);
+    if (new Date(formatted).getTime() <= previous.getTime()) {
       throw new Error('versionTime must be greater than previous versionTime');
     }
-    return formatDate(requestedVersionTime);
+    return formatted;
   }
 
-  return formatDate(new Date());
+  const formattedNow = formatDate(new Date());
+  if (new Date(formattedNow).getTime() <= previous.getTime()) {
+    return formatDate(new Date(previous.getTime() + 1000));
+  }
+
+  return formattedNow;
 }

--- a/test/iso8601-datetime.test.ts
+++ b/test/iso8601-datetime.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
-import { parseUtcIso8601VersionTime } from '../src/utils/iso8601-datetime';
+import { createDate } from '../src/utils';
+import { createNextVersionTime, parseUtcIso8601VersionTime } from '../src/utils/iso8601-datetime';
 
 describe('ISO8601 DateTime Validation', () => {
   test('Accepts Z timezone', () => {
@@ -11,5 +12,26 @@ describe('ISO8601 DateTime Validation', () => {
     expect(() => {
       parseUtcIso8601VersionTime('2025-11-02T10:20:30+01:00', 'test');
     }).toThrow('must be in UTC (Z or +00:00), found +01:00');
+  });
+});
+
+describe('createNextVersionTime', () => {
+  // versionTime is stored at second precision, so monotonicity must hold after trimming.
+  test('rejects a requested time that collides with previous once trimmed to seconds', () => {
+    expect(() => createNextVersionTime('2025-01-01T00:00:00Z', '2025-01-01T00:00:00.500Z', createDate)).toThrow(
+      'versionTime must be greater than previous versionTime'
+    );
+  });
+
+  test('advances past previous when the clock has not reached the next second', () => {
+    // Previous is ahead of the wall clock, forcing the same-second collision branch.
+    const previous = createDate(new Date(Date.now() + 60_000));
+    const next = createNextVersionTime(previous, undefined, createDate);
+    expect(new Date(next).getTime()).toBeGreaterThan(new Date(previous).getTime());
+  });
+
+  test('returns a strictly greater time for a valid requested update', () => {
+    const next = createNextVersionTime('2025-01-01T00:00:00Z', '2025-01-01T00:00:01Z', createDate);
+    expect(next).toBe('2025-01-01T00:00:01Z');
   });
 });


### PR DESCRIPTION
## Problem

#132 trimmed `versionTime` to whole-second precision **and** removed the runtime safeguard in `createNextVersionTime` that used to bump each new entry past the previous one. With both gone, two operations in the same wall-clock second now write identical `versionTime` values, and the resulting log fails its own resolution check (`versionTime ... must be greater than previous entry time`).

Two concrete failures:

1. **`deactivateDID` can produce an unresolvable log.** It has no `updated` passthrough, so a create-then-deactivate within the same second is unresolvable — and callers cannot work around it. The test suite masks this with `waitForNextSecondBoundary()` sleeps added before every deactivate in #132, which is direct evidence the production path was broken.
2. **The monotonicity guard checked the wrong precision.** Requested `updated` times were compared at millisecond precision while persisted at second precision, so e.g. `previous=12:00:00Z` + `updated=12:00:00.500Z` passed validation but trimmed to `12:00:00Z` — equal to previous — writing a non-increasing (invalid) entry.

## Fix

Both stem from one root cause, so the fix lands in the single chokepoint shared by `updateDID` and `deactivateDID` — `createNextVersionTime`:

- Compare the **formatted (trimmed)** value, not the raw millisecond value, so the guard reflects what actually gets persisted.
- When the clock has not yet advanced to the next second, return `previous + 1s` so consecutive entries are always strictly increasing.

No changes to `deactivateDID`/`updateDID` call sites needed; the existing test sleeps are now redundant but left in place to keep this PR minimal.

## Tests

Added deterministic regression tests in `test/iso8601-datetime.test.ts` covering both gaps (both fail on current `main`, pass with this change). Full suite: 258 pass / 0 fail.
