### PR TITLE
revert: PR #132 (versionTime trim-to-second)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -45,7 +45,6 @@ Options:
   --domain [domain]         DEPRECATED: Use --address instead. Domain for the DID (backwards compatibility).
   --log [file]              Path to the DID log file (required for resolve, update, deactivate)
   --output [file]           Path to save the updated DID log (optional for create, update, deactivate)
-  --updated [timestamp]     Explicit update timestamp in UTC ISO8601 (e.g. 2026-01-01T12:00:00Z)
   --portable                Make the DID portable (optional for create)
   --witness [witness]       Add a witness (can be used multiple times)
   --witness-threshold [n]   Set witness threshold (optional, defaults to number of witnesses)
@@ -70,7 +69,6 @@ Examples:
   bun run cli resolve --did did:webvh:123456:example.com
   bun run cli resolve --log ./did.jsonl --witness-file ./did-witness.json
   bun run cli update --log ./did.jsonl --output ./updated-did.jsonl --add-vm keyAgreement --service LinkedDomains,https://example.com
-  bun run cli update --log ./did.jsonl --output ./updated-did.jsonl --updated 2026-01-01T12:00:00Z
   bun run cli deactivate --log ./did.jsonl --output ./deactivated-did.jsonl
   bun run cli generate-witness-proof --version-id 1-abc123 --witness-did did:key:z6Mk... --witness-secret z1A... --output did-witness.json
   bun run cli generate-witness-proof --version-id 1-abc123 --version-id 2-def456 --witness-did did:key:z6Mk... --witness-secret z1A... --output did-witness.json
@@ -302,7 +300,6 @@ export async function handleUpdate(args: string[]) {
   const options = parseOptions(args);
   const logFile = options.log as string;
   const output = options.output as string | undefined;
-  const updated = options.updated as string | undefined;
   const witnesses = options.witness as string[] | undefined;
   const witnessThreshold = options['witness-threshold']
     ? parseInt(options['witness-threshold'] as string, 10)
@@ -395,7 +392,6 @@ export async function handleUpdate(args: string[]) {
     const crypto = createCustomCrypto(vm);
     const result = await updateDID({
       log,
-      updated,
       signer: crypto,
       verifier: crypto,
       updateKeys: [vmPublicKeyMultibase],

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -717,8 +717,7 @@ export async function fetchLogFromIdentifier(identifier: string, controlled: boo
   }
 }
 
-export const createDate = (created?: Date | string) =>
-  new Date(created ?? Date.now()).toISOString().replace(/\.\d{1,3}Z$/, 'Z');
+export const createDate = (created?: Date | string) => new Date(created ?? Date.now()).toISOString();
 
 export function bytesToHex(bytes: Uint8Array): string {
   return Array.from(bytes)

--- a/src/utils/iso8601-datetime.ts
+++ b/src/utils/iso8601-datetime.ts
@@ -128,5 +128,10 @@ export function createNextVersionTime(
     return formatDate(requestedVersionTime);
   }
 
-  return formatDate(new Date());
+  const now = new Date();
+  if (now.getTime() <= previous.getTime()) {
+    return formatDate(new Date(previous.getTime() + 1));
+  }
+
+  return formatDate(now);
 }

--- a/test/cli-e2e.test.ts
+++ b/test/cli-e2e.test.ts
@@ -56,19 +56,6 @@ async function createTempVerificationMethod(vm: VerificationMethod): Promise<str
   return tempFile;
 }
 
-async function nextUpdatedTimestamp(logFile: string): Promise<string> {
-  const log = await readLogFromDisk(logFile);
-  const lastVersionTime = new Date(log[log.length - 1].versionTime);
-  return new Date(lastVersionTime.getTime() + 1000).toISOString().replace(/\.\d{1,3}Z$/, 'Z');
-}
-
-async function waitForNextSecondBoundary(): Promise<void> {
-  const startSecond = Math.floor(Date.now() / 1000);
-  while (Math.floor(Date.now() / 1000) === startSecond) {
-    await Bun.sleep(20);
-  }
-}
-
 describe('CLI End-to-End Tests', async () => {
   test('Create DID using CLI', async () => {
     const proc =
@@ -85,8 +72,7 @@ describe('CLI End-to-End Tests', async () => {
     expect(createProc.exitCode).toBe(0);
 
     // Update the DID — reads authKey from .env so signer matches updateKeys
-    const updated = await nextUpdatedTimestamp(logFile);
-    const updateProc = await $`bun run cli update --log ${logFile} --output ${logFile} --updated ${updated}`.quiet();
+    const updateProc = await $`bun run cli update --log ${logFile} --output ${logFile}`.quiet();
     expect(updateProc.exitCode).toBe(0);
 
     // Verify the update was successful
@@ -102,13 +88,11 @@ describe('CLI End-to-End Tests', async () => {
     expect(createProc.exitCode).toBe(0);
 
     // First update
-    const updated1 = await nextUpdatedTimestamp(logFile);
-    const update1Proc = await $`bun run cli update --log ${logFile} --output ${logFile} --updated ${updated1}`.quiet();
+    const update1Proc = await $`bun run cli update --log ${logFile} --output ${logFile}`.quiet();
     expect(update1Proc.exitCode).toBe(0);
 
     // Second update
-    const updated2 = await nextUpdatedTimestamp(logFile);
-    const update2Proc = await $`bun run cli update --log ${logFile} --output ${logFile} --updated ${updated2}`.quiet();
+    const update2Proc = await $`bun run cli update --log ${logFile} --output ${logFile}`.quiet();
     expect(update2Proc.exitCode).toBe(0);
 
     // Verify the updates were successful
@@ -124,7 +108,6 @@ describe('CLI End-to-End Tests', async () => {
     expect(createProc.exitCode).toBe(0);
 
     // Deactivate the DID — reads authKey from .env so signer matches updateKeys
-    await waitForNextSecondBoundary();
     const deactivateProc = await $`bun run cli deactivate --log ${logFile} --output ${logFile}`.quiet();
     expect(deactivateProc.exitCode).toBe(0);
 
@@ -169,9 +152,8 @@ describe('CLI End-to-End Tests', async () => {
     const { did } = await resolveDIDFromLog(initialLog, { verifier });
 
     // Add all VM types in a single update — reads authKey from .env
-    const updated = await nextUpdatedTimestamp(vmLogFile);
     const proc =
-      await $`bun run cli update --log ${vmLogFile} --output ${vmLogFile} --updated ${updated} --add-vm authentication --add-vm assertionMethod --add-vm keyAgreement --add-vm capabilityInvocation --add-vm capabilityDelegation`.quiet();
+      await $`bun run cli update --log ${vmLogFile} --output ${vmLogFile} --add-vm authentication --add-vm assertionMethod --add-vm keyAgreement --add-vm capabilityInvocation --add-vm capabilityDelegation`.quiet();
     expect(proc.exitCode).toBe(0);
 
     // Verify all VM types were added
@@ -207,9 +189,7 @@ describe('CLI End-to-End Tests', async () => {
 
     // Update with alsoKnownAs — reads authKey from .env
     const alias = 'https://example.com/users/123';
-    const updated = await nextUpdatedTimestamp(akLogFile);
-    const proc =
-      await $`bun run cli update --log ${akLogFile} --output ${akLogFile} --updated ${updated} --also-known-as ${alias}`.quiet();
+    const proc = await $`bun run cli update --log ${akLogFile} --output ${akLogFile} --also-known-as ${alias}`.quiet();
     expect(proc.exitCode).toBe(0);
 
     // Verify alsoKnownAs was added

--- a/test/did-document-passthrough.test.ts
+++ b/test/did-document-passthrough.test.ts
@@ -6,7 +6,6 @@ import {
   createTestSigner,
   createTestVerifier,
   generateTestVerificationMethod,
-  nextSecond,
 } from './utils';
 
 describe('didDocument create pass-through', () => {
@@ -151,7 +150,6 @@ describe('didDocument create pass-through', () => {
     try {
       const updated = await updateDID({
         log: created.log,
-        updated: nextSecond(created.log),
         signer: createTestSigner(authKey),
         verifier: createTestVerifier(authKey),
         updateKeys: [authKey.publicKeyMultibase!],
@@ -335,7 +333,6 @@ describe('generateParallelDidWeb', () => {
 
     const updated = await updateDID({
       log: created.log,
-      updated: nextSecond(created.log),
       signer: createTestSigner(authKey),
       verifier: createTestVerifier(authKey),
       updateKeys: [authKey.publicKeyMultibase!],

--- a/test/features.test.ts
+++ b/test/features.test.ts
@@ -7,7 +7,6 @@ import {
   asPublicVerificationMethods,
   createTestSigner,
   generateTestVerificationMethod,
-  nextSecond,
   TestCryptoImplementation,
 } from './utils';
 
@@ -172,7 +171,6 @@ test('Empty nextKeyHashes array should not enable prerotation', async () => {
   // Update with different updateKeys — no prerotation constraint
   const { log: log2 } = await updateDID({
     log: log1,
-    updated: nextSecond(log1),
     signer: createTestSigner(authKey1),
     updateKeys: [authKey2.publicKeyMultibase!],
     verificationMethods: asPublicVerificationMethods(authKey2),
@@ -198,7 +196,6 @@ test('Omitted nextKeyHashes inherits previous pre-rotation state', async () => {
 
   const { log: log2 } = await updateDID({
     log: log1,
-    updated: nextSecond(log1),
     signer: createTestSigner(authKey2),
     updateKeys: [authKey2.publicKeyMultibase!],
     verificationMethods: asPublicVerificationMethods(authKey2),
@@ -246,7 +243,6 @@ test('Explicit empty nextKeyHashes disables pre-rotation', async () => {
 
   const { log: log2 } = await updateDID({
     log: log1,
-    updated: nextSecond(log1),
     signer: createTestSigner(authKey2),
     updateKeys: [authKey2.publicKeyMultibase!],
     nextKeyHashes: [],

--- a/test/happy-path.test.ts
+++ b/test/happy-path.test.ts
@@ -4,7 +4,6 @@ import {
   asPublicVerificationMethods,
   createTestSigner,
   generateTestVerificationMethod,
-  nextSecond,
   TestCryptoImplementation,
 } from './utils';
 
@@ -62,7 +61,6 @@ describe('Happy Path Tests', () => {
     const authKey2 = await generateTestVerificationMethod();
     const { doc: updatedDoc } = await updateDID({
       log: initialLog,
-      updated: nextSecond(initialLog),
       signer: createTestSigner(authKey1),
       updateKeys: [authKey2.publicKeyMultibase!],
       verificationMethods: asPublicVerificationMethods(authKey2),
@@ -90,7 +88,6 @@ describe('Happy Path Tests', () => {
     const authKey3 = await generateTestVerificationMethod();
     const { doc: updatedDoc } = await updateDID({
       log: initialLog,
-      updated: nextSecond(initialLog),
       signer: createTestSigner(authKey1),
       updateKeys: [authKey2.publicKeyMultibase!, authKey3.publicKeyMultibase!],
       verificationMethods: asPublicVerificationMethods(authKey2, authKey3),
@@ -118,7 +115,6 @@ describe('Happy Path Tests', () => {
     const externalDID = 'did:example:123#key-1';
     const { doc: updatedDoc } = await updateDID({
       log: initialLog,
-      updated: nextSecond(initialLog),
       signer: createTestSigner(authKey1),
       updateKeys: [authKey1.publicKeyMultibase!],
       authentication: [externalDID],
@@ -150,7 +146,6 @@ describe('Happy Path Tests', () => {
     // Update the DID with the new verification methods
     const { doc: updatedDoc } = await updateDID({
       log: initialLog,
-      updated: nextSecond(initialLog),
       signer: createTestSigner(authKey1),
       updateKeys: [authKey1.publicKeyMultibase!],
       verificationMethods: asPublicVerificationMethods(assertionKey, keyAgreementKey),
@@ -183,7 +178,6 @@ describe('Happy Path Tests', () => {
 
     const { doc: updatedDoc } = await updateDID({
       log: initialLog,
-      updated: nextSecond(initialLog),
       signer: createTestSigner(authKey1),
       updateKeys: [authKey1.publicKeyMultibase!],
       services: [service],
@@ -209,7 +203,6 @@ describe('Happy Path Tests', () => {
     const alias = 'did:web:example.com';
     const { doc: updatedDoc } = await updateDID({
       log: initialLog,
-      updated: nextSecond(initialLog),
       signer: createTestSigner(authKey1),
       updateKeys: [authKey1.publicKeyMultibase!],
       alsoKnownAs: [alias],
@@ -235,7 +228,6 @@ describe('Happy Path Tests', () => {
     const controller = 'did:example:123';
     const { doc: updatedDoc } = await updateDID({
       log: initialLog,
-      updated: nextSecond(initialLog),
       signer: createTestSigner(authKey1),
       updateKeys: [authKey1.publicKeyMultibase!],
       controller,
@@ -260,7 +252,6 @@ describe('Happy Path Tests', () => {
     const nextKeyHash = 'z6MkgYGF3thn8k1Qz9P4c3mKthZXNhUgkdwBwE5hbWFJktGH';
     const { doc: updatedDoc, meta } = await updateDID({
       log: initialLog,
-      updated: nextSecond(initialLog),
       signer: createTestSigner(authKey1),
       updateKeys: [authKey1.publicKeyMultibase!],
       nextKeyHashes: [nextKeyHash],
@@ -293,7 +284,6 @@ describe('Happy Path Tests', () => {
 
     const { doc: updatedDoc } = await updateDID({
       log: initialLog,
-      updated: nextSecond(initialLog),
       signer: createTestSigner(authKey1),
       verificationMethods: asPublicVerificationMethods(authKey1),
       verifier,
@@ -323,7 +313,6 @@ describe('Happy Path Tests', () => {
 
     const { log: updatedLog, meta } = await updateDID({
       log: initialLog,
-      updated: nextSecond(initialLog),
       signer: createTestSigner(authKey1),
       verificationMethods: asPublicVerificationMethods(authKey1),
       verifier,

--- a/test/not-so-happy-path.test.ts
+++ b/test/not-so-happy-path.test.ts
@@ -8,7 +8,6 @@ import {
   createFutureDIDLog,
   createTestSigner,
   generateTestVerificationMethod,
-  nextSecond,
   TestCryptoImplementation,
 } from './utils';
 
@@ -16,13 +15,6 @@ describe('Not So Happy Path Tests', () => {
   let authKey: VerificationMethod;
   let testImplementation: TestCryptoImplementation;
   let initialDID: CreateDIDResult;
-
-  const waitForNextSecondBoundary = async () => {
-    const startSecond = Math.floor(Date.now() / 1000);
-    while (Math.floor(Date.now() / 1000) === startSecond) {
-      await Bun.sleep(20);
-    }
-  };
 
   beforeAll(async () => {
     authKey = await generateTestVerificationMethod();
@@ -97,7 +89,6 @@ describe('Not So Happy Path Tests', () => {
 
     const { log: log2 } = await updateDID({
       log: log1,
-      updated: nextSecond(log1),
       signer: createTestSigner(authKey),
       updateKeys: [authKey.publicKeyMultibase!],
       verificationMethods: asPublicVerificationMethods(authKey),
@@ -126,7 +117,6 @@ describe('Not So Happy Path Tests', () => {
     for (let j = 0; j < 12; j++) {
       const { log: nextLog } = await updateDID({
         log: currentLog,
-        updated: nextSecond(currentLog),
         signer: createTestSigner(authKey),
         updateKeys: [authKey.publicKeyMultibase!],
         verificationMethods: asPublicVerificationMethods(authKey),
@@ -158,7 +148,6 @@ describe('Not So Happy Path Tests', () => {
     for (let j = 0; j < 12; j++) {
       const { log: nextLog } = await updateDID({
         log: currentLog,
-        updated: nextSecond(currentLog),
         signer: createTestSigner(authKey),
         updateKeys: [authKey.publicKeyMultibase!],
         verificationMethods: asPublicVerificationMethods(authKey),
@@ -184,7 +173,6 @@ describe('Not So Happy Path Tests', () => {
 
     const { log: log2 } = await updateDID({
       log: log1,
-      updated: nextSecond(log1),
       signer: createTestSigner(authKey),
       updateKeys: [authKey.publicKeyMultibase!],
       verificationMethods: asPublicVerificationMethods(authKey),
@@ -193,7 +181,6 @@ describe('Not So Happy Path Tests', () => {
 
     const { log: log3 } = await updateDID({
       log: log2,
-      updated: nextSecond(log2),
       signer: createTestSigner(authKey),
       updateKeys: [authKey.publicKeyMultibase!],
       verificationMethods: asPublicVerificationMethods(authKey),
@@ -228,7 +215,6 @@ describe('Not So Happy Path Tests', () => {
 
     const { log: log2 } = await updateDID({
       log: log1,
-      updated: nextSecond(log1),
       signer: createTestSigner(authKey),
       updateKeys: [authKey.publicKeyMultibase!],
       verificationMethods: asPublicVerificationMethods(authKey),
@@ -237,7 +223,6 @@ describe('Not So Happy Path Tests', () => {
 
     const { log: log3 } = await updateDID({
       log: log2,
-      updated: nextSecond(log2),
       signer: createTestSigner(authKey),
       updateKeys: [authKey.publicKeyMultibase!],
       verificationMethods: asPublicVerificationMethods(authKey),
@@ -269,7 +254,6 @@ describe('Not So Happy Path Tests', () => {
 
     const { log: log2 } = await updateDID({
       log: log1,
-      updated: nextSecond(log1),
       signer: createTestSigner(authKey),
       updateKeys: [authKey.publicKeyMultibase!],
       verificationMethods: asPublicVerificationMethods(authKey),
@@ -278,7 +262,6 @@ describe('Not So Happy Path Tests', () => {
 
     const { log: log3 } = await updateDID({
       log: log2,
-      updated: nextSecond(log2),
       signer: createTestSigner(authKey),
       updateKeys: [authKey.publicKeyMultibase!],
       verificationMethods: asPublicVerificationMethods(authKey),
@@ -423,7 +406,6 @@ describe('Not So Happy Path Tests', () => {
     const { log } = initialDID;
     const updateResult = await updateDID({
       log,
-      updated: nextSecond(log),
       domain: 'example.com',
       signer: createTestSigner(authKey),
       updateKeys: [authKey.publicKeyMultibase!],
@@ -442,7 +424,6 @@ describe('Not So Happy Path Tests', () => {
     const { log } = initialDID;
     const updateResult = await updateDID({
       log,
-      updated: nextSecond(log),
       domain: 'example.com',
       signer: createTestSigner(authKey),
       updateKeys: [authKey.publicKeyMultibase!],
@@ -461,7 +442,6 @@ describe('Not So Happy Path Tests', () => {
     const { log } = initialDID;
     const updateResult = await updateDID({
       log,
-      updated: nextSecond(log),
       domain: 'example.com',
       signer: createTestSigner(authKey),
       updateKeys: [authKey.publicKeyMultibase!],
@@ -598,8 +578,6 @@ describe('Not So Happy Path Tests', () => {
   });
 
   test('updateDID rejects when the DID is already deactivated', async () => {
-    await waitForNextSecondBoundary();
-
     const { log: deactivatedLog } = await deactivateDID({
       log: initialDID.log,
       signer: createTestSigner(authKey),
@@ -625,9 +603,6 @@ describe('Not So Happy Path Tests', () => {
       verificationMethods: asPublicVerificationMethods(authKey),
       verifier: testImplementation,
     });
-
-    await waitForNextSecondBoundary();
-
     const { log: deactivatedLog } = await deactivateDID({
       log: log1,
       signer: createTestSigner(authKey),

--- a/test/portability.test.ts
+++ b/test/portability.test.ts
@@ -5,7 +5,6 @@ import {
   asPublicVerificationMethods,
   createTestSigner,
   generateTestVerificationMethod,
-  nextSecond,
   TestCryptoImplementation,
 } from './utils';
 
@@ -40,7 +39,6 @@ describe('Portability', () => {
   test('Rejects setting portable: true in a later entry', async () => {
     const updateResult = await updateDID({
       log: nonPortableDID.log,
-      updated: nextSecond(nonPortableDID.log),
       domain: 'example.com',
       signer: createTestSigner(authKey),
       updateKeys: [authKey.publicKeyMultibase!],
@@ -80,7 +78,6 @@ describe('Portability', () => {
 
     const updateResult = await updateDID({
       log: did.log,
-      updated: nextSecond(did.log),
       domain: 'example.com',
       signer: createTestSigner(authKey),
       updateKeys: [authKey.publicKeyMultibase!],
@@ -99,7 +96,6 @@ describe('Portability', () => {
   test('Setting portable: false in a later entry permanently locks portability', async () => {
     const updateResult = await updateDID({
       log: portableDID.log,
-      updated: nextSecond(portableDID.log),
       domain: 'example.com',
       portable: false,
       signer: createTestSigner(authKey),
@@ -131,7 +127,6 @@ describe('Portability', () => {
   test('Rejects SCID change in state.id during portable rename', async () => {
     const updateResult = await updateDID({
       log: portableDID.log,
-      updated: nextSecond(portableDID.log),
       domain: 'example.com',
       signer: createTestSigner(authKey),
       updateKeys: [authKey.publicKeyMultibase!],
@@ -153,7 +148,6 @@ describe('Portability', () => {
   test('Portable DID moves to a new domain via the domain option', async () => {
     const updateResult = await updateDID({
       log: portableDID.log,
-      updated: nextSecond(portableDID.log),
       domain: 'example.org',
       signer: createTestSigner(authKey),
       updateKeys: [authKey.publicKeyMultibase!],
@@ -177,7 +171,6 @@ describe('Portability', () => {
     await expect(
       updateDID({
         log: nonPortableDID.log,
-        updated: nextSecond(nonPortableDID.log),
         domain: 'example.org',
         signer: createTestSigner(authKey),
         updateKeys: [authKey.publicKeyMultibase!],
@@ -200,7 +193,6 @@ describe('Portability', () => {
     // Caller threads the same domain through the update but omits paths.
     const updateResult = await updateDID({
       log: pathedDID.log,
-      updated: nextSecond(pathedDID.log),
       domain: 'example.com',
       signer: createTestSigner(authKey),
       updateKeys: [authKey.publicKeyMultibase!],
@@ -216,7 +208,6 @@ describe('Portability', () => {
   test('Portable DID moves to a pathed location via the address option', async () => {
     const updateResult = await updateDID({
       log: portableDID.log,
-      updated: nextSecond(portableDID.log),
       address: 'https://example.org/dids/alice',
       signer: createTestSigner(authKey),
       updateKeys: [authKey.publicKeyMultibase!],

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -11,12 +11,8 @@ import type {
   VerificationMethod,
   Verifier,
 } from '../src/interfaces';
-import { createDate, createDIDDoc, createSCID, deriveHash, replaceCreateDidPlaceholders } from '../src/utils';
+import { createDIDDoc, createSCID, deriveHash, replaceCreateDidPlaceholders } from '../src/utils';
 import { MultibaseEncoding, multibaseDecode, multibaseEncode } from '../src/utils/multiformats';
-
-/** Returns the versionTime one second after the last entry in a DID log. Use in tests when chaining rapid create/update/deactivate calls. */
-export const nextSecond = (log: DIDLog): string =>
-  createDate(new Date(new Date(log[log.length - 1].versionTime).getTime() + 1000));
 
 export function createMockDIDLog(entries: Partial<DIDLogEntry>[]): DIDLog {
   return entries.map((entry, index) => {

--- a/test/watchers.test.ts
+++ b/test/watchers.test.ts
@@ -4,7 +4,6 @@ import {
   asPublicVerificationMethods,
   createTestSigner,
   generateTestVerificationMethod,
-  nextSecond,
   TestCryptoImplementation,
 } from './utils';
 
@@ -43,7 +42,6 @@ describe('Watcher Handling', () => {
 
     const updated = await updateDID({
       log: initial.log,
-      updated: nextSecond(initial.log),
       signer: createTestSigner(authKey),
       updateKeys: [authKey.publicKeyMultibase!],
       verificationMethods: asPublicVerificationMethods(authKey),
@@ -70,7 +68,6 @@ describe('Watcher Handling', () => {
 
     const updated = await updateDID({
       log: initial.log,
-      updated: nextSecond(initial.log),
       signer: createTestSigner(authKey),
       updateKeys: [authKey.publicKeyMultibase!],
       verificationMethods: asPublicVerificationMethods(authKey),

--- a/test/witness.test.ts
+++ b/test/witness.test.ts
@@ -20,7 +20,6 @@ import {
   asPublicVerificationMethods,
   createTestSigner,
   generateTestVerificationMethod,
-  nextSecond,
   TestCryptoImplementation,
 } from './utils';
 
@@ -102,7 +101,6 @@ describe('Witness Implementation Tests', async () => {
 
     const updatedDID = await updateDID({
       log: noWitnessDID.log,
-      updated: nextSecond(noWitnessDID.log),
       signer: createTestSigner(authKey),
       updateKeys: [newAuthKey.publicKeyMultibase!],
       verificationMethods: asPublicVerificationMethods(newAuthKey),
@@ -153,7 +151,6 @@ describe('Witness Implementation Tests', async () => {
 
     const updatedDID = await updateDID({
       log: noWitnessDID.log,
-      updated: nextSecond(noWitnessDID.log),
       signer: createTestSigner(authKey),
       updateKeys: [newAuthKey.publicKeyMultibase!],
       verificationMethods: asPublicVerificationMethods(newAuthKey),
@@ -239,7 +236,6 @@ describe('Witness Implementation Tests', async () => {
 
     const updated = await updateDID({
       log: created.log,
-      updated: nextSecond(created.log),
       signer: createTestSigner(authKey),
       updateKeys: [authKey2.publicKeyMultibase!],
       verificationMethods: asPublicVerificationMethods(authKey2),
@@ -300,7 +296,6 @@ describe('Witness Implementation Tests', async () => {
 
     const firstUpdate = await updateDID({
       log: created.log,
-      updated: nextSecond(created.log),
       signer: createTestSigner(authKey),
       updateKeys: [`did:key:${authKey2.publicKeyMultibase}`],
       verificationMethods: asPublicVerificationMethods(authKey2),
@@ -322,7 +317,6 @@ describe('Witness Implementation Tests', async () => {
     await expect(
       updateDID({
         log: firstUpdate.log,
-        updated: nextSecond(firstUpdate.log),
         signer: createTestSigner(authKey2),
         updateKeys: [authKey3.publicKeyMultibase!],
         verificationMethods: asPublicVerificationMethods(authKey3),
@@ -361,7 +355,6 @@ describe('Witness Implementation Tests', async () => {
     await expect(
       updateDID({
         log: created.log,
-        updated: nextSecond(created.log),
         signer: nonCompliantSigner,
         updateKeys: [authKey2.publicKeyMultibase!],
         verificationMethods: asPublicVerificationMethods(authKey2),
@@ -385,7 +378,6 @@ describe('Witness Implementation Tests', async () => {
 
     const updatedDID = await updateDID({
       log: initialDID.log,
-      updated: nextSecond(initialDID.log),
       signer: createTestSigner(authKey),
       updateKeys: [authKey.publicKeyMultibase!],
       verificationMethods: asPublicVerificationMethods(authKey),
@@ -429,7 +421,6 @@ describe('Witness Implementation Tests', async () => {
 
     const updatedDID = await updateDID({
       log: initialDID.log,
-      updated: nextSecond(initialDID.log),
       signer: createTestSigner(authKey),
       updateKeys: [authKey.publicKeyMultibase!],
       verificationMethods: asPublicVerificationMethods(authKey),
@@ -686,7 +677,6 @@ describe('Witness Implementation Tests', async () => {
 
     const updatedDid = await updateDID({
       log: didWithWitness.log,
-      updated: nextSecond(didWithWitness.log),
       signer: createTestSigner(authKey),
       updateKeys: [authKey.publicKeyMultibase!],
       verificationMethods: asPublicVerificationMethods(authKey),
@@ -740,7 +730,6 @@ describe('Witness Implementation Tests', async () => {
 
     const updatedDid = await updateDID({
       log: didWithWitness.log,
-      updated: nextSecond(didWithWitness.log),
       signer: createTestSigner(authKey),
       updateKeys: [authKey.publicKeyMultibase!],
       verificationMethods: asPublicVerificationMethods(authKey),
@@ -843,7 +832,6 @@ describe('Witness Implementation Tests', async () => {
 
     const updatedDid = await updateDID({
       log: didWithWitness.log,
-      updated: nextSecond(didWithWitness.log),
       signer: createTestSigner(authKey),
       updateKeys: [authKey.publicKeyMultibase!],
       verificationMethods: asPublicVerificationMethods(authKey),
@@ -902,7 +890,6 @@ describe('Witness Implementation Tests', async () => {
     expect(
       updateDID({
         log: noWitnessDID.log,
-        updated: nextSecond(noWitnessDID.log),
         signer: createTestSigner(authKey),
         updateKeys: [authKey.publicKeyMultibase!],
         verificationMethods: asPublicVerificationMethods(authKey),
@@ -926,7 +913,6 @@ describe('Witness Implementation Tests', async () => {
 
     const updatedDID = await updateDID({
       log: noWitnessDID.log,
-      updated: nextSecond(noWitnessDID.log),
       signer: createTestSigner(authKey),
       updateKeys: [authKey.publicKeyMultibase!],
       verificationMethods: asPublicVerificationMethods(authKey),


### PR DESCRIPTION
Reverts the merge of #132 (commit `2ef12d1`).

Per the discussion on #133 (https://github.com/decentralized-identity/didwebvh-ts/pull/133#discussion_r3472664451), strict `versionTime` monotonicity will instead be enforced by bumping each new log entry by **+1 second on update**, without the changes introduced in #132. This PR is the first step (the revert); the alternative fix will follow separately.

## What this restores

`src/cli.ts`, `src/utils.ts`, `src/utils/iso8601-datetime.ts` and the associated test files return to their pre-#132 state. Specifically it removes:

- the `--updated` CLI flag,
- second-accuracy trimming of `versionTime`,
- the `nextSecond` test helper and its usages.

## Testing

- Clean revert of the tip merge commit (no conflicts).
- Full suite green (**255 pass / 0 fail**); `bun run build` (tsc strict) clean.

## Note

PR #135 (witness spec-conformance) is currently based on a main that includes #132 and uses the `nextSecond` helper in its tests. If this revert lands, #135 will be rebased onto the reverted base and updated accordingly.
