### PR TITLE
fix: deactivateDID produces an unresolvable log when pre-rotation is active

### DIFF
--- a/src/method_versions/method.v1.0.entries.ts
+++ b/src/method_versions/method.v1.0.entries.ts
@@ -348,8 +348,14 @@ export async function prepareDeactivationEntry({
   versionNumber: number;
   createdDate: string;
 }): Promise<PreparedEntry> {
+  if (lastMeta.prerotation) {
+    await newKeysAreInNextKeys(options.updateKeys ?? [], lastMeta.nextKeyHashes ?? []);
+  }
+
   const params = {
     updateKeys: options.updateKeys ?? lastMeta.updateKeys,
+    // Close the rotation: a deactivated DID carries no dangling key commitment.
+    nextKeyHashes: [],
     deactivated: true,
   };
 
@@ -360,12 +366,19 @@ export async function prepareDeactivationEntry({
     state: lastEntry.state,
   };
 
+  // Under active pre-rotation the resolver verifies this entry against its own
+  // updateKeys, so sign and validate with the pre-committed keys.
+  const keysToVerify = lastMeta.prerotation ? options.updateKeys : lastMeta.updateKeys;
+  if (!keysToVerify) {
+    throw new Error('updateKeys could not be determined for deactivation verification');
+  }
+
   const entry = await finalizeNonGenesisEntry({
     logEntry,
     versionNumber,
     created: createdDate,
     signer: options.signer,
-    updateKeys: lastMeta.updateKeys,
+    updateKeys: keysToVerify,
     witness: lastMeta.witness,
     verifier: options.verifier,
   });

--- a/src/method_versions/method.v1.0.ts
+++ b/src/method_versions/method.v1.0.ts
@@ -180,6 +180,9 @@ export const deactivateDID = async (
   if (lastMeta.deactivated) {
     throw new Error('DID already deactivated');
   }
+  if (lastMeta.prerotation && options.updateKeys === undefined) {
+    throw new Error('updateKeys must be provided while pre-rotation is active');
+  }
   const versionNumber = log.length + 1;
   const createdDate = createNextVersionTime(lastMeta.updated, undefined, createDate);
 
@@ -194,6 +197,8 @@ export const deactivateDID = async (
   const meta = mergeMetaFromEntry({
     previousMeta: lastMeta,
     entry,
+    // Deactivation closes any pending rotation, matching the entry's parameters.
+    nextKeyHashes: [],
     deactivated: true,
   });
 

--- a/test/features.test.ts
+++ b/test/features.test.ts
@@ -1,6 +1,6 @@
 import { beforeAll, expect, test } from 'vitest';
 import type { CreateDIDResult, DIDLog, DIDLogEntry, ServiceEndpoint, VerificationMethod } from '../src/interfaces';
-import { createDID, resolveDIDFromLog, updateDID } from '../src/method';
+import { createDID, deactivateDID, resolveDIDFromLog, updateDID } from '../src/method';
 import { deriveHash, deriveNextKeyHash } from '../src/utils/crypto';
 import { createDate } from '../src/utils/iso8601-datetime';
 import {
@@ -231,6 +231,76 @@ test('Omitted nextKeyHashes inherits previous pre-rotation state', async () => {
   const { didDocumentMetadata: meta } = await resolveDIDFromLog(log2, { verifier: testImplementation });
   expect(meta.prerotation).toBe(true);
   expect(meta.nextKeyHashes).toEqual([nextKeyHash]);
+});
+
+test('deactivateDID with pre-rotation active produces a resolvable deactivated log', async () => {
+  const nextKeyHash = await deriveNextKeyHash(authKey2.publicKeyMultibase!);
+  const { log: log1 } = await createDID({
+    address: 'example.com',
+    signer: createTestSigner(authKey1),
+    updateKeys: [authKey1.publicKeyMultibase!],
+    verificationMethods: asPublicVerificationMethods(authKey1),
+    nextKeyHashes: [nextKeyHash],
+    verifier: testImplementation,
+  });
+
+  const deactivated = await deactivateDID({
+    log: log1,
+    signer: createTestSigner(authKey2),
+    updateKeys: [authKey2.publicKeyMultibase!],
+    verifier: testImplementation,
+  });
+
+  expect(deactivated.meta.deactivated).toBe(true);
+  expect(deactivated.log[1].parameters.updateKeys).toEqual([authKey2.publicKeyMultibase!]);
+  expect(deactivated.log[1].parameters.nextKeyHashes).toEqual([]);
+
+  const { didDocumentMetadata: meta } = await resolveDIDFromLog(deactivated.log, {
+    verifier: testImplementation,
+  });
+  expect(meta.deactivated).toBe(true);
+  expect(meta.prerotation).toBe(false);
+});
+
+test('deactivateDID rejects keys that are not in the prior nextKeyHashes', async () => {
+  const nextKeyHash = await deriveNextKeyHash(authKey2.publicKeyMultibase!);
+  const { log: log1 } = await createDID({
+    address: 'example.com',
+    signer: createTestSigner(authKey1),
+    updateKeys: [authKey1.publicKeyMultibase!],
+    verificationMethods: asPublicVerificationMethods(authKey1),
+    nextKeyHashes: [nextKeyHash],
+    verifier: testImplementation,
+  });
+
+  await expect(
+    deactivateDID({
+      log: log1,
+      signer: createTestSigner(authKey3),
+      updateKeys: [authKey3.publicKeyMultibase!],
+      verifier: testImplementation,
+    })
+  ).rejects.toThrow('Invalid update key');
+});
+
+test('deactivateDID omitting updateKeys is rejected while pre-rotation is active', async () => {
+  const nextKeyHash = await deriveNextKeyHash(authKey2.publicKeyMultibase!);
+  const { log: log1 } = await createDID({
+    address: 'example.com',
+    signer: createTestSigner(authKey1),
+    updateKeys: [authKey1.publicKeyMultibase!],
+    verificationMethods: asPublicVerificationMethods(authKey1),
+    nextKeyHashes: [nextKeyHash],
+    verifier: testImplementation,
+  });
+
+  await expect(
+    deactivateDID({
+      log: log1,
+      signer: createTestSigner(authKey1),
+      verifier: testImplementation,
+    })
+  ).rejects.toThrow('updateKeys must be provided while pre-rotation is active');
 });
 
 test('Omitted updateKeys is rejected while pre-rotation is active', async () => {


### PR DESCRIPTION
Fixes #161.

### Problem

When a DID has active pre-rotation (a non-empty `nextKeyHashes` commitment), `deactivateDID` succeeds and returns `deactivated: true`, but the log it produces is rejected by the library's own resolver. The DID is permanently bricked: it can no longer be resolved, and it cannot be un-deactivated.

`prepareDeactivationEntry` defaults the deactivation entry's `updateKeys` to the *current* keys with no pre-rotation guard, while `processV1SubsequentEntry` verifies any non-genesis entry under active pre-rotation against the entry's **own** `parameters.updateKeys` and requires those keys to hash into the previous entry's `nextKeyHashes`. The current keys are (by construction) not in `nextKeyHashes`, so resolution throws:

```
Invalid update key Qm... Not found in nextKeyHashes Qm...
```

There was also no caller-side workaround: passing the pre-committed keys explicitly failed at deactivation time with `'Key ... is not authorized to update.'`, because `prepareDeactivationEntry` unconditionally passed `lastMeta.updateKeys` to `finalizeNonGenesisEntry`. A DID with active pre-rotation therefore could not be deactivated through the public API at all.

See #161 for a full reproduction against current `main` (052ede9).

### Fix

Mirrors the existing `updateDID` behavior on the deactivation path:

1. `deactivateDID` (`src/method_versions/method.v1.0.ts`): when `lastMeta.prerotation` is true, `options.updateKeys` is required; otherwise it throws `'updateKeys must be provided while pre-rotation is active'`, matching the existing `updateDID` guard. The returned metadata now reports `nextKeyHashes: []` / `prerotation: false`, matching what the resolver reports for the deactivated log.
2. `prepareDeactivationEntry` (`src/method_versions/method.v1.0.entries.ts`): validates the provided keys against `lastMeta.nextKeyHashes` via `newKeysAreInNextKeys`, so a mismatch fails at deactivation time instead of at resolution time; signs and verifies with the pre-committed keys (`lastMeta.prerotation ? options.updateKeys : lastMeta.updateKeys`, the same selection `prepareUpdateEntry` uses); and includes `nextKeyHashes: []` in the deactivation parameters to close the rotation.

The deactivation entry is then signed by the pre-committed keys and satisfies the resolver's `newKeysAreInNextKeys` check, consistent with the [v1.0 spec's deactivation section](https://identity.foundation/didwebvh/v1.0/#deactivate-revoke), which describes deactivation as a standard log entry update and therefore subject to the same pre-rotation rules as any other entry.

### Tests

Three new cases in `test/features.test.ts`:

- Deactivating a pre-rotation DID while providing the pre-committed `updateKeys` produces a log that resolves with `deactivated: true` and `prerotation: false`, and the deactivation entry carries the new keys plus `nextKeyHashes: []`.
- Deactivating with keys that are not in the prior `nextKeyHashes` rejects with `'Invalid update key'` at deactivation time.
- Deactivating without `updateKeys` while pre-rotation is active throws `'updateKeys must be provided while pre-rotation is active'` instead of emitting an unresolvable log.

Full suite: 26 files / 352 tests passing; `tsc --noEmit` and Biome clean.
