### PR TITLE
fix(updateDID): make timestamp optional on method

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -229,6 +229,13 @@ export interface SignDIDDocInterface {
 export interface UpdateDIDInterface {
   log: DIDLog;
   signer: Signer;
+  /**
+   * Optional explicit timestamp for the new DID log entry.
+   *
+   * When omitted, the implementation generates the timestamp internally.
+   * This option is primarily intended for deterministic test/migration flows.
+   */
+  updated?: string;
   updateKeys?: string[];
   verificationMethods?: VerificationMethod[];
   controller?: string;

--- a/src/method.ts
+++ b/src/method.ts
@@ -138,7 +138,6 @@ export const updateDID = async (
     domain?: string;
     address?: string;
     paths?: string[];
-    updated?: string;
   }
 ): Promise<UpdateDIDResult> => {
   const version = options.log ? getWebvhVersionFromLog(options.log) : getWebvhVersionFromOptions(options);

--- a/src/method_versions/method.v0.5.ts
+++ b/src/method_versions/method.v0.5.ts
@@ -388,7 +388,7 @@ export const resolveDIDFromLog = async (
 };
 
 export const updateDID = async (
-  options: UpdateDIDInterface & { services?: ServiceEndpoint[]; domain?: string; updated?: string }
+  options: UpdateDIDInterface & { services?: ServiceEndpoint[]; domain?: string }
 ): Promise<{ did: string; doc: DIDDoc; meta: DIDResolutionMeta; log: DIDLog }> => {
   const log = options.log;
   const lastEntry = log[log.length - 1];

--- a/src/method_versions/method.v1.0.ts
+++ b/src/method_versions/method.v1.0.ts
@@ -618,7 +618,6 @@ export const updateDID = async (
     domain?: string;
     address?: string;
     paths?: string[];
-    updated?: string;
   }
 ): Promise<UpdateDIDResult> => {
   const log = options.log;


### PR DESCRIPTION
The updateDID method currently exposes `updated` as a parameter. This should be optional so that normal callers do not think they can provide a timestamp.

Even if a caller passes the optional timestamp it still passes through internal validation for `iso8601` compliance and clock skew.