### PR TITLE
chore(verificationMethod): remove redundant parsing and tests

### DIFF
--- a/src/core/resolution.ts
+++ b/src/core/resolution.ts
@@ -13,15 +13,12 @@ import type {
   DIDLogEntry,
   DIDResolutionMeta,
   ResolutionOptions,
-  VerificationMethod,
   WitnessParameterResolution,
   WitnessProofFileEntry,
 } from '../interfaces';
 import { buildProblemDetails } from '../resolver-result';
 import {
   deepClone,
-  fetchLogFromIdentifier,
-  getActiveDIDs,
   parseAndValidateVersionId,
   parseDidWebvhIdentifier,
   replaceValueInObject,
@@ -29,8 +26,6 @@ import {
 } from '../utils';
 import { deriveHash } from '../utils/crypto';
 import { MAX_FUTURE_SKEW_MS, parseUtcIso8601VersionTime } from '../utils/iso8601-datetime';
-import { findVerificationMethod } from '../utils/verification-methods';
-import { defaultVerifier } from '../verifier';
 import {
   countVerifiedWitnessApprovals,
   fetchWitnessProofs,
@@ -83,21 +78,6 @@ interface ParsedResolutionEntryContext {
 const SUPPORTED_INITIAL_METHODS = new Set([METHOD_PROTOCOL_V0_5, METHOD_PROTOCOL_V1_0]);
 const isSupportedInitialMethod = (m: string | undefined): m is string =>
   m !== undefined && SUPPORTED_INITIAL_METHODS.has(m);
-
-export const resolveDidWebvhVerificationMethod = async (vm: string): Promise<VerificationMethod | null> => {
-  const did = vm.split('#')[0];
-  const activeDIDs = await getActiveDIDs();
-  const controlled = activeDIDs.includes(did);
-  const log = await fetchLogFromIdentifier(did, controlled);
-  const resolution = await resolveLog(log, { requestedDid: did, verifier: defaultVerifier });
-  const didDocument = resolution.doc;
-
-  if (!didDocument) {
-    throw new Error(`Verification method ${vm} not found`);
-  }
-
-  return findVerificationMethod(didDocument as DIDDoc, vm);
-};
 
 export const resolveLog = async (
   log: DIDLog,

--- a/src/witness.ts
+++ b/src/witness.ts
@@ -262,7 +262,7 @@ export async function countVerifiedWitnessApprovals(
           continue;
         }
 
-        const publicKeyMultibase = parseDidKeyVerificationMethod(proof.verificationMethod)?.keyMultibase;
+        const publicKeyMultibase = parsedVerificationMethod.keyMultibase;
         if (!publicKeyMultibase) {
           throw new Error(`Verification Method ${proof.verificationMethod} not found`);
         }

--- a/test/resolve-http.test.ts
+++ b/test/resolve-http.test.ts
@@ -1,10 +1,7 @@
 import { afterEach, beforeAll, describe, expect, test, vi } from 'vitest';
-import { resolveDidWebvhVerificationMethod } from '../src/core/resolution';
 import type { DIDLog, VerificationMethod } from '../src/interfaces';
 import { createDID, resolveDID } from '../src/method';
-import * as utilsModule from '../src/utils';
 import { fetchLogFromIdentifier, fetchWitnessProofs } from '../src/utils';
-import { findVerificationMethod } from '../src/utils/verification-methods';
 import {
   asPublicVerificationMethods,
   createTestSigner,
@@ -175,73 +172,5 @@ describe('fetchWitnessProofs', () => {
     stubFetchFailure(new Error('connection refused'));
 
     expect(await fetchWitnessProofs('did:webvh:scid123:example.com')).toEqual([]);
-  });
-});
-
-describe('resolveVM', () => {
-  afterEach(() => {
-    restoreStubs();
-    vi.restoreAllMocks();
-  });
-
-  test('resolves did:webvh VM via direct verificationMethod array match', async () => {
-    const authKey = await generateTestVerificationMethod();
-    const verifier = new TestCryptoImplementation({ verificationMethod: authKey });
-    const { did: localDid, log: localLog } = await createDID({
-      address: 'example.com',
-      signer: createTestSigner(authKey),
-      updateKeys: [authKey.publicKeyMultibase!],
-      verificationMethods: asPublicVerificationMethods(authKey),
-      verifier,
-    });
-
-    const vmId = localLog[0].state.verificationMethod?.[0].id;
-    if (!vmId) {
-      throw new Error('Test DID log did not include a verificationMethod id');
-    }
-
-    const getActiveDIDsSpy = vi.spyOn(utilsModule, 'getActiveDIDs').mockResolvedValue([]);
-    const fetchLogSpy = vi.spyOn(utilsModule, 'fetchLogFromIdentifier');
-    stubFetchResponse(toJsonl(localLog));
-
-    const resolved = await resolveDidWebvhVerificationMethod(vmId);
-
-    expect(getActiveDIDsSpy).toHaveBeenCalledTimes(1);
-    expect(fetchLogSpy).toHaveBeenCalledWith(localDid, false);
-
-    expect(resolved).toMatchObject({
-      id: vmId,
-      type: 'Multikey',
-      publicKeyMultibase: authKey.publicKeyMultibase,
-    });
-  });
-
-  test('resolves did:webvh VM via verification relationship object fallback', () => {
-    const vmId = 'did:webvh:scid123:example.com#assertion-key';
-
-    const didDocument = {
-      id: 'did:webvh:scid123:example.com',
-      verificationMethod: [],
-      assertionMethod: [
-        'did:webvh:scid123:example.com#string-reference',
-        {
-          id: vmId,
-          type: 'Multikey',
-          publicKeyMultibase: 'z6MkoJ8mW6T2d4QF9xk33bQ4rQk6N4R8c6rj59YxQG3hbtVW',
-        },
-      ],
-    } as unknown as DIDLog[number]['state'];
-
-    const resolved = findVerificationMethod(didDocument, vmId);
-
-    expect(resolved).toEqual({
-      id: vmId,
-      type: 'Multikey',
-      publicKeyMultibase: 'z6MkoJ8mW6T2d4QF9xk33bQ4rQk6N4R8c6rj59YxQG3hbtVW',
-    });
-  });
-
-  test('wraps unsupported verification method schemes', async () => {
-    await expect(resolveDidWebvhVerificationMethod('did:web:example.com#key-1')).rejects.toThrow();
   });
 });


### PR DESCRIPTION
Following @brianorwhatever 's comment on #163 have removed:

* redundant parsing in `witness.ts:265` 
* `resolveDidWebvhVerificationMethod` + tests (we already test for spec-required `assertionMethod` in `did-document.test.ts`)