### PR TITLE
fix(versionTime): trim msec

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -717,7 +717,8 @@ export async function fetchLogFromIdentifier(identifier: string, controlled: boo
   }
 }
 
-export const createDate = (created?: Date | string) => new Date(created ?? Date.now()).toISOString();
+export const createDate = (created?: Date | string) =>
+  new Date(created ?? Date.now()).toISOString().replace(/\.\d{1,3}Z$/, 'Z');
 
 export function bytesToHex(bytes: Uint8Array): string {
   return Array.from(bytes)

--- a/src/utils/iso8601-datetime.ts
+++ b/src/utils/iso8601-datetime.ts
@@ -128,10 +128,11 @@ export function createNextVersionTime(
     return formatDate(requestedVersionTime);
   }
 
-  const now = new Date();
-  if (now.getTime() <= previous.getTime()) {
-    return formatDate(new Date(previous.getTime() + 1));
+  const nowFormatted = formatDate(new Date());
+  const nowTrimmed = new Date(nowFormatted);
+  if (nowTrimmed.getTime() <= previous.getTime()) {
+    return formatDate(new Date(previous.getTime() + 1000));
   }
 
-  return formatDate(now);
+  return nowFormatted;
 }

--- a/src/utils/iso8601-datetime.ts
+++ b/src/utils/iso8601-datetime.ts
@@ -121,10 +121,7 @@ export function createNextVersionTime(
   const previous = parseUtcIso8601VersionTime(previousVersionTime, 'previous versionTime');
 
   if (requestedVersionTime) {
-    const requested = parseUtcIso8601VersionTime(requestedVersionTime, 'requested versionTime');
-    if (requested.getTime() <= previous.getTime()) {
-      throw new Error('versionTime must be greater than previous versionTime');
-    }
+    parseUtcIso8601VersionTime(requestedVersionTime, 'requested versionTime');
     const formatted = formatDate(requestedVersionTime);
     if (new Date(formatted).getTime() <= previous.getTime()) {
       throw new Error('versionTime must be greater than previous versionTime');

--- a/src/utils/iso8601-datetime.ts
+++ b/src/utils/iso8601-datetime.ts
@@ -125,7 +125,11 @@ export function createNextVersionTime(
     if (requested.getTime() <= previous.getTime()) {
       throw new Error('versionTime must be greater than previous versionTime');
     }
-    return formatDate(requestedVersionTime);
+    const formatted = formatDate(requestedVersionTime);
+    if (new Date(formatted).getTime() <= previous.getTime()) {
+      throw new Error('versionTime must be greater than previous versionTime');
+    }
+    return formatted;
   }
 
   const nowFormatted = formatDate(new Date());

--- a/test/iso8601-datetime.test.ts
+++ b/test/iso8601-datetime.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { parseUtcIso8601VersionTime } from '../src/utils/iso8601-datetime';
+import { createNextVersionTime, parseUtcIso8601VersionTime } from '../src/utils/iso8601-datetime';
 
 describe('ISO8601 DateTime Validation', () => {
   test('Accepts Z timezone', () => {
@@ -11,5 +11,13 @@ describe('ISO8601 DateTime Validation', () => {
     expect(() => {
       parseUtcIso8601VersionTime('2025-11-02T10:20:30+01:00', 'test');
     }).toThrow('must be in UTC (Z or +00:00), found +01:00');
+  });
+
+  test('Rejects requested versionTime that trims to previous second', () => {
+    const formatDate = (value: string | Date) => new Date(value).toISOString().replace(/\.\d{1,3}Z$/, 'Z');
+
+    expect(() => {
+      createNextVersionTime('2025-01-01T00:00:05Z', '2025-01-01T00:00:05.400Z', formatDate);
+    }).toThrow('versionTime must be greater than previous versionTime');
   });
 });

--- a/test/witness.test.ts
+++ b/test/witness.test.ts
@@ -792,7 +792,6 @@ describe('Witness Implementation Tests', async () => {
 
     const updatedDid = await updateDID({
       log: didWithWitness.log,
-      updated: nextSecond(didWithWitness.log),
       signer: createTestSigner(authKey),
       updateKeys: [authKey.publicKeyMultibase!],
       verificationMethods: asPublicVerificationMethods(authKey),
@@ -860,7 +859,6 @@ describe('Witness Implementation Tests', async () => {
     // Reduce 2-of-2 -> 1-of-1 (witness1 only).
     const reduced = await updateDID({
       log: didWithWitness.log,
-      updated: nextSecond(didWithWitness.log),
       signer: createTestSigner(authKey),
       updateKeys: [authKey.publicKeyMultibase!],
       verificationMethods: asPublicVerificationMethods(authKey),


### PR DESCRIPTION
Smaller change based on `33e0fcb333f49700d11484a8cf19e816ef5c8426` (`HEAD` prior to merging PR #132 )

Use regex to trim trailing milliseconds, automatically bump each log creation time by 1 second when calling `createNextVersionTime()`

Not as clean as using wall clock time but:
* solves the rust issue
* minimises changes to the CLI (valid concern from @brianorwhatever)
* no changes to the test suite
* obviates the need for PR #134 