### PR TITLE
chore(cli): cli owns persistence

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.1/schema.json",
   "formatter": {
     "indentStyle": "space",
     "lineWidth": 120

--- a/bun.lock
+++ b/bun.lock
@@ -24,23 +24,23 @@
     },
   },
   "packages": {
-    "@biomejs/biome": ["@biomejs/biome@2.4.16", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.16", "@biomejs/cli-darwin-x64": "2.4.16", "@biomejs/cli-linux-arm64": "2.4.16", "@biomejs/cli-linux-arm64-musl": "2.4.16", "@biomejs/cli-linux-x64": "2.4.16", "@biomejs/cli-linux-x64-musl": "2.4.16", "@biomejs/cli-win32-arm64": "2.4.16", "@biomejs/cli-win32-x64": "2.4.16" }, "bin": { "biome": "bin/biome" } }, "sha512-x9ajFh1zChVybCiM3TN6OD4phAqLgtPZjFrZF+aTMYCPjwBO+k529TX7PPsAqtGNLeV4UgzwQnowEgS7bGmzcA=="],
+    "@biomejs/biome": ["@biomejs/biome@2.5.1", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.1", "@biomejs/cli-darwin-x64": "2.5.1", "@biomejs/cli-linux-arm64": "2.5.1", "@biomejs/cli-linux-arm64-musl": "2.5.1", "@biomejs/cli-linux-x64": "2.5.1", "@biomejs/cli-linux-x64-musl": "2.5.1", "@biomejs/cli-win32-arm64": "2.5.1", "@biomejs/cli-win32-x64": "2.5.1" }, "bin": { "biome": "bin/biome" } }, "sha512-IXWLCxKmae+rI7LOHS1B3EbVisQ6GRAWbhN9msa6KjNCyFWrvKZWR4oUdinaNssrV852OrSHuSPa95h1GPJc7Q=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.16", "", { "os": "darwin", "cpu": "arm64" }, "sha512-wxPvu4XOA85YJk9ixSWUmq/QBHbid85BISbOAqqBM/5xQpPk9ayjk5375tOlSC0BeCwNSbPFafQBm+vBumXq0A=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-npqDzvqv7vFaWRiNN1Te71siRgPaqS9MpqgYCdP/CrUbkJ7ApezaeaKjueKHRN/JH/6lRjJQAHi8acQDCAz22w=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.16", "", { "os": "darwin", "cpu": "x64" }, "sha512-xFCqGPwYusQJp4N4NJLi1XJiZqjwFdjhT+KqtNy+Ug3qgfczqnTa6MSDvxJF6TkuDLoYJItMapz6tAf7kCekFw=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.5.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-RgwTqPAM8g2tn1j+b5oRjF/DbSBX8a4gwojtuG9XuhfK7GgomvZ9+T+tqjXiVbjLEeGJOoL6VEk8mvRTVeSybw=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.16", "", { "os": "linux", "cpu": "arm64" }, "sha512-2kFb4//jxfZaP6D+Rj5VkHkxgyD9EoRAVBEQb8PKRv+s4NO2zYNJKXFaJmK1CmhufJOWEfpHKaRbOja7qjmdhQ=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.5.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-yhV35CzZh38VyMvTEXi3JTjxZBs++oCKK9KG8vB6VI5+uvQvZNR3BFWEKKzuOmx9DJJj7sQpZ4LQJcmbGTs3+Q=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.16", "", { "os": "linux", "cpu": "arm64" }, "sha512-oYxnW0ARfJkr72ezzF2OR8N/rtkgLUQeYtF8cFhVswbknHxtTcmzSsanVJP8yQKnGpGpc2ck6c5zLvHahL6Cbg=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.5.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-WMcvMLgByyTqVxGlq918NBBYliq9FRR9GAQVETHb+VjGVqXCZFfHlZHC1FX4ibuYY/Hg6TJE3rHU0xVrdJXNRw=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.16", "", { "os": "linux", "cpu": "x64" }, "sha512-NbcBbi/nJqn5baae6wqRXdS7Gadf2uRpehSh6vMSYpG8OhkXl/Xg8aorWrJ+9VWqAT5ml90alLvorkpMW0nBwQ=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.5.1", "", { "os": "linux", "cpu": "x64" }, "sha512-J/7uHSX7NfoYDI7HijAkd8lnQIOrRb2W7j3X+tw4R+N5ExvXGsyXFiGdQcfcxfOmNQmZVSQOCDk757fwpzqQcg=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.16", "", { "os": "linux", "cpu": "x64" }, "sha512-iHDS+MCM65DPqWGu+ECC3uoALyj2H7F4nVUPxIPjz/PIl94EUu+EDfGZDzFP+NY1EOPVt9NQvwFqq7HdMmowdg=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.5.1", "", { "os": "linux", "cpu": "x64" }, "sha512-ANTowtlLmPYm5yeMckWY8Xzb9Ix+JJP3tgHR/n6xRj1VWyIzzWtfRfih9hv9VmClwadpBvZduISZIbBsIlYG3A=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.16", "", { "os": "win32", "cpu": "arm64" }, "sha512-0rgImMsNb5v/chhkIFe3wu7PEFClS6RBAYUijGL9UsYN3PanSaoK24HSSuSJb1pYbYYVjzAyZTl3gtjJ84BM8A=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-zgXnKNgWPC4iPF7Y1lR3STUeCUuZRpD6IiOrC7TZTlh0Lx6FiVUT05myuMQHQ9D+1cc7uyMldi4forE6lp0ivQ=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.16", "", { "os": "win32", "cpu": "x64" }, "sha512-Kp85jgoBHa05gix6UIRjfCDiUV3w/8VIdZ247VyyO2gEjaw12WEVhdIjlxp/AMzXxqxQwbxNTDVZ3Mwd2RG5rw=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.1", "", { "os": "win32", "cpu": "x64" }, "sha512-6uxpR9hvaglANkZemeSiN/FhYgkGasrEGn267eXIWvjrjJ2LhDlk251IhjVJq6MXzkV2/bcXwLwSroLyPtqRZg=="],
 
     "@borewit/text-codec": ["@borewit/text-codec@0.2.2", "", {}, "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ=="],
 
@@ -72,13 +72,11 @@
 
     "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
 
-    "@types/express": ["@types/express@5.0.3", "", { "dependencies": { "@types/body-parser": "*", "@types/express-serve-static-core": "^5.0.0", "@types/serve-static": "*" } }, "sha512-wGA0NX93b19/dZC1J18tKWVIYWyyF2ZjT9vin/NRu0qzzvfVzWjs04iq2rQ3H65vCTQYlRqs3YHfY7zjdV+9Kw=="],
+    "@types/express": ["@types/express@5.0.6", "", { "dependencies": { "@types/body-parser": "*", "@types/express-serve-static-core": "^5.0.0", "@types/serve-static": "^2" } }, "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA=="],
 
     "@types/express-serve-static-core": ["@types/express-serve-static-core@5.1.0", "", { "dependencies": { "@types/node": "*", "@types/qs": "*", "@types/range-parser": "*", "@types/send": "*" } }, "sha512-jnHMsrd0Mwa9Cf4IdOzbz543y4XJepXrbia2T4b6+spXC2We3t1y6K44D3mR8XMFSXMCf3/l7rCgddfx7UNVBA=="],
 
     "@types/http-errors": ["@types/http-errors@2.0.5", "", {}, "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg=="],
-
-    "@types/mime": ["@types/mime@1.3.5", "", {}, "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w=="],
 
     "@types/node": ["@types/node@22.13.10", "", { "dependencies": { "undici-types": "~6.20.0" } }, ""],
 
@@ -88,7 +86,7 @@
 
     "@types/send": ["@types/send@1.2.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-zBF6vZJn1IaMpg3xUF25VK3gd3l8zwE0ZLRX7dsQyQi+jp4E8mMDJNGDYnYse+bQhYwWERTxVwHpi3dMOq7RKQ=="],
 
-    "@types/serve-static": ["@types/serve-static@1.15.9", "", { "dependencies": { "@types/http-errors": "*", "@types/node": "*", "@types/send": "<1" } }, "sha512-dOTIuqpWLyl3BBXU3maNQsS4A3zuuoYRNIvYSxxhebPfXg2mzWQEPne/nlJ37yOse6uGgR386uTpdsx4D0QZWA=="],
+    "@types/serve-static": ["@types/serve-static@2.2.0", "", { "dependencies": { "@types/http-errors": "*", "@types/node": "*" } }, "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ=="],
 
     "argparse": ["argparse@2.0.1", "", {}, ""],
 
@@ -104,7 +102,7 @@
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
-    "elysia": ["elysia@1.4.28", "", { "dependencies": { "cookie": "^1.1.1", "exact-mirror": "^0.2.7", "fast-decode-uri-component": "^1.0.1", "memoirist": "^0.4.0" }, "peerDependencies": { "@sinclair/typebox": ">= 0.34.0 < 1", "@types/bun": ">= 1.2.0", "file-type": ">= 20.0.0", "openapi-types": ">= 12.0.0", "typescript": ">= 5.0.0" }, "optionalPeers": ["@types/bun", "typescript"] }, "sha512-Vrx8sBnvq8squS/3yNBzR1jBXI+SgmnmvwawPjNuEHndUe5l1jV2Gp6JJ4ulDkEB8On6bWmmuyPpA+bq4t+WYg=="],
+    "elysia": ["elysia@1.4.29", "", { "dependencies": { "cookie": "^1.1.1", "exact-mirror": "^0.2.7", "fast-decode-uri-component": "^1.0.1", "memoirist": "^0.4.0" }, "peerDependencies": { "@sinclair/typebox": ">= 0.34.0 < 1", "@types/bun": ">= 1.2.0", "file-type": ">= 20.0.0", "openapi-types": ">= 12.0.0", "typescript": ">= 5.0.0" }, "optionalPeers": ["@types/bun", "typescript"] }, "sha512-GwMRGGwSdjfPt+w3LA0fqTuYJtS8uVRJicvoar98/HrO5qdFKDc9CwjIb6Kja+v39lkY+58hr2JvdR9jQzlUuA=="],
 
     "exact-mirror": ["exact-mirror@0.2.7", "", { "peerDependencies": { "@sinclair/typebox": "^0.34.15" }, "optionalPeers": ["@sinclair/typebox"] }, "sha512-+MeEmDcLA4o/vjK2zujgk+1VTxPR4hdp23qLqkWfStbECtAq9gmsvQa3LW6z/0GXZyHJobrCnmy1cdeE7BjsYg=="],
 
@@ -143,7 +141,5 @@
     "uint8array-extras": ["uint8array-extras@1.5.0", "", {}, "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="],
 
     "undici-types": ["undici-types@6.20.0", "", {}, ""],
-
-    "@types/serve-static/@types/send": ["@types/send@0.17.5", "", { "dependencies": { "@types/mime": "^1", "@types/node": "*" } }, "sha512-z6F2D3cOStZvuk2SaP6YrwkNO65iTZcwA2ZkSABegdkAh/lf+Aa/YQndZVfmEXT5vgAp6zv06VQ3ejSVjAny4w=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "didwebvh-ts",
   "module": "dist/esm/index.js",
   "type": "module",
-  "version": "2.7.4",
+  "version": "3.0.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -36,20 +36,20 @@
     "example:resolver": "bun run examples/elysia-resolver.ts"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.3.6",
+    "@biomejs/biome": "^2.5.1",
     "@sinclair/typebox": "0.34.49",
     "@stablelib/ed25519": "^2.1.0",
     "@types/bun": "^1.3.14",
-    "@types/express": "^5.0.1",
-    "bun-bagel": "^1.1.0",
+    "@types/express": "^5.0.6",
+    "bun-bagel": "^1.2.0",
     "bun-types": "^1.3.14",
-    "elysia": "^1.4.28"
+    "elysia": "^1.4.29"
   },
   "dependencies": {
     "@noble/hashes": "^2.2.0",
     "cookie": "^1.1.1",
     "glob": "^13.0.6",
-    "js-yaml": "^4.1.1",
+    "js-yaml": "^4.2.0",
     "json-canonicalize": "^2.0.0"
   },
   "bin": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test:watch": "NODE_ENV=test rm -rf ./test/logs/** && bun test --watch",
     "test:bail": "NODE_ENV=test rm -rf ./test/logs/** && bun test --watch --bail --verbose",
     "test:log": "mkdir -p ./test/logs && LOG_RESOLVES=true NODE_ENV=test rm -rf ./test/logs/** && bun test &> ./test/logs/test-run.txt",
-    "cli": "bun src/cli.ts",
+    "cli": "bun src/cli/index.ts",
     "build": "bun run scripts/build.ts",
     "build:clean": "rm -rf dist",
     "check": "bunx tsc --noEmit",

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -52,7 +52,7 @@ const cjsConfig: BuildConfig = {
 };
 
 const cliConfig: BuildConfig = {
-  entrypoints: ['./src/cli.ts'],
+  entrypoints: ['./src/cli/index.ts'],
   minify: false,
   sourcemap: 'external',
   target: 'node',

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -15,16 +15,13 @@ import type {
   WitnessProofFileEntry,
 } from '../interfaces';
 import { createDID, deactivateDID, resolveDIDFromLog, updateDID } from '../method';
-import {
-  fetchLogFromIdentifier,
-  parseDidKeyDid,
-} from '../utils';
+import { fetchLogFromIdentifier, parseDidKeyDid } from '../utils';
 import { bufferToString, concatBuffers, createBuffer } from '../utils/buffer';
 import { canonicalizeStrict } from '../utils/canonicalize';
 import { createHash } from '../utils/crypto';
 import { MultibaseEncoding, multibaseDecode, multibaseEncode } from '../utils/multiformats';
-import { readLogFromDisk, writeLogToDisk, writeVerificationMethodToEnv } from './persistence';
 import { signWitnessProofEntries } from '../witness';
+import { readLogFromDisk, writeLogToDisk, writeVerificationMethodToEnv } from './persistence';
 
 const usage = `
 Usage: bun run cli [command] [options]

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -13,21 +13,18 @@ import type {
   VerificationMethod,
   Verifier,
   WitnessProofFileEntry,
-} from './interfaces';
-import { createDID, deactivateDID, resolveDIDFromLog, updateDID } from './method';
+} from '../interfaces';
+import { createDID, deactivateDID, resolveDIDFromLog, updateDID } from '../method';
 import {
   fetchLogFromIdentifier,
   parseDidKeyDid,
-  readLogFromDisk,
-  writeLogToDisk,
-  writeVerificationMethodToEnv,
-} from './utils';
-import { bufferToString, concatBuffers, createBuffer } from './utils/buffer';
-import { canonicalizeStrict } from './utils/canonicalize';
-import { createHash } from './utils/crypto';
-import { MultibaseEncoding, multibaseDecode, multibaseEncode } from './utils/multiformats';
-
-import { signWitnessProofEntries } from './witness';
+} from '../utils';
+import { bufferToString, concatBuffers, createBuffer } from '../utils/buffer';
+import { canonicalizeStrict } from '../utils/canonicalize';
+import { createHash } from '../utils/crypto';
+import { MultibaseEncoding, multibaseDecode, multibaseEncode } from '../utils/multiformats';
+import { readLogFromDisk, writeLogToDisk, writeVerificationMethodToEnv } from './persistence';
+import { signWitnessProofEntries } from '../witness';
 
 const usage = `
 Usage: bun run cli [command] [options]

--- a/src/cli/persistence.ts
+++ b/src/cli/persistence.ts
@@ -1,0 +1,169 @@
+import type { DIDLog, VerificationMethod } from '../interfaces';
+import { bufferToString, createBuffer } from '../utils/buffer';
+import { config } from '../config';
+
+type ProcessVersionsLike = { node?: string; bun?: string };
+
+// Environment detection - treat React Native like a browser, but Bun as Node-like
+const isNodeEnvironment =
+  typeof process !== 'undefined' &&
+  typeof window === 'undefined' &&
+  !!(
+    (process.versions as ProcessVersionsLike | undefined)?.node ||
+    (process.versions as ProcessVersionsLike | undefined)?.bun
+  );
+
+// Avoid bundlers including `fs`: hide the specifier from static analyzers
+const fsModuleSpecifier = ['node', 'fs'].join(':');
+// We'll resolve require dynamically only in Node runtimes; otherwise use dynamic import with a non-literal
+
+type FsModule = typeof import('node:fs');
+type GlobalRequire = (id: string) => FsModule;
+
+let fsModule: FsModule | null = null;
+let fsImportPromise: Promise<FsModule> | null = null;
+
+const getFS = async (): Promise<FsModule> => {
+  if (!isNodeEnvironment) {
+    throw new Error(
+      'Filesystem access is not available in this environment (React Native, browser, or failed Node.js import)'
+    );
+  }
+
+  if (fsModule) {
+    return fsModule;
+  }
+
+  if (fsImportPromise) {
+    return fsImportPromise;
+  }
+
+  fsImportPromise = (async () => {
+    // Prefer require when present (Node)
+    const maybeRequire = (globalThis as { require?: GlobalRequire }).require;
+    if (typeof maybeRequire === 'function') {
+      try {
+        const module = maybeRequire(fsModuleSpecifier);
+        fsModule = module;
+        return module;
+      } catch {}
+      try {
+        const module = maybeRequire('fs');
+        fsModule = module;
+        return module;
+      } catch {}
+    }
+    // Fallback to dynamic import (Bun/ESM)
+    try {
+      const module = (await import(fsModuleSpecifier)) as FsModule;
+      fsModule = module;
+      return module;
+    } catch {}
+    try {
+      const module = (await import('node:fs')) as FsModule;
+      fsModule = module;
+      return module;
+    } catch {}
+    try {
+      // biome-ignore lint/style/useNodejsImportProtocol: Compatibility fallback for runtimes/bundlers that reject node: builtins.
+      const module = (await import('fs')) as FsModule;
+      fsModule = module;
+      return module;
+    } catch {}
+    throw new Error('Filesystem access is not available in this environment (unable to load fs)');
+  })();
+
+  return fsImportPromise;
+};
+
+function parseDidLogText(text: string): DIDLog {
+  return text.split('\n').map((line) => JSON.parse(line));
+}
+
+export const readLogFromDisk = async (path: string): Promise<DIDLog> => {
+  const fs = await getFS();
+  return readLogFromString(fs.readFileSync(path, 'utf8'));
+};
+
+export const readLogFromString = (str: string): DIDLog => {
+  return parseDidLogText(str.trim());
+};
+
+export const writeLogToDisk = async (path: string, log: DIDLog) => {
+  const fs = await getFS();
+  try {
+    const dir = path.substring(0, path.lastIndexOf('/'));
+    if (dir && !fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+
+    fs.writeFileSync(path, `${JSON.stringify(log[0])}\n`);
+
+    for (let i = 1; i < log.length; i++) {
+      fs.appendFileSync(path, `${JSON.stringify(log[i])}\n`);
+    }
+  } catch (error) {
+    console.error('Error writing log to disk:', error);
+    throw error;
+  }
+};
+
+export const writeVerificationMethodToEnv = async (verificationMethod: VerificationMethod) => {
+  const envFilePath = `${process.cwd()}/.env`;
+
+  const vmData = {
+    id: verificationMethod.id,
+    type: verificationMethod.type,
+    controller: verificationMethod.controller || '',
+    publicKeyMultibase: verificationMethod.publicKeyMultibase,
+    secretKeyMultibase: verificationMethod.secretKeyMultibase || '',
+  };
+
+  const fs = await getFS();
+  try {
+    let envContent = '';
+    let existingData: Array<typeof vmData> = [];
+
+    if (fs.existsSync(envFilePath)) {
+      envContent = fs.readFileSync(envFilePath, 'utf8');
+      const match = envContent.match(/DID_VERIFICATION_METHODS=(.*)/);
+      if (match?.[1]) {
+        const decodedData = bufferToString(createBuffer(match[1], 'base64'));
+        const parsedData = JSON.parse(decodedData) as unknown;
+        existingData = Array.isArray(parsedData) ? (parsedData as Array<typeof vmData>) : [];
+
+        // Check if verification method with same ID already exists
+        const existingIndex = existingData.findIndex((vm) => vm.id === vmData.id);
+        if (existingIndex !== -1) {
+          // Update existing verification method
+          existingData[existingIndex] = vmData;
+        } else {
+          // Add new verification method
+          existingData.push(vmData);
+        }
+      } else {
+        // No existing verification methods, create new array
+        existingData = [vmData];
+      }
+    } else {
+      // No .env file exists, create new array
+      existingData = [vmData];
+    }
+
+    const jsonData = JSON.stringify(existingData);
+    const encodedData = bufferToString(createBuffer(jsonData), 'base64');
+
+    // If DID_VERIFICATION_METHODS already exists, replace it
+    if (envContent.includes('DID_VERIFICATION_METHODS=')) {
+      envContent = envContent.replace(/DID_VERIFICATION_METHODS=.*\n?/, `DID_VERIFICATION_METHODS=${encodedData}\n`);
+    } else {
+      // Otherwise append it
+      envContent += `DID_VERIFICATION_METHODS=${encodedData}\n`;
+    }
+
+    fs.writeFileSync(envFilePath, `${envContent.trim()}\n`);
+    console.log('Verification method written to .env file successfully.');
+  } catch (error) {
+    console.error('Error writing verification method to .env file:', error);
+  }
+};

--- a/src/cli/persistence.ts
+++ b/src/cli/persistence.ts
@@ -1,6 +1,5 @@
 import type { DIDLog, VerificationMethod } from '../interfaces';
 import { bufferToString, createBuffer } from '../utils/buffer';
-import { config } from '../config';
 
 type ProcessVersionsLike = { node?: string; bun?: string };
 

--- a/src/method.ts
+++ b/src/method.ts
@@ -12,7 +12,7 @@ import type {
 import { DidResolutionError } from './interfaces';
 import * as v0_5 from './method_versions/method.v0.5';
 import * as v1 from './method_versions/method.v1.0';
-import { fetchLogFromIdentifier, getActiveDIDs, maybeWriteTestLog } from './utils';
+import { fetchLogFromIdentifier, getActiveDIDs } from './utils';
 
 const LATEST_VERSION = '1.0';
 
@@ -48,7 +48,6 @@ function getWebvhVersionFromOptions(options?: unknown): string {
 export const createDID = async (options: CreateDIDInterface): Promise<CreateDIDResult> => {
   const version = getWebvhVersionFromOptions(options);
   const result = version === '0.5' ? await v0_5.createDID(options) : await v1.createDID(options);
-  maybeWriteTestLog(result.did, result.log);
   return result;
 };
 
@@ -77,7 +76,6 @@ export const resolveDID = async (
       version === '0.5'
         ? await v0_5.resolveDIDFromLog(log, optsWithScid)
         : await v1.resolveDIDFromLog(log, optsWithScid);
-    maybeWriteTestLog(result.did, log);
 
     return { ...result, controlled };
   } catch (e) {
@@ -122,11 +120,9 @@ export const resolveDIDFromLog = async (
   const version = getWebvhVersionFromLog(log);
   if (version === '0.5') {
     const result = await v0_5.resolveDIDFromLog(log, options);
-    maybeWriteTestLog(result.did, log);
     return result;
   }
   const result = await v1.resolveDIDFromLog(log, options);
-  maybeWriteTestLog(result.did, log);
   return result;
 };
 
@@ -147,7 +143,6 @@ export const updateDID = async (
 ): Promise<UpdateDIDResult> => {
   const version = options.log ? getWebvhVersionFromLog(options.log) : getWebvhVersionFromOptions(options);
   const result = version === '0.5' ? await v0_5.updateDID(options) : await v1.updateDID(options);
-  maybeWriteTestLog(result.did, result.log);
   return result;
 };
 
@@ -160,6 +155,5 @@ export const updateDID = async (
 export const deactivateDID = async (options: DeactivateDIDInterface & { updateKeys?: string[] }) => {
   const version = options.log ? getWebvhVersionFromLog(options.log) : getWebvhVersionFromOptions(options);
   const result = version === '0.5' ? await v0_5.deactivateDID(options) : await v1.deactivateDID(options);
-  maybeWriteTestLog(result.did, result.log);
   return result;
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -557,111 +557,6 @@ export function generateParallelDidWeb(didwebvhDid: string, didwebvhDoc: DIDDoc)
   };
 }
 
-// Filesystem and log IO helpers
-
-function parseDidLogText(text: string): DIDLog {
-  return text.split('\n').map((line) => JSON.parse(line));
-}
-
-export const readLogFromDisk = async (path: string): Promise<DIDLog> => {
-  const fs = await getFS();
-  return readLogFromString(fs.readFileSync(path, 'utf8'));
-};
-
-export const readLogFromString = (str: string): DIDLog => {
-  return parseDidLogText(str.trim());
-};
-
-export const writeLogToDisk = async (path: string, log: DIDLog) => {
-  const fs = await getFS();
-  try {
-    const dir = path.substring(0, path.lastIndexOf('/'));
-    if (dir && !fs.existsSync(dir)) {
-      fs.mkdirSync(dir, { recursive: true });
-    }
-
-    fs.writeFileSync(path, `${JSON.stringify(log[0])}\n`);
-
-    for (let i = 1; i < log.length; i++) {
-      fs.appendFileSync(path, `${JSON.stringify(log[i])}\n`);
-    }
-  } catch (error) {
-    console.error('Error writing log to disk:', error);
-    throw error;
-  }
-};
-
-export const maybeWriteTestLog = async (did: string, log: DIDLog) => {
-  if (!config.isTestEnvironment) return;
-  try {
-    const fileSafe = did.replace(/[^a-zA-Z0-9]+/g, '_');
-    const path = `./test/logs/${fileSafe}.jsonl`;
-    await writeLogToDisk(path, log);
-  } catch (error) {
-    console.error('Error writing test log:', error);
-  }
-};
-
-export const writeVerificationMethodToEnv = async (verificationMethod: VerificationMethod) => {
-  const envFilePath = `${process.cwd()}/.env`;
-
-  const vmData = {
-    id: verificationMethod.id,
-    type: verificationMethod.type,
-    controller: verificationMethod.controller || '',
-    publicKeyMultibase: verificationMethod.publicKeyMultibase,
-    secretKeyMultibase: verificationMethod.secretKeyMultibase || '',
-  };
-
-  const fs = await getFS();
-  try {
-    let envContent = '';
-    let existingData: Array<typeof vmData> = [];
-
-    if (fs.existsSync(envFilePath)) {
-      envContent = fs.readFileSync(envFilePath, 'utf8');
-      const match = envContent.match(/DID_VERIFICATION_METHODS=(.*)/);
-      if (match?.[1]) {
-        const decodedData = bufferToString(createBuffer(match[1], 'base64'));
-        const parsedData = JSON.parse(decodedData) as unknown;
-        existingData = Array.isArray(parsedData) ? (parsedData as Array<typeof vmData>) : [];
-
-        // Check if verification method with same ID already exists
-        const existingIndex = existingData.findIndex((vm) => vm.id === vmData.id);
-        if (existingIndex !== -1) {
-          // Update existing verification method
-          existingData[existingIndex] = vmData;
-        } else {
-          // Add new verification method
-          existingData.push(vmData);
-        }
-      } else {
-        // No existing verification methods, create new array
-        existingData = [vmData];
-      }
-    } else {
-      // No .env file exists, create new array
-      existingData = [vmData];
-    }
-
-    const jsonData = JSON.stringify(existingData);
-    const encodedData = bufferToString(createBuffer(jsonData), 'base64');
-
-    // If DID_VERIFICATION_METHODS already exists, replace it
-    if (envContent.includes('DID_VERIFICATION_METHODS=')) {
-      envContent = envContent.replace(/DID_VERIFICATION_METHODS=.*\n?/, `DID_VERIFICATION_METHODS=${encodedData}\n`);
-    } else {
-      // Otherwise append it
-      envContent += `DID_VERIFICATION_METHODS=${encodedData}\n`;
-    }
-
-    fs.writeFileSync(envFilePath, `${envContent.trim()}\n`);
-    console.log('Verification method written to .env file successfully.');
-  } catch (error) {
-    console.error('Error writing verification method to .env file:', error);
-  }
-};
-
 export function deepClone<T>(obj: T): T {
   if (obj === null || typeof obj !== 'object') return obj;
   if (obj instanceof Date) return new Date(obj.getTime()) as T;
@@ -675,6 +570,10 @@ export function deepClone<T>(obj: T): T {
 }
 
 export async function fetchLogFromIdentifier(identifier: string, controlled: boolean = false): Promise<DIDLog> {
+  const parseDidLogText = (text: string): DIDLog => {
+    return text.split('\n').map((line) => JSON.parse(line));
+  };
+
   try {
     if (controlled) {
       const didParts = identifier.split(':');

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -16,7 +16,6 @@ import type {
   WitnessProofFileEntry,
 } from './interfaces';
 import { resolveDIDFromLog } from './method';
-import { bufferToString, createBuffer } from './utils/buffer';
 import { canonicalizeStrict } from './utils/canonicalize';
 import { createHash } from './utils/crypto';
 import { createMultihash, encodeBase58Btc, MultihashAlgorithm, multibaseDecode } from './utils/multiformats';

--- a/test/cli/e2e.test.ts
+++ b/test/cli/e2e.test.ts
@@ -2,10 +2,9 @@ import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 import fs from 'node:fs';
 import { join } from 'node:path';
 import { $ } from 'bun';
+import { readLogFromDisk } from '../../src/cli/persistence';
 import type { VerificationMethod } from '../../src/interfaces';
 import { resolveDIDFromLog } from '../../src/method';
-import { resolveDIDFromLog } from '../../src/method';
-import { readLogFromDisk } from '../../src/cli/persistence';
 import { generateTestVerificationMethod, TestCryptoImplementation } from '../utils';
 
 const TEST_DIR = join(process.cwd(), 'test', 'temp-cli-e2e');

--- a/test/cli/e2e.test.ts
+++ b/test/cli/e2e.test.ts
@@ -2,10 +2,11 @@ import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 import fs from 'node:fs';
 import { join } from 'node:path';
 import { $ } from 'bun';
-import type { VerificationMethod } from '../src/interfaces';
-import { resolveDIDFromLog } from '../src/method';
-import { readLogFromDisk } from '../src/utils';
-import { generateTestVerificationMethod, TestCryptoImplementation } from './utils';
+import type { VerificationMethod } from '../../src/interfaces';
+import { resolveDIDFromLog } from '../../src/method';
+import { resolveDIDFromLog } from '../../src/method';
+import { readLogFromDisk } from '../../src/cli/persistence';
+import { generateTestVerificationMethod, TestCryptoImplementation } from '../utils';
 
 const TEST_DIR = join(process.cwd(), 'test', 'temp-cli-e2e');
 const ENV_FILE = join(process.cwd(), '.env');


### PR DESCRIPTION
Start of `3.0.0`

Removes disk persistence from core runtime, putting this responsibility solely in the caller (the cli)

Library methods now only return objects to the caller

Also enables tree-shaking of `cli` from library code

Bump core deps