### PR TITLE
fix(witness): verify proofs against their own versionId; govern list changes by the previous list

### DIFF
--- a/src/method_versions/method.v1.0.ts
+++ b/src/method_versions/method.v1.0.ts
@@ -909,20 +909,14 @@ const getRequiredWitnessForEntry = (
 ): WitnessParameterResolution | undefined => {
   const explicitWitness = getEntryWitnessParameter(parameters);
 
-  if (explicitWitness !== undefined) {
-    if (isWitnessActive(currentWitness)) {
-      return deepClone(currentWitness);
-    }
-
-    if (isWitnessActive(previousWitness)) {
-      return deepClone(previousWitness);
-    }
-
-    return undefined;
-  }
-
+  // A list change takes effect only after its entry is published, so the previous list
+  // governs that entry; only activation from {} uses the new (current) list immediately.
   if (isWitnessActive(previousWitness)) {
     return deepClone(previousWitness);
+  }
+
+  if (explicitWitness !== undefined && isWitnessActive(currentWitness)) {
+    return deepClone(currentWitness);
   }
 
   return undefined;

--- a/src/witness.ts
+++ b/src/witness.ts
@@ -282,8 +282,9 @@ export async function countVerifiedWitnessApprovals(
 
         const { proofValue, ...proofWithoutValue } = proof;
 
-        // Create hashes
-        const canonicalizedData = canonicalizeStrict({ versionId: logEntry.versionId });
+        // Verify against the proof entry's own versionId (what the witness signed); a
+        // later proof cumulatively approves earlier entries.
+        const canonicalizedData = canonicalizeStrict({ versionId: proofSet.versionId });
         const canonicalizedProof = canonicalizeStrict(proofWithoutValue);
         const dataHash = await createHash(canonicalizedData);
         const proofHash = await createHash(canonicalizedProof);

--- a/test/witness.test.ts
+++ b/test/witness.test.ts
@@ -397,14 +397,15 @@ describe('Witness Implementation Tests', async () => {
       witnessProofs,
     });
 
-    // Create proof for new version from new witness
+    // The replacing entry is governed by the previous list, so v2 needs witness1 + witness2.
     const newVersionId = updatedDID.log[1].versionId;
-    const newWitnessSignerFn = createWitnessSigner(newWitness);
-    const newProof = await createWitnessProof(newWitnessSignerFn, newVersionId, witnessVerificationMethod(newWitness));
     const newWitnessProofs = [
       {
         versionId: newVersionId,
-        proof: [newProof],
+        proof: await Promise.all([
+          createWitnessProof(createWitnessSigner(witness1), newVersionId, witnessVerificationMethod(witness1)),
+          createWitnessProof(createWitnessSigner(witness2), newVersionId, witnessVerificationMethod(witness2)),
+        ]),
       },
     ];
 
@@ -705,23 +706,25 @@ describe('Witness Implementation Tests', async () => {
       ],
     });
 
+    // A v1-only proof leaves v2 unwitnessed: cumulative approval runs backwards, so an
+    // earlier proof never covers a later entry.
     await expect(
       resolveDIDFromLog(updatedDid.log, {
         verifier: testImplementation,
         witnessProofs: [
           {
-            versionId: updatedDid.log[1].versionId,
+            versionId: didWithWitness.log[0].versionId,
             proof: [
               await createWitnessProof(
                 createWitnessSigner(witness1),
-                updatedDid.log[1].versionId,
+                didWithWitness.log[0].versionId,
                 witnessVerificationMethod(witness1)
               ),
             ],
           },
         ],
       })
-    ).rejects.toThrow(`Witness threshold not met for version ${didWithWitness.log[0].versionId}`);
+    ).rejects.toThrow(`Witness threshold not met for version ${updatedDid.log[1].versionId}`);
   });
 
   test('Resolve accepts later proof for earlier required entry', async () => {
@@ -783,6 +786,115 @@ describe('Witness Implementation Tests', async () => {
     });
 
     expect(resolved.did).toBe(updatedDid.did);
+  });
+
+  test('Resolve accepts a single pruned later proof as cumulative approval for prior entries', async () => {
+    // A pruned file (one proof at the latest versionId) must witness every earlier entry,
+    // since a valid proof implies approval of all prior entries.
+    const witnessDid = `did:key:${witness1.publicKeyMultibase}`;
+    const didWithWitness = await createDID({
+      domain: 'example.com',
+      signer: createTestSigner(authKey),
+      updateKeys: [authKey.publicKeyMultibase!],
+      verificationMethods: asPublicVerificationMethods(authKey),
+      witness: { threshold: 1, witnesses: [{ id: witnessDid }] },
+      verifier: testImplementation,
+    });
+
+    const updatedDid = await updateDID({
+      log: didWithWitness.log,
+      updated: nextSecond(didWithWitness.log),
+      signer: createTestSigner(authKey),
+      updateKeys: [authKey.publicKeyMultibase!],
+      verificationMethods: asPublicVerificationMethods(authKey),
+      verifier: testImplementation,
+      witnessProofs: [
+        {
+          versionId: didWithWitness.log[0].versionId,
+          proof: [
+            await createWitnessProof(
+              createWitnessSigner(witness1),
+              didWithWitness.log[0].versionId,
+              witnessVerificationMethod(witness1)
+            ),
+          ],
+        },
+      ],
+    });
+
+    // Pruned file: only the latest proof, signing the LATEST versionId.
+    const prunedWitnessProofs = [
+      {
+        versionId: updatedDid.log[1].versionId,
+        proof: [
+          await createWitnessProof(
+            createWitnessSigner(witness1),
+            updatedDid.log[1].versionId,
+            witnessVerificationMethod(witness1)
+          ),
+        ],
+      },
+    ];
+
+    const resolved = await resolveDIDFromLog(updatedDid.log, {
+      verifier: testImplementation,
+      witnessProofs: prunedWitnessProofs,
+    });
+
+    expect(resolved.did).toBe(updatedDid.did);
+    expect(resolved.meta?.error).toBeUndefined();
+  });
+
+  test('Resolve rejects a witness-list reduction approved only by the reduced list', async () => {
+    // The reducing entry must still meet the previous list's threshold (the new list
+    // activates only after publication).
+    const witnessDid1 = `did:key:${witness1.publicKeyMultibase}`;
+    const witnessDid2 = `did:key:${witness2.publicKeyMultibase}`;
+    const didWithWitness = await createDID({
+      domain: 'example.com',
+      signer: createTestSigner(authKey),
+      updateKeys: [authKey.publicKeyMultibase!],
+      verificationMethods: asPublicVerificationMethods(authKey),
+      witness: { threshold: 2, witnesses: [{ id: witnessDid1 }, { id: witnessDid2 }] },
+      verifier: testImplementation,
+    });
+
+    const v1 = didWithWitness.log[0].versionId;
+    const v1Proofs = {
+      versionId: v1,
+      proof: await Promise.all([
+        createWitnessProof(createWitnessSigner(witness1), v1, witnessVerificationMethod(witness1)),
+        createWitnessProof(createWitnessSigner(witness2), v1, witnessVerificationMethod(witness2)),
+      ]),
+    };
+
+    // Reduce 2-of-2 -> 1-of-1 (witness1 only).
+    const reduced = await updateDID({
+      log: didWithWitness.log,
+      updated: nextSecond(didWithWitness.log),
+      signer: createTestSigner(authKey),
+      updateKeys: [authKey.publicKeyMultibase!],
+      verificationMethods: asPublicVerificationMethods(authKey),
+      witness: { threshold: 1, witnesses: [{ id: witnessDid1 }] },
+      verifier: testImplementation,
+      witnessProofs: [v1Proofs],
+    });
+
+    const v2 = reduced.log[1].versionId;
+
+    // Only witness1 (the reduced list) approves v2 — insufficient for the old 2-of-2.
+    await expect(
+      resolveDIDFromLog(reduced.log, {
+        verifier: testImplementation,
+        witnessProofs: [
+          v1Proofs,
+          {
+            versionId: v2,
+            proof: [await createWitnessProof(createWitnessSigner(witness1), v2, witnessVerificationMethod(witness1))],
+          },
+        ],
+      })
+    ).rejects.toThrow(`Witness threshold not met for version ${v2}`);
   });
 
   test('Resolve ignores invalid witness proof if enough valid proofs remain', async () => {


### PR DESCRIPTION
## Summary

Two spec-conformance bugs in witness handling, both surfaced by the [didwebvh-test-suite](https://github.com/decentralized-identity/didwebvh-test-suite) `witness-update` interop scenario. With these fixes, the resolver correctly handles every other implementation's witness files (rust, python, java, java-eecc, dart).

### Bug A — resolver verified witness proofs against the wrong `versionId`

`countVerifiedWitnessApprovals` hashed the **target** entry's `versionId` instead of the `did-witness.json` entry's own `versionId` (the value the witness actually signed). This defeats the spec's cumulative-approval rule and makes the resolver unable to verify a **pruned** witness file.

- Spec (§The Witness Proofs File): *"A valid proof from a witness carries the implication that ALL prior DID Log entries are also approved"*, and controllers **SHOULD** prune to *"keeping only the latest proof for each witness."*
- Spec (§Verifying Witness Proofs During Resolution, step 5): a target is met by proofs *"whose versionId matches the current or any later published entry."*
- Reproduced: resolving the suite's Rust `witness-update` vector (a pruned file) threw `Witness threshold not met`. Fix lives in `src/witness.ts` and is shared by both v1.0 and v0.5.

### Bug B — witness-list change applied to the entry that defines it

When an entry **replaced/reduced** the witness list, that entry was required to be witnessed by the **new** list. Per spec the new list becomes active only *after* the entry is published, so the entry must be witnessed by the **previous** list.

- Spec (§Witness Lists): *"If a DID log entry contains a new (replacement) list of witnesses … that new list becomes active AFTER the new DID log entry has been published."*
- Activation from `{}` (no witnesses → witnesses) remains immediately active, per §The `witness` Parameter — preserved.
- Fix reorders `getRequiredWitnessForEntry` in `method.v1.0.ts` (v1.0-only; v0.5 witness-change semantics not touched).

## Changes

- `src/witness.ts` — verify each proof against `proofSet.versionId` (covers v1.0 and v0.5).
- `src/method_versions/method.v1.0.ts` — previously-active list governs a list change/removal; activation-from-`{}` is the only immediate case.
- `test/witness.test.ts` — rewrote two tests that encoded the buggy behavior; added a pruned cumulative-approval test and a list-reduction rejection test.

## Testing

- Full suite green (**257 pass / 0 fail**); `bun run build` (tsc strict) clean.
- New/rewritten behavior tests confirmed RED before the fix and GREEN after, on this base.
- Interop verified against the official test-suite vectors: the resolver now resolves rust/python/java/java-eecc/dart `witness-update` and all `witness-threshold` vectors.

## Note for the test-suite

After Bug B, this library's **own** committed `witness-update` vector is now correctly rejected as under-witnessed (its reducing entry carries only one witness proof; every other implementation carries both). The TS vector should be regenerated in the test-suite repo so the reducing entry is witnessed by the full previous list.