### PR TITLE
feat(controller): controller APIs for witnessing convenience

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,15 @@ const result = await resolveDID(did, {
 The callback returns a `DIDLog` or `undefined`. Returning `undefined` uses the
 normal HTTPS fallback. Callback-supplied logs go through the same validation
 pipeline as remotely fetched logs. When explicit witness proofs are omitted,
-the runtime retrieves them from the specification-defined deterministic URL.
+`resolveDID`/`resolveDIDFromLog` retrieve them from the specification-defined
+deterministic URL.
+
+`updateDID` and `deactivateDID` never perform this network fetch: when
+`options.witnessProofs` is omitted, they pass `[]` rather than fetching, so a
+missing or insufficient proof set surfaces immediately as an unmet witness
+threshold instead of a network-dependent lookup. Callers that need witness
+verification for an update or deactivation must supply `witnessProofs`
+explicitly (see [Witness Functions](#witness-functions) below).
 
 The CLI owns environment variables, `.env` persistence, private-key selection,
 and its local log-file layout. `DID_VERIFICATION_METHODS` is therefore a CLI
@@ -302,6 +310,44 @@ Method-specific metadata (`scid`, `updateKeys`, `nextKeyHashes`, `prerotation`, 
 
 - `signWitnessProofEntries(versionIds: string[], witnesses: WitnessEntry[], witnessSignersByDid: Record<string, WitnessSigner>, created?: string): Promise<WitnessSigningResult[]>`
   Signs did-witness proof entries for multiple target versions.
+
+- `getWitnessRequirements(result: { log: DIDLog }): WitnessRequirement[]`
+  Derives the witness approvals required for each entry in a DID log that requires witnessing, by applying the did:webvh witness transition rules (genesis activation, inheritance, replacement, and removal). Synchronous, performs no network fetch, and requires no `Verifier`. Accepts any object with a `log: DIDLog` property, so a `CreateDIDResult`/`UpdateDIDResult`/`DIDResolutionResult`-shaped value can be passed directly. Returns `[]` when the log has no active witness requirement.
+
+- `verifyWitnessProofs(result: { log: DIDLog }, witnessProofs: WitnessProofFileEntry[], options?: { verifier?: Verifier }): Promise<WitnessVerificationResult>`
+  Verifies every witness requirement in a DID log against the supplied `witnessProofs`, without any network fetch — proofs must be provided by the caller (e.g. proofs obtained for a proposed, not-yet-published log chain tip before it and its witness proofs are published). Returns `{ verified: boolean, requirements: (WitnessRequirement & { approvals: number, satisfied: boolean })[] }`, reporting an unmet threshold as data (`verified: false`) rather than throwing. All other verification failures (hash chain, SCID, controller proof, etc.) still throw.
+
+### Witness lifecycle sequence
+
+`createDID`, `updateDID`, and `deactivateDID` always return their normal, complete result — a proposed log chain tip is generated and returned regardless of whether any witness requirement is satisfied. Witness proofs are a separate artifact (`did-witness.json`) from the DID log (`did.jsonl`); collecting or verifying them never modifies the returned result.
+
+`getWitnessRequirements` tells the caller which approvals must be collected for the returned log. `verifyWitnessProofs` then checks a prospective proof file against that exact result: `verified: true` means the caller may proceed with the specification's publication order — it does **not** mean the library has published anything. The caller remains responsible for publishing `did-witness.json` before publishing the corresponding `did.jsonl` update.
+
+`result.meta.witness` describes the witness configuration active *after* the result is published; it must not be assumed to be the configuration that approves the transition into that result (see `getWitnessRequirements`, which derives the correct governing configuration per did:webvh's witness transition rules).
+
+```ts
+const result = await createDID(options);
+const requirements = getWitnessRequirements(result);
+
+if (requirements.length > 0) {
+  // Application-owned: collect signed witness proofs out-of-band (e.g. via a
+  // witness service or manual approval flow), not part of this library.
+  const prospectiveWitnessFile = await collectProofsOutsideTheLibrary(result, requirements);
+
+  const { verified } = await verifyWitnessProofs(result, prospectiveWitnessFile);
+  if (!verified) {
+    // Keep collecting proofs; this is expected, not an error.
+  }
+
+  // Application-owned: publish did-witness.json to its well-known location.
+  await callerPublishesWitnessFile(prospectiveWitnessFile);
+}
+
+// Application-owned: publish did.jsonl only after the witness file above.
+await callerPublishesDIDLog(result.log);
+```
+
+`updateDID` and `deactivateDID` default `witnessProofs` to `[]` (never fetching) when the option is omitted, so an unmet witness threshold on those two methods surfaces immediately as an error rather than a network-dependent lookup — see [Runtime and CLI separation](#runtime-and-cli-separation).
 
 ### Cryptography Functions
 

--- a/README.md
+++ b/README.md
@@ -311,30 +311,30 @@ Method-specific metadata (`scid`, `updateKeys`, `nextKeyHashes`, `prerotation`, 
 - `signWitnessProofEntries(versionIds: string[], witnesses: WitnessEntry[], witnessSignersByDid: Record<string, WitnessSigner>, created?: string): Promise<WitnessSigningResult[]>`
   Signs did-witness proof entries for multiple target versions.
 
-- `getWitnessRequirements(result: { log: DIDLog }): WitnessRequirement[]`
-  Derives the witness approvals required for each entry in a DID log that requires witnessing, by applying the did:webvh witness transition rules (genesis activation, inheritance, replacement, and removal). Synchronous, performs no network fetch, and requires no `Verifier`. Accepts any object with a `log: DIDLog` property, so a `CreateDIDResult`/`UpdateDIDResult`/`DIDResolutionResult`-shaped value can be passed directly. Returns `[]` when the log has no active witness requirement.
+- `getWitnessRequirements(log: DIDLog): WitnessRequirement[]`
+  Derives the witness approvals required for each entry in a DID log that requires witnessing, by applying the did:webvh witness transition rules (genesis activation, inheritance, replacement, and removal). Synchronous, performs no network fetch, and requires no `Verifier`. Returns `[]` when the log has no active witness requirement.
 
-- `verifyWitnessProofs(result: { log: DIDLog }, witnessProofs: WitnessProofFileEntry[], options?: { verifier?: Verifier }): Promise<WitnessVerificationResult>`
+- `verifyWitnessProofs(log: DIDLog, witnessProofs: WitnessProofFileEntry[], options?: { verifier?: Verifier }): Promise<WitnessVerificationResult>`
   Verifies every witness requirement in a DID log against the supplied `witnessProofs`, without any network fetch — proofs must be provided by the caller (e.g. proofs obtained for a proposed, not-yet-published log chain tip before it and its witness proofs are published). Returns `{ verified: boolean, requirements: (WitnessRequirement & { approvals: number, satisfied: boolean })[] }`, reporting an unmet threshold as data (`verified: false`) rather than throwing. All other verification failures (hash chain, SCID, controller proof, etc.) still throw.
 
 ### Witness lifecycle sequence
 
 `createDID`, `updateDID`, and `deactivateDID` always return their normal, complete result — a proposed log chain tip is generated and returned regardless of whether any witness requirement is satisfied. Witness proofs are a separate artifact (`did-witness.json`) from the DID log (`did.jsonl`); collecting or verifying them never modifies the returned result.
 
-`getWitnessRequirements` tells the caller which approvals must be collected for the returned log. `verifyWitnessProofs` then checks a prospective proof file against that exact result: `verified: true` means the caller may proceed with the specification's publication order — it does **not** mean the library has published anything. The caller remains responsible for publishing `did-witness.json` before publishing the corresponding `did.jsonl` update.
+`getWitnessRequirements` tells the caller which approvals must be collected for a DID log. `verifyWitnessProofs` then checks a prospective proof file against that exact log: `verified: true` means the caller may proceed with the specification's publication order — it does **not** mean the library has published anything. The caller remains responsible for publishing `did-witness.json` before publishing the corresponding `did.jsonl` update.
 
 `result.meta.witness` describes the witness configuration active *after* the result is published; it must not be assumed to be the configuration that approves the transition into that result (see `getWitnessRequirements`, which derives the correct governing configuration per did:webvh's witness transition rules).
 
 ```ts
 const result = await createDID(options);
-const requirements = getWitnessRequirements(result);
+const requirements = getWitnessRequirements(result.log);
 
 if (requirements.length > 0) {
   // Application-owned: collect signed witness proofs out-of-band (e.g. via a
   // witness service or manual approval flow), not part of this library.
   const prospectiveWitnessFile = await collectProofsOutsideTheLibrary(result, requirements);
 
-  const { verified } = await verifyWitnessProofs(result, prospectiveWitnessFile);
+  const { verified } = await verifyWitnessProofs(result.log, prospectiveWitnessFile);
   if (!verified) {
     // Keep collecting proofs; this is expected, not an error.
   }

--- a/README.md
+++ b/README.md
@@ -130,7 +130,40 @@ The following commands are defined in the `package.json` file:
   pnpm cli
 ```
 
-The CLI accepts a `--watcher` option during create and update operations to specify one or more watcher URLs.
+The CLI accepts a `--watcher` option during create and update operations to specify one or more watcher URLs. Witnessed DID operations use the published witness proof file by default:
+
+```bash
+pnpm cli -- update --log ./did.jsonl --output ./updated-did.jsonl
+pnpm cli -- deactivate --log ./did.jsonl --output ./deactivated-did.jsonl
+```
+
+Pass `--witness-file` to use a local `did-witness.json` file instead:
+
+```bash
+pnpm cli -- update \
+  --log ./did.jsonl \
+  --output ./updated-did.jsonl \
+  --witness-file ./did-witness.json
+
+pnpm cli -- deactivate \
+  --log ./did.jsonl \
+  --output ./deactivated-did.jsonl \
+  --witness-file ./did-witness.json
+```
+
+When `--witness-file` is omitted, `update` and `deactivate` retain the normal network-fetch behavior. Providing a witness file avoids that fetch; an empty JSON array (`[]`) explicitly disables fetching and fails fast when witnesses are required.
+
+Use `verify-proofs` to inspect a local witness proof file before publishing or updating a DID:
+
+```bash
+pnpm cli -- verify-proofs \
+  --log ./did.jsonl \
+  --witness-file ./did-witness.json
+```
+
+The command prints the `verifyWitnessProofs` result as JSON, including per-entry
+approval counts and satisfaction status. It exits successfully when all witness
+thresholds are satisfied and exits with status `1` when they are not.
 
 1. `build`: Build the package.
 
@@ -313,7 +346,7 @@ Method-specific metadata (`scid`, `updateKeys`, `nextKeyHashes`, `prerotation`, 
   Derives the witness approvals required for each entry in a DID log that requires witnessing, by applying the did:webvh witness transition rules (genesis activation, inheritance, replacement, and removal). Synchronous, performs no network fetch, and requires no `Verifier`. Returns `[]` when the log has no active witness requirement.
 
 - `verifyWitnessProofs(log: DIDLog, witnessProofs: WitnessProofFileEntry[], options?: { verifier?: Verifier }): Promise<WitnessVerificationResult>`
-  Verifies every witness requirement in a DID log against the supplied `witnessProofs`, without any network fetch — proofs must be provided by the caller (e.g. proofs obtained for a proposed, not-yet-published log chain tip before it and its witness proofs are published). Returns `{ verified: boolean, requirements: (WitnessRequirement & { approvals: number, satisfied: boolean })[] }`, reporting an unmet threshold as data (`verified: false`) rather than throwing. All other verification failures (hash chain, SCID, controller proof, etc.) still throw.
+  Verifies every witness requirement in a DID log against the supplied `witnessProofs`, without any network fetch — proofs must be provided by the caller (e.g. proofs obtained for a proposed, not-yet-published log chain tip before it and its witness proofs are published). Returns `{ verified, requirements, rejectedProofs }`, reporting an unmet threshold as data (`verified: false`) rather than throwing. `rejectedProofs` contains structured diagnostics for discarded proofs, including a library-defined rejection code, proof location, verification method, and governing requirement when available. All other verification failures (hash chain, SCID, controller proof, etc.) still throw.
 
 ### Witness lifecycle sequence
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ For this to work, the `didwebvh-ts` package on npmjs.com must have a Trusted Pub
 
 Resolution follows the standard W3C [`did-resolver`](https://github.com/decentralized-identity/did-resolver) interface. `resolveDID` / `resolveDIDFromLog` return a `DIDResolutionResult` (`{ didResolutionMetadata, didDocument, didDocumentMetadata }`), and `getResolver()` produces a registry entry you can drop into a `did-resolver` `Resolver` alongside `did:web`, `did:ethr`, etc.
 
-#### Using the did-resolver interface
+### Using the did-resolver interface
 
 ```typescript
 import { Resolver } from 'did-resolver';

--- a/README.md
+++ b/README.md
@@ -239,12 +239,10 @@ pipeline as remotely fetched logs. When explicit witness proofs are omitted,
 `resolveDID`/`resolveDIDFromLog` retrieve them from the specification-defined
 deterministic URL.
 
-`updateDID` and `deactivateDID` never perform this network fetch: when
-`options.witnessProofs` is omitted, they pass `[]` rather than fetching, so a
-missing or insufficient proof set surfaces immediately as an unmet witness
-threshold instead of a network-dependent lookup. Callers that need witness
-verification for an update or deactivation must supply `witnessProofs`
-explicitly (see [Witness Functions](#witness-functions) below).
+When `witnessProofs` is omitted (`undefined`), `resolveDID`, `resolveDIDFromLog`,
+`updateDID`, and `deactivateDID` use the normal specification-defined witness
+proof fetch. Pass `witnessProofs: []` explicitly to disable network fetching and fail fast when a witnessed log has no locally supplied proofs. Any non-empty
+explicit proof array is verified directly without fetching.
 
 The CLI owns environment variables, `.env` persistence, private-key selection,
 and its local log-file layout. `DID_VERIFICATION_METHODS` is therefore a CLI
@@ -347,7 +345,10 @@ if (requirements.length > 0) {
 await callerPublishesDIDLog(result.log);
 ```
 
-`updateDID` and `deactivateDID` default `witnessProofs` to `[]` (never fetching) when the option is omitted, so an unmet witness threshold on those two methods surfaces immediately as an error rather than a network-dependent lookup — see [Runtime and CLI separation](#runtime-and-cli-separation).
+For `updateDID` and `deactivateDID`, omitting `witnessProofs` preserves normal
+proof retrieval. Pass `witnessProofs: []` when the caller intentionally wants
+network-free, fail-fast validation; pass an explicit proof array to validate
+against caller-supplied proofs.
 
 ### Cryptography Functions
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -21,6 +21,7 @@ import {
   resolveDIDFromLog,
   signWitnessProofEntries,
   updateDID,
+  verifyWitnessProofs,
 } from '../index.js';
 import { concatBuffers } from '../utils/buffer.js';
 import { canonicalizeStrict } from '../utils/canonicalize.js';
@@ -40,6 +41,7 @@ Usage: pnpm cli -- [command] [options]
 Commands:
   create     Create a new DID
   resolve    Resolve a DID
+  verify-proofs Verify witness proofs for a DID log
   update     Update an existing DID
   deactivate Deactivate an existing DID
   generate-witness-proof Generate witness proofs for a DID version
@@ -57,7 +59,7 @@ Options:
   --add-vm [type]           Add a verification method (type can be authentication, assertionMethod, keyAgreement, capabilityInvocation, capabilityDelegation)
   --also-known-as [alias]   Add an alsoKnownAs alias (can be used multiple times)
   --next-key-hash [hash]    Add a nextKeyHash (can be used multiple times)
-  --witness-file [file]     Path to witness proofs file (optional for resolve)
+  --witness-file [file]     Path to witness proofs file (optional for resolve, update, deactivate)
 
   # Options for generate-witness-proof:
   --version-id [id]         The version ID to generate proofs for (required, can be used multiple times)
@@ -71,6 +73,7 @@ Examples:
   pnpm cli -- create --address "did:webvh:example.com:3000" --portable
   pnpm cli -- resolve --did did:webvh:123456:example.com
   pnpm cli -- resolve --log ./did.jsonl --witness-file ./did-witness.json
+  pnpm cli -- verify-proofs --log ./did.jsonl --witness-file ./did-witness.json
   pnpm cli -- update --log ./did.jsonl --output ./updated-did.jsonl --add-vm keyAgreement --service LinkedDomains,https://example.com
   pnpm cli -- deactivate --log ./did.jsonl --output ./deactivated-did.jsonl
   pnpm cli -- generate-witness-proof --version-id 1-abc123 --witness-did did:key:z6Mk... --witness-secret z1A... --output did-witness.json
@@ -177,6 +180,11 @@ function getLocalDidLogPath(did: string): string | undefined {
   if (parts.length < 3 || parts[0] !== 'did' || parts[1] !== 'webvh') return undefined;
   const fileIdentifier = parts.slice(4).join(':');
   return `./src/routes/${fileIdentifier || '.well-known'}/did.jsonl`;
+}
+
+function readWitnessProofsFile(path: string | undefined): WitnessProofFileEntry[] | undefined {
+  if (!path) return undefined;
+  return JSON.parse(fs.readFileSync(path, 'utf8')) as WitnessProofFileEntry[];
 }
 
 async function resolveControlledDidFromEnv(did: string): Promise<DIDLog | undefined> {
@@ -337,10 +345,46 @@ export async function handleResolve(args: string[]) {
   }
 }
 
+export async function handleVerifyProofs(args: string[]) {
+  const options = parseOptions(args);
+  const logFile = options.log as string;
+  const witnessFile = options['witness-file'] as string | undefined;
+
+  if (!logFile) {
+    console.error('Log file is required for verify-proofs command');
+    process.exit(1);
+  }
+  if (!witnessFile) {
+    console.error('Witness file is required for verify-proofs command');
+    process.exit(1);
+  }
+
+  try {
+    const log = await readLogFromDisk(logFile);
+    const witnessProofs = readWitnessProofsFile(witnessFile);
+    if (!witnessProofs) {
+      throw new Error('Witness proofs could not be loaded');
+    }
+
+    const result = await verifyWitnessProofs(log, witnessProofs, {
+      verifier: createCustomCrypto(),
+    });
+    console.log(JSON.stringify(result, null, 2));
+    if (!result.verified) {
+      process.exitCode = 1;
+    }
+    return result;
+  } catch (error) {
+    console.error('Error verifying witness proofs:', error);
+    process.exit(1);
+  }
+}
+
 export async function handleUpdate(args: string[]) {
   const options = parseOptions(args);
   const logFile = options.log as string;
   const output = options.output as string | undefined;
+  const witnessProofs = readWitnessProofsFile(options['witness-file'] as string | undefined);
   const witnesses = options.witness as string[] | undefined;
   const witnessThreshold = options['witness-threshold']
     ? parseInt(options['witness-threshold'] as string, 10)
@@ -358,7 +402,10 @@ export async function handleUpdate(args: string[]) {
 
   try {
     const log = await readLogFromDisk(logFile);
-    const updateResolution = await resolveDIDFromLog(log, { verifier: createCustomCrypto() });
+    const updateResolution = await resolveDIDFromLog(log, {
+      verifier: createCustomCrypto(),
+      witnessProofs,
+    });
     if (updateResolution.didResolutionMetadata.error) {
       throw new Error(`Resolution failed: ${updateResolution.didResolutionMetadata.error}`);
     }
@@ -449,6 +496,7 @@ export async function handleUpdate(args: string[]) {
       watchers: watchers ?? undefined,
       services,
       alsoKnownAs,
+      witnessProofs,
     });
 
     if (output) {
@@ -467,6 +515,7 @@ export async function handleDeactivate(args: string[]) {
   const options = parseOptions(args);
   const logFile = options.log as string;
   const output = options.output as string | undefined;
+  const witnessProofs = readWitnessProofsFile(options['witness-file'] as string | undefined);
 
   if (!logFile) {
     console.error('Log file is required for deactivate command');
@@ -476,7 +525,10 @@ export async function handleDeactivate(args: string[]) {
   try {
     // Read the current log to get the latest state
     const log = await readLogFromDisk(logFile);
-    const deactivateResolution = await resolveDIDFromLog(log, { verifier: createCustomCrypto() });
+    const deactivateResolution = await resolveDIDFromLog(log, {
+      verifier: createCustomCrypto(),
+      witnessProofs,
+    });
     if (deactivateResolution.didResolutionMetadata.error) {
       throw new Error(`Resolution failed: ${deactivateResolution.didResolutionMetadata.error}`);
     }
@@ -504,6 +556,7 @@ export async function handleDeactivate(args: string[]) {
       log,
       signer: crypto,
       verifier: crypto,
+      witnessProofs,
     });
 
     if (output) {
@@ -641,6 +694,9 @@ export async function main() {
         break;
       case 'resolve':
         await handleResolve(args);
+        break;
+      case 'verify-proofs':
+        await handleVerifyProofs(args);
         break;
       case 'update':
         await handleUpdate(args);

--- a/src/core/resolution.ts
+++ b/src/core/resolution.ts
@@ -32,7 +32,7 @@ import {
   resolveWitnessParameter,
   validateWitnessParameter,
 } from '../witness';
-import { getRequiredWitnessForEntry, type RequiredWitnessCheck } from './witness-requirements';
+import { getRequiredWitnessForEntry, type RequiredWitnessCheck, type WitnessCheckResult } from './witness-requirements';
 
 const hasOwn = <K extends PropertyKey>(obj: object, key: K): obj is Record<K, unknown> => Object.hasOwn(obj, key);
 
@@ -74,6 +74,10 @@ const isSupportedInitialMethod = (m: string | undefined): m is string =>
 
 type InternalResolutionOptions = ResolutionOptions & {
   requestedDid?: string;
+  // Internal-only hook used by `verifyWitnessProofs` (see method.ts) to observe
+  // per-entry witness check outcomes without converting an unmet threshold
+  // into a thrown error.
+  onWitnessChecksComputed?: (checks: WitnessCheckResult[]) => void;
 };
 
 export const resolveLog = async (
@@ -583,6 +587,7 @@ const finalizeResolutionChecks = async ({
       onThresholdFailure: () => {
         resolverContext.witnessThresholdFailure = true;
       },
+      onWitnessChecksComputed: options.onWitnessChecksComputed,
     });
   }
 };
@@ -594,6 +599,7 @@ const enforceRequiredWitnessChecks = async ({
   logEntries,
   verifier,
   onThresholdFailure,
+  onWitnessChecksComputed,
 }: {
   requiredWitnessChecks: RequiredWitnessCheck[];
   witnessProofs: WitnessProofFileEntry[] | undefined;
@@ -601,6 +607,7 @@ const enforceRequiredWitnessChecks = async ({
   logEntries: DIDLog;
   verifier: ResolutionOptions['verifier'];
   onThresholdFailure: () => void;
+  onWitnessChecksComputed?: (checks: WitnessCheckResult[]) => void;
 }): Promise<void> => {
   let resolvedWitnessProofs = witnessProofs;
   if (!resolvedWitnessProofs) {
@@ -608,6 +615,13 @@ const enforceRequiredWitnessChecks = async ({
   }
 
   const publishedVersionNumbers = new Map(logEntries.map((entry, index) => [entry.versionId, index + 1]));
+
+  // When `onWitnessChecksComputed` is supplied (internal-only, see
+  // `verifyWitnessProofs` in method.ts), every check is computed and reported
+  // to the caller instead of throwing on the first unmet threshold, so the
+  // caller can report a complete per-entry breakdown rather than stopping at
+  // the first failure.
+  const computedChecks: WitnessCheckResult[] = [];
 
   for (const check of requiredWitnessChecks) {
     const candidateProofs = resolvedWitnessProofs.filter((witnessProof) => {
@@ -622,12 +636,25 @@ const enforceRequiredWitnessChecks = async ({
       verifier
     );
     const threshold = normalizeWitnessThreshold(check.witness.threshold);
+    const satisfied = approvals >= threshold;
 
-    if (approvals < threshold) {
+    if (onWitnessChecksComputed) {
+      computedChecks.push({ ...check, approvals, satisfied });
+      if (!satisfied) {
+        onThresholdFailure();
+      }
+      continue;
+    }
+
+    if (!satisfied) {
       onThresholdFailure();
       throw new Error(
         `Witness threshold not met for version ${check.targetVersionId}: got ${approvals}, need ${check.witness.threshold}`
       );
     }
+  }
+
+  if (onWitnessChecksComputed) {
+    onWitnessChecksComputed(computedChecks);
   }
 };

--- a/src/core/resolution.ts
+++ b/src/core/resolution.ts
@@ -13,7 +13,6 @@ import type {
   DIDLogEntry,
   DIDResolutionMeta,
   ResolutionOptions,
-  WitnessParameterResolution,
   WitnessProofFileEntry,
 } from '../interfaces';
 import { buildProblemDetails } from '../resolver-result';
@@ -29,19 +28,13 @@ import { MAX_FUTURE_SKEW_MS, parseUtcIso8601VersionTime } from '../utils/iso8601
 import {
   countVerifiedWitnessApprovals,
   fetchWitnessProofs,
-  hasActiveWitnessRequirement,
   normalizeWitnessThreshold,
   resolveWitnessParameter,
   validateWitnessParameter,
 } from '../witness';
+import { getRequiredWitnessForEntry, type RequiredWitnessCheck } from './witness-requirements';
 
 const hasOwn = <K extends PropertyKey>(obj: object, key: K): obj is Record<K, unknown> => Object.hasOwn(obj, key);
-
-interface RequiredWitnessCheck {
-  targetVersionId: string;
-  targetVersionNumber: number;
-  witness: WitnessParameterResolution;
-}
 
 interface ResolutionSnapshot {
   did: string;
@@ -565,24 +558,6 @@ const processSubsequentEntry = async ({
   }
 
   return sourceEntry.state;
-};
-
-const getRequiredWitnessForEntry = (
-  previousWitness: WitnessParameterResolution | undefined,
-  parameters: DIDLogEntry['parameters'],
-  currentWitness: WitnessParameterResolution | undefined
-): WitnessParameterResolution | undefined => {
-  const explicitWitness = resolveWitnessParameter(parameters);
-
-  if (hasActiveWitnessRequirement(previousWitness)) {
-    return deepClone(previousWitness);
-  }
-
-  if (explicitWitness !== undefined && hasActiveWitnessRequirement(currentWitness)) {
-    return deepClone(currentWitness);
-  }
-
-  return undefined;
 };
 
 const finalizeResolutionChecks = async ({

--- a/src/core/resolution.ts
+++ b/src/core/resolution.ts
@@ -31,8 +31,12 @@ import {
   normalizeWitnessThreshold,
   resolveWitnessParameter,
   validateWitnessParameter,
-} from '../witness';
-import { getRequiredWitnessForEntry, type RequiredWitnessCheck, type WitnessCheckResult } from './witness-requirements';
+} from '../witness.js';
+import {
+  getRequiredWitnessForEntry,
+  type RequiredWitnessCheck,
+  type WitnessCheckResult,
+} from './witness-requirements.js';
 
 const hasOwn = <K extends PropertyKey>(obj: object, key: K): obj is Record<K, unknown> => Object.hasOwn(obj, key);
 

--- a/src/core/resolution.ts
+++ b/src/core/resolution.ts
@@ -55,8 +55,8 @@ interface ResolverContext {
   resolvedSnapshot: ResolutionSnapshot | null;
   lastValidSnapshot: ResolutionSnapshot | null;
   requiredWitnessChecks: RequiredWitnessCheck[];
+  witnessChecks?: WitnessCheckResult[];
   didIdMatchCount: number;
-  witnessThresholdFailure: boolean;
 }
 
 interface ParsedResolutionEntryContext {
@@ -78,16 +78,48 @@ const isSupportedInitialMethod = (m: string | undefined): m is string =>
 
 type InternalResolutionOptions = ResolutionOptions & {
   requestedDid?: string;
-  // Internal-only hook used by `verifyWitnessProofs` (see method.ts) to observe
-  // per-entry witness check outcomes without converting an unmet threshold
-  // into a thrown error.
-  onWitnessChecksComputed?: (checks: WitnessCheckResult[]) => void;
 };
 
+/**
+ * Resolves a DID log and enforces every applicable witness threshold.
+ *
+ * @param log The DID log to resolve.
+ * @param options Internal resolution options, including verifier and witness proofs.
+ * @returns The resolved DID, document, and metadata.
+ * @throws If the log is invalid or an applicable witness threshold is not met.
+ */
 export const resolveLog = async (
   log: DIDLog,
   options: InternalResolutionOptions = {}
 ): Promise<{ did: string; doc: DIDDoc | null; meta: DIDResolutionMeta }> => {
+  const { result, witnessChecks } = await resolveLogWithWitnessResults(log, options);
+  const failedCheck = witnessChecks.find((check) => !check.satisfied);
+  if (failedCheck) {
+    throw new Error(
+      `Witness threshold not met for version ${failedCheck.targetVersionId}: got ${failedCheck.approvals}, need ${failedCheck.witness.threshold}`
+    );
+  }
+  return result;
+};
+
+/**
+ * Resolves a DID log and evaluates all applicable witness proofs, returning the
+ * computed witness results without strictly enforcing their thresholds.
+ * Structural, cryptographic, and non-witness integrity failures still throw;
+ * only an unmet witness threshold is returned as an unsatisfied result.
+ *
+ * @param log The DID log to resolve.
+ * @param options Internal resolution options, including verifier and witness proofs.
+ * @returns The resolved DID result and per-entry witness results.
+ * @throws If the log is structurally invalid or fails non-witness validation.
+ */
+export const resolveLogWithWitnessResults = async (
+  log: DIDLog,
+  options: InternalResolutionOptions = {}
+): Promise<{
+  result: { did: string; doc: DIDDoc | null; meta: DIDResolutionMeta };
+  witnessChecks: WitnessCheckResult[];
+}> => {
   // Stage 1: initialize resolution input and context.
   const logEntries = log.map((l) => deepClone(l));
   if (logEntries.length === 0) {
@@ -117,8 +149,7 @@ export const resolveLog = async (
       throw e;
     }
 
-    const decorateError =
-      resolvedSnapshot.meta && (!hasExplicitHistoricalSelector || resolverContext.witnessThresholdFailure);
+    const decorateError = resolvedSnapshot.meta && !hasExplicitHistoricalSelector;
     if (decorateError) {
       const message = e instanceof Error ? e.message : String(e);
       resolvedSnapshot.meta.error = 'invalidDid';
@@ -135,12 +166,12 @@ export const resolveLog = async (
       throw new Error('DID resolution failed: No valid result available for explicit selector');
     }
 
-    return {
+    const result = {
       did: lastValidSnapshot.did,
       doc: null,
       meta: {
         ...lastValidSnapshot.meta,
-        error: 'notFound',
+        error: 'notFound' as const,
         problemDetails: buildProblemDetails(
           'notFound',
           'The supplied explicit version selector did not match any entry in the DID log.',
@@ -148,6 +179,7 @@ export const resolveLog = async (
         ),
       },
     };
+    return { result, witnessChecks: resolverContext.witnessChecks ?? [] };
   }
 
   if (!resolvedSnapshot) {
@@ -178,22 +210,24 @@ export const resolveLog = async (
     }
   } else if (resolvedSnapshot.meta.deactivated) {
     resolvedSnapshot = markResolvedSnapshotDeactivated({ resolvedSnapshot, resolverContext });
-    return {
+    const result = {
       did: resolvedSnapshot.did,
       doc: null,
       meta: resolvedSnapshot.meta,
     };
+    return { result, witnessChecks: resolverContext.witnessChecks ?? [] };
   }
 
   if (!resolvedSnapshot.doc) {
     throw new Error('DID resolution failed: No valid document found');
   }
 
-  return {
+  const result = {
     did: resolvedSnapshot.did,
     doc: resolvedSnapshot.doc,
     meta: resolvedSnapshot.meta,
   };
+  return { result, witnessChecks: resolverContext.witnessChecks ?? [] };
 };
 
 const markResolvedSnapshotDeactivated = ({
@@ -224,7 +258,7 @@ const processResolvedLogEntries = async ({
   logEntries: DIDLog;
   initialMethod: string;
   options: InternalResolutionOptions;
-}): Promise<void> => {
+}): Promise<WitnessCheckResult[]> => {
   let activeMethod = initialMethod; // mutable; changes only on a single permitted upgrade
   let transitionOccurred = false;
 
@@ -328,6 +362,7 @@ const processResolvedLogEntries = async ({
     options,
     logEntries,
   });
+  return resolverContext.witnessChecks ?? [];
 };
 
 const createInitialResolverContext = (): ResolverContext => {
@@ -354,7 +389,6 @@ const createInitialResolverContext = (): ResolverContext => {
     lastValidSnapshot: null,
     requiredWitnessChecks: [],
     didIdMatchCount: 0,
-    witnessThresholdFailure: false,
   };
 };
 
@@ -579,37 +613,42 @@ const finalizeResolutionChecks = async ({
   }
 
   if (resolverContext.requiredWitnessChecks.length > 0) {
-    await enforceRequiredWitnessChecks({
+    const witnessChecks = await evaluateRequiredWitnessChecks({
       requiredWitnessChecks: resolverContext.requiredWitnessChecks,
       witnessProofs: options.witnessProofs,
       did: resolverContext.did,
       logEntries,
       verifier: options.verifier,
-      onThresholdFailure: () => {
-        resolverContext.witnessThresholdFailure = true;
-      },
-      onWitnessChecksComputed: options.onWitnessChecksComputed,
     });
+    resolverContext.witnessChecks = witnessChecks;
   }
 };
 
-const enforceRequiredWitnessChecks = async ({
+/**
+ * Evaluates witness approvals for all required log entries without applying
+ * threshold policy. The internal resolution entry points decide whether
+ * unsatisfied checks should throw or be returned as verification results.
+ *
+ * @param requiredWitnessChecks The witness requirements derived during log traversal.
+ * @param witnessProofs Caller-supplied proofs, or undefined to fetch the published proof file.
+ * @param did The DID whose witness proof file should be fetched when needed.
+ * @param logEntries The resolved log entries used to determine proof coverage.
+ * @param verifier The verifier used to validate witness proofs.
+ * @returns The computed approval and satisfaction result for each requirement.
+ */
+const evaluateRequiredWitnessChecks = async ({
   requiredWitnessChecks,
   witnessProofs,
   did,
   logEntries,
   verifier,
-  onThresholdFailure,
-  onWitnessChecksComputed,
 }: {
   requiredWitnessChecks: RequiredWitnessCheck[];
   witnessProofs: WitnessProofFileEntry[] | undefined;
   did: string;
   logEntries: DIDLog;
   verifier: ResolutionOptions['verifier'];
-  onThresholdFailure: () => void;
-  onWitnessChecksComputed?: (checks: WitnessCheckResult[]) => void;
-}): Promise<void> => {
+}): Promise<WitnessCheckResult[]> => {
   let resolvedWitnessProofs = witnessProofs;
   if (!resolvedWitnessProofs) {
     resolvedWitnessProofs = await fetchWitnessProofs(did);
@@ -617,11 +656,6 @@ const enforceRequiredWitnessChecks = async ({
 
   const publishedVersionNumbers = new Map(logEntries.map((entry, index) => [entry.versionId, index + 1]));
 
-  // When `onWitnessChecksComputed` is supplied (internal-only, see
-  // `verifyWitnessProofs` in method.ts), every check is computed and reported
-  // to the caller instead of throwing on the first unmet threshold, so the
-  // caller can report a complete per-entry breakdown rather than stopping at
-  // the first failure.
   const computedChecks: WitnessCheckResult[] = [];
 
   for (const check of requiredWitnessChecks) {
@@ -633,24 +667,8 @@ const enforceRequiredWitnessChecks = async ({
     const approvals = await countVerifiedWitnessApprovals(candidateProofs, check.witness, verifier);
     const threshold = normalizeWitnessThreshold(check.witness.threshold);
     const satisfied = approvals >= threshold;
-
-    if (onWitnessChecksComputed) {
-      computedChecks.push({ ...check, approvals, satisfied });
-      if (!satisfied) {
-        onThresholdFailure();
-      }
-      continue;
-    }
-
-    if (!satisfied) {
-      onThresholdFailure();
-      throw new Error(
-        `Witness threshold not met for version ${check.targetVersionId}: got ${approvals}, need ${check.witness.threshold}`
-      );
-    }
+    computedChecks.push({ ...check, approvals, satisfied });
   }
 
-  if (onWitnessChecksComputed) {
-    onWitnessChecksComputed(computedChecks);
-  }
+  return computedChecks;
 };

--- a/src/core/witness-requirements.ts
+++ b/src/core/witness-requirements.ts
@@ -1,22 +1,22 @@
-import type {
-  DIDLog,
-  DIDLogEntry,
-  WitnessParameterResolution,
-  WitnessRequirement,
-  WitnessVerifiableResult,
-} from '../interfaces';
+import type { DIDLog, DIDLogEntry, WitnessParameterResolution } from '../interfaces';
 import { deepClone, parseAndValidateVersionId } from '../utils';
-import {
-  hasActiveWitnessRequirement,
-  normalizeWitnessThreshold,
-  resolveWitnessParameter,
-  validateWitnessParameter,
-} from '../witness';
+import { hasActiveWitnessRequirement, resolveWitnessParameter, validateWitnessParameter } from '../witness';
 
 export interface RequiredWitnessCheck {
   targetVersionId: string;
   targetVersionNumber: number;
   witness: WitnessParameterResolution;
+}
+
+/**
+ * A single required-witness check paired with the outcome of counting
+ * verified approvals against it. Used by `verifyWitnessProofs` to report an
+ * unmet threshold as data rather than throwing, while other verification
+ * failures (hash chain, SCID, controller proof, etc.) still throw as before.
+ */
+export interface WitnessCheckResult extends RequiredWitnessCheck {
+  approvals: number;
+  satisfied: boolean;
 }
 
 /**
@@ -96,25 +96,4 @@ export const computeWitnessRequirementChecks = (log: DIDLog): RequiredWitnessChe
   });
 
   return checks;
-};
-
-/**
- * Derives the witness approvals required for every entry in `result.log` that
- * requires witnessing. Unlike inspecting the final resolved `meta.witness`,
- * this correctly distinguishes the configuration that approves a given
- * transition from the configuration that becomes active after publication.
- *
- * Synchronous and verifier-independent: it performs structural witness-list
- * validation only, not Data Integrity proof verification. Returns defensive
- * copies so callers cannot mutate state held elsewhere.
- */
-export const getWitnessRequirements = (result: WitnessVerifiableResult): WitnessRequirement[] => {
-  const checks = computeWitnessRequirementChecks(result.log);
-
-  return checks.map((check) => ({
-    versionId: check.targetVersionId,
-    versionNumber: check.targetVersionNumber,
-    threshold: normalizeWitnessThreshold(check.witness.threshold),
-    witnesses: deepClone(check.witness.witnesses ?? []),
-  }));
 };

--- a/src/core/witness-requirements.ts
+++ b/src/core/witness-requirements.ts
@@ -1,0 +1,120 @@
+import type {
+  DIDLog,
+  DIDLogEntry,
+  WitnessParameterResolution,
+  WitnessRequirement,
+  WitnessVerifiableResult,
+} from '../interfaces';
+import { deepClone, parseAndValidateVersionId } from '../utils';
+import {
+  hasActiveWitnessRequirement,
+  normalizeWitnessThreshold,
+  resolveWitnessParameter,
+  validateWitnessParameter,
+} from '../witness';
+
+export interface RequiredWitnessCheck {
+  targetVersionId: string;
+  targetVersionNumber: number;
+  witness: WitnessParameterResolution;
+}
+
+/**
+ * Derives the witness configuration that governs the transition into one log
+ * entry, given the configuration active before the entry and the configuration
+ * active after it. This is the single authoritative implementation of the
+ * did:webvh witness transition rules:
+ *
+ * - A non-empty previously active configuration governs the next entry, even
+ *   when that entry replaces or clears the witness list.
+ * - Only when the previous configuration is empty does an entry that
+ *   introduces a non-empty configuration become immediately active and govern
+ *   that same entry (first activation).
+ *
+ * Both the resolver (`resolveLog`) and the public `getWitnessRequirements` API
+ * call this function so there is exactly one witness-transition state
+ * machine.
+ */
+export const getRequiredWitnessForEntry = (
+  previousWitness: WitnessParameterResolution | undefined,
+  parameters: DIDLogEntry['parameters'],
+  currentWitness: WitnessParameterResolution | undefined
+): WitnessParameterResolution | undefined => {
+  const explicitWitness = resolveWitnessParameter(parameters);
+
+  if (hasActiveWitnessRequirement(previousWitness)) {
+    return deepClone(previousWitness);
+  }
+
+  if (explicitWitness !== undefined && hasActiveWitnessRequirement(currentWitness)) {
+    return deepClone(currentWitness);
+  }
+
+  return undefined;
+};
+
+/**
+ * Walks a DID log and derives the witness approvals required for each entry,
+ * applying the did:webvh witness transition rules (genesis activation,
+ * inheritance, replacement, and removal). Performs no cryptographic
+ * verification and requires no `Verifier`; only structural witness-parameter
+ * validation via `validateWitnessParameter`.
+ *
+ * This is the pure, synchronous, verifier-independent counterpart to the
+ * resolver's per-entry witness-requirement tracking. `resolveLog` and
+ * `getWitnessRequirements` both derive their required-witness checks from
+ * this single function.
+ */
+export const computeWitnessRequirementChecks = (log: DIDLog): RequiredWitnessCheck[] => {
+  const checks: RequiredWitnessCheck[] = [];
+  let previousWitness: WitnessParameterResolution | undefined;
+
+  log.forEach((entry, index) => {
+    const { versionNumber } = parseAndValidateVersionId(entry.versionId, index + 1);
+    const explicitWitness = resolveWitnessParameter(entry.parameters);
+
+    // All parameters in the genesis entry take effect immediately. Subsequent
+    // entries inherit the previously active configuration unless they
+    // explicitly declare a new one (including an explicit `witness: {}`).
+    const currentWitness: WitnessParameterResolution =
+      index === 0 ? (explicitWitness ?? {}) : explicitWitness !== undefined ? explicitWitness : (previousWitness ?? {});
+
+    if (currentWitness.witnesses?.length) {
+      validateWitnessParameter(currentWitness);
+    }
+
+    const requiredWitness = getRequiredWitnessForEntry(previousWitness, entry.parameters, currentWitness);
+    if (requiredWitness) {
+      checks.push({
+        targetVersionId: entry.versionId,
+        targetVersionNumber: versionNumber,
+        witness: requiredWitness,
+      });
+    }
+
+    previousWitness = currentWitness;
+  });
+
+  return checks;
+};
+
+/**
+ * Derives the witness approvals required for every entry in `result.log` that
+ * requires witnessing. Unlike inspecting the final resolved `meta.witness`,
+ * this correctly distinguishes the configuration that approves a given
+ * transition from the configuration that becomes active after publication.
+ *
+ * Synchronous and verifier-independent: it performs structural witness-list
+ * validation only, not Data Integrity proof verification. Returns defensive
+ * copies so callers cannot mutate state held elsewhere.
+ */
+export const getWitnessRequirements = (result: WitnessVerifiableResult): WitnessRequirement[] => {
+  const checks = computeWitnessRequirementChecks(result.log);
+
+  return checks.map((check) => ({
+    versionId: check.targetVersionId,
+    versionNumber: check.targetVersionNumber,
+    threshold: normalizeWitnessThreshold(check.witness.threshold),
+    witnesses: deepClone(check.witness.witnesses ?? []),
+  }));
+};

--- a/src/core/witness-requirements.ts
+++ b/src/core/witness-requirements.ts
@@ -1,6 +1,6 @@
-import type { DIDLog, DIDLogEntry, WitnessParameterResolution } from '../interfaces';
-import { deepClone, parseAndValidateVersionId } from '../utils';
-import { hasActiveWitnessRequirement, resolveWitnessParameter, validateWitnessParameter } from '../witness';
+import type { DIDLog, DIDLogEntry, WitnessParameterResolution } from '../interfaces.js';
+import { deepClone, parseAndValidateVersionId } from '../utils.js';
+import { hasActiveWitnessRequirement, resolveWitnessParameter, validateWitnessParameter } from '../witness.js';
 
 export interface RequiredWitnessCheck {
   targetVersionId: string;

--- a/src/core/witness-requirements.ts
+++ b/src/core/witness-requirements.ts
@@ -31,9 +31,10 @@ export interface WitnessCheckResult extends RequiredWitnessCheck {
  *   introduces a non-empty configuration become immediately active and govern
  *   that same entry (first activation).
  *
- * Both the resolver (`resolveLog`) and the public `getWitnessRequirements` API
- * call this function so there is exactly one witness-transition state
- * machine.
+ * The resolver and the public `getWitnessRequirements` API both use this
+ * helper when determining which configuration governs an entry. The resolver
+ * retains its own entry-processing walk because it must validate and resolve
+ * each log entry.
  */
 export const getRequiredWitnessForEntry = (
   previousWitness: WitnessParameterResolution | undefined,
@@ -60,10 +61,9 @@ export const getRequiredWitnessForEntry = (
  * verification and requires no `Verifier`; only structural witness-parameter
  * validation via `validateWitnessParameter`.
  *
- * This is the pure, synchronous, verifier-independent counterpart to the
- * resolver's per-entry witness-requirement tracking. `resolveLog` and
- * `getWitnessRequirements` both derive their required-witness checks from
- * this single function.
+ * This is the pure, synchronous, verifier-independent walk used by
+ * `getWitnessRequirements`. The resolver performs its own entry-processing
+ * walk and shares the witness transition helper above.
  */
 export const computeWitnessRequirementChecks = (log: DIDLog): RequiredWitnessCheck[] => {
   const checks: RequiredWitnessCheck[] = [];

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export { getWitnessRequirements } from './core/witness-requirements';
 export {
   AbstractCrypto,
   createDataIntegrityProofTemplate,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-export { getWitnessRequirements } from './core/witness-requirements';
 export {
   AbstractCrypto,
   createDataIntegrityProofTemplate,
@@ -8,7 +7,15 @@ export {
 } from './cryptography';
 export { generateParallelDidWeb } from './did-document';
 export * from './interfaces';
-export { createDID, deactivateDID, resolveDID, resolveDIDFromLog, updateDID } from './method';
+export {
+  createDID,
+  deactivateDID,
+  getWitnessRequirements,
+  resolveDID,
+  resolveDIDFromLog,
+  updateDID,
+  verifyWitnessProofs,
+} from './method';
 export type { GetResolverConfig } from './resolver';
 export { getResolver } from './resolver';
 export type { ResolutionOptionsError, WebvhDocumentMetadata, WebvhResolutionMetadata } from './resolver-result';

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ export {
   updateDID,
   verifyWitnessProofs,
 } from './method.js';
-export type { GetResolverConfig } from './resolver';
+export type { GetResolverConfig } from './resolver.js';
 export { getResolver } from './resolver.js';
 export type { ResolutionOptionsError, WebvhDocumentMetadata, WebvhResolutionMetadata } from './resolver-result.js';
 export { WEBVH_ERROR_TYPES } from './resolver-result.js';

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -270,3 +270,28 @@ export interface WitnessProofFileEntry {
   versionId: string;
   proof: DataIntegrityProof[];
 }
+
+/**
+ * Common structural input accepted by the witness verification APIs.
+ * `CreateDIDResult`, `UpdateDIDResult`, and the deactivation result are all
+ * structurally compatible because they expose `log: DIDLog`.
+ */
+export interface WitnessVerifiableResult {
+  log: DIDLog;
+}
+
+/**
+ * The witness configuration that governs approval of one DID log entry,
+ * derived by applying the did:webvh witness transition rules rather than
+ * read directly from final resolved metadata.
+ */
+export interface WitnessRequirement {
+  versionId: string;
+  versionNumber: number;
+  threshold: number;
+  witnesses: WitnessEntry[];
+}
+
+export interface VerifyWitnessProofsOptions {
+  verifier?: Verifier;
+}

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -295,3 +295,11 @@ export interface WitnessRequirement {
 export interface VerifyWitnessProofsOptions {
   verifier?: Verifier;
 }
+
+export interface WitnessVerificationResult {
+  verified: boolean;
+  requirements: (WitnessRequirement & {
+    satisfied: boolean;
+    approvals: number;
+  })[];
+}

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -253,6 +253,7 @@ export interface DeactivateDIDInterface {
   log: DIDLog;
   signer: Signer;
   verifier?: Verifier;
+  witnessProofs?: WitnessProofFileEntry[];
 }
 
 export interface ResolutionOptions {
@@ -273,8 +274,7 @@ export interface WitnessProofFileEntry {
 
 /**
  * Common structural input accepted by the witness verification APIs.
- * `CreateDIDResult`, `UpdateDIDResult`, and the deactivation result are all
- * structurally compatible because they expose `log: DIDLog`.
+ * Compatible with any method exposing `log: DIDLog`.
  */
 export interface WitnessVerifiableResult {
   log: DIDLog;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -273,14 +273,6 @@ export interface WitnessProofFileEntry {
 }
 
 /**
- * Common structural input accepted by the witness verification APIs.
- * Compatible with any method exposing `log: DIDLog`.
- */
-export interface WitnessVerifiableResult {
-  log: DIDLog;
-}
-
-/**
  * The witness configuration that governs approval of one DID log entry,
  * derived by applying the did:webvh witness transition rules rather than
  * read directly from final resolved metadata.

--- a/src/method.ts
+++ b/src/method.ts
@@ -199,7 +199,10 @@ export const resolveDIDFromLog = async (log: DIDLog, options: ResolutionOptions 
 export const updateDID = async (options: UpdateDIDInterface): Promise<UpdateDIDResult> => {
   const log = options.log;
   const lastEntry = log[log.length - 1];
-  const lastMeta = (await resolveLog(log, { verifier: options.verifier, witnessProofs: options.witnessProofs })).meta;
+  // Default to an empty proof array so missing witnessProofs never falls back to network fetch.
+  // Unmet witness requirement surfaces as a thrown error below.
+  const lastMeta = (await resolveLog(log, { verifier: options.verifier, witnessProofs: options.witnessProofs ?? [] }))
+    .meta;
   const currentUpdateKeys = options.updateKeys;
   if (lastMeta.deactivated) {
     throw new Error('Cannot update deactivated DID');
@@ -252,7 +255,10 @@ export const deactivateDID = async (
 ): Promise<{ did: string; doc: DIDDoc; meta: DIDResolutionMeta; log: DIDLog }> => {
   const log = options.log;
   const lastEntry = log[log.length - 1];
-  const lastMeta = (await resolveLog(log, { verifier: options.verifier })).meta;
+  // Default to an empty proof array so missing witnessProofs never falls back to network fetch.
+  // Unmet witness requirement surfaces as a thrown error below.
+  const lastMeta = (await resolveLog(log, { verifier: options.verifier, witnessProofs: options.witnessProofs ?? [] }))
+    .meta;
   if (lastMeta.deactivated) {
     throw new Error('DID already deactivated');
   }

--- a/src/method.ts
+++ b/src/method.ts
@@ -2,6 +2,7 @@ import type { DIDResolutionResult } from 'did-resolver';
 import { DEFAULT_TTL_SECONDS, SCID_PLACEHOLDER } from './constants';
 import { prepareDeactivationEntry, prepareGenesisEntry, prepareUpdateEntry } from './core/entries';
 import { resolveLog } from './core/resolution';
+import { computeWitnessRequirementChecks } from './core/witness-requirements';
 import { generateParallelDidWeb } from './did-document';
 import type {
   CreateDIDInterface,
@@ -14,9 +15,20 @@ import type {
   ResolutionOptions,
   UpdateDIDInterface,
   UpdateDIDResult,
+  VerifyWitnessProofsOptions,
+  WitnessProofFileEntry,
+  WitnessRequirement,
+  WitnessVerifiableResult,
+  WitnessVerificationResult,
 } from './interfaces';
 import { mapErrorToCode, toErrorResult, toResolutionResult, validateSingleVersionSelector } from './resolver-result';
-import { fetchLogFromIdentifier, normalizeDidAddress, parseDidWebvhIdentifier, requireDidDocumentId } from './utils';
+import {
+  deepClone,
+  fetchLogFromIdentifier,
+  normalizeDidAddress,
+  parseDidWebvhIdentifier,
+  requireDidDocumentId,
+} from './utils';
 import {
   createDate,
   createNextVersionTime,
@@ -24,7 +36,7 @@ import {
   validateUtcIso8601NotInFuture,
 } from './utils/iso8601-datetime';
 import { defaultVerifier } from './verifier';
-import { resolveWitnessParameter, validateWitnessParameter } from './witness';
+import { normalizeWitnessThreshold, resolveWitnessParameter, validateWitnessParameter } from './witness';
 
 const buildMetaFromEntry = (entry: DIDLogEntry): DIDResolutionMeta => {
   const resolvedWitness = resolveWitnessParameter(entry.parameters);
@@ -274,5 +286,69 @@ export const deactivateDID = async (
     doc: entry.state,
     meta,
     log: [...log, entry],
+  };
+};
+
+/**
+ * Derives the witness approvals required for each entry in a DID log that requires witnessing.
+ *
+ * @param result A created, updated, or resolved DID result containing the log to inspect.
+ * @returns The witness requirements for each entry that requires witnessing.
+ */
+export const getWitnessRequirements = (result: WitnessVerifiableResult): WitnessRequirement[] => {
+  const checks = computeWitnessRequirementChecks(result.log);
+
+  return checks.map((check) => ({
+    versionId: check.targetVersionId,
+    versionNumber: check.targetVersionNumber,
+    threshold: normalizeWitnessThreshold(check.witness.threshold),
+    witnesses: deepClone(check.witness.witnesses ?? []),
+  }));
+};
+
+/**
+ * Verifies that every witness requirement in a DID log is satisfied by the locally supplied
+ * witness proofs without network fetch.
+ *
+ * @param result A created, updated, or resolved DID result containing the log to verify.
+ * @param witnessProofs The witness proofs to verify against the log, in place of a network fetch.
+ * @param options Optional verifier override.
+ * @returns Per-entry witness requirements annotated with counted approvals and satisfaction.
+ * @throws If the log or supplied proofs fail any non-witness-threshold verification.
+ */
+export const verifyWitnessProofs = async (
+  result: WitnessVerifiableResult,
+  witnessProofs: WitnessProofFileEntry[],
+  options: VerifyWitnessProofsOptions = {}
+): Promise<WitnessVerificationResult> => {
+  const requirements = getWitnessRequirements(result);
+  let checkOutcomes: { targetVersionId: string; approvals: number; satisfied: boolean }[] = [];
+
+  await resolveLog(result.log, {
+    witnessProofs,
+    verifier: options.verifier ?? defaultVerifier,
+    onWitnessChecksComputed: (checks) => {
+      checkOutcomes = checks.map((check) => ({
+        targetVersionId: check.targetVersionId,
+        approvals: check.approvals,
+        satisfied: check.satisfied,
+      }));
+    },
+  });
+
+  const outcomesByVersionId = new Map(checkOutcomes.map((outcome) => [outcome.targetVersionId, outcome]));
+
+  const annotatedRequirements = requirements.map((requirement) => {
+    const outcome = outcomesByVersionId.get(requirement.versionId);
+    return {
+      ...requirement,
+      approvals: outcome?.approvals ?? 0,
+      satisfied: outcome?.satisfied ?? false,
+    };
+  });
+
+  return {
+    verified: annotatedRequirements.every((requirement) => requirement.satisfied),
+    requirements: annotatedRequirements,
   };
 };

--- a/src/method.ts
+++ b/src/method.ts
@@ -18,7 +18,6 @@ import type {
   VerifyWitnessProofsOptions,
   WitnessProofFileEntry,
   WitnessRequirement,
-  WitnessVerifiableResult,
   WitnessVerificationResult,
 } from './interfaces.js';
 import { mapErrorToCode, toErrorResult, toResolutionResult, validateSingleVersionSelector } from './resolver-result.js';
@@ -298,11 +297,11 @@ export const deactivateDID = async (
 /**
  * Derives the witness approvals required for each entry in a DID log that requires witnessing.
  *
- * @param result A created, updated, or resolved DID result containing the log to inspect.
+ * @param log The DID log to inspect.
  * @returns The witness requirements for each entry that requires witnessing.
  */
-export const getWitnessRequirements = (result: WitnessVerifiableResult): WitnessRequirement[] => {
-  const checks = computeWitnessRequirementChecks(result.log);
+export const getWitnessRequirements = (log: DIDLog): WitnessRequirement[] => {
+  const checks = computeWitnessRequirementChecks(log);
 
   return checks.map((check) => ({
     versionId: check.targetVersionId,
@@ -316,21 +315,21 @@ export const getWitnessRequirements = (result: WitnessVerifiableResult): Witness
  * Verifies that every witness requirement in a DID log is satisfied by the locally supplied
  * witness proofs without network fetch.
  *
- * @param result A created, updated, or resolved DID result containing the log to verify.
+ * @param log The DID log to verify.
  * @param witnessProofs The witness proofs to verify against the log, in place of a network fetch.
  * @param options Optional verifier override.
  * @returns Per-entry witness requirements annotated with counted approvals and satisfaction.
  * @throws If the log or supplied proofs fail any non-witness-threshold verification.
  */
 export const verifyWitnessProofs = async (
-  result: WitnessVerifiableResult,
+  log: DIDLog,
   witnessProofs: WitnessProofFileEntry[],
   options: VerifyWitnessProofsOptions = {}
 ): Promise<WitnessVerificationResult> => {
-  const requirements = getWitnessRequirements(result);
+  const requirements = getWitnessRequirements(log);
   let checkOutcomes: { targetVersionId: string; approvals: number; satisfied: boolean }[] = [];
 
-  await resolveLog(result.log, {
+  await resolveLog(log, {
     witnessProofs,
     verifier: options.verifier ?? defaultVerifier,
     onWitnessChecksComputed: (checks) => {

--- a/src/method.ts
+++ b/src/method.ts
@@ -1,9 +1,9 @@
 import type { DIDResolutionResult } from 'did-resolver';
-import { DEFAULT_TTL_SECONDS, SCID_PLACEHOLDER } from './constants';
-import { prepareDeactivationEntry, prepareGenesisEntry, prepareUpdateEntry } from './core/entries';
-import { resolveLog } from './core/resolution';
-import { computeWitnessRequirementChecks } from './core/witness-requirements';
-import { generateParallelDidWeb } from './did-document';
+import { DEFAULT_TTL_SECONDS, SCID_PLACEHOLDER } from './constants.js';
+import { prepareDeactivationEntry, prepareGenesisEntry, prepareUpdateEntry } from './core/entries.js';
+import { resolveLog } from './core/resolution.js';
+import { computeWitnessRequirementChecks } from './core/witness-requirements.js';
+import { generateParallelDidWeb } from './did-document.js';
 import type {
   CreateDIDInterface,
   CreateDIDResult,
@@ -20,23 +20,23 @@ import type {
   WitnessRequirement,
   WitnessVerifiableResult,
   WitnessVerificationResult,
-} from './interfaces';
-import { mapErrorToCode, toErrorResult, toResolutionResult, validateSingleVersionSelector } from './resolver-result';
+} from './interfaces.js';
+import { mapErrorToCode, toErrorResult, toResolutionResult, validateSingleVersionSelector } from './resolver-result.js';
+import {
+  createDate,
+  createNextVersionTime,
+  MAX_FUTURE_SKEW_MS,
+  validateUtcIso8601NotInFuture,
+} from './utils/iso8601-datetime.js';
 import {
   deepClone,
   fetchLogFromIdentifier,
   normalizeDidAddress,
   parseDidWebvhIdentifier,
   requireDidDocumentId,
-} from './utils';
-import {
-  createDate,
-  createNextVersionTime,
-  MAX_FUTURE_SKEW_MS,
-  validateUtcIso8601NotInFuture,
-} from './utils/iso8601-datetime';
-import { defaultVerifier } from './verifier';
-import { normalizeWitnessThreshold, resolveWitnessParameter, validateWitnessParameter } from './witness';
+} from './utils.js';
+import { defaultVerifier } from './verifier.js';
+import { normalizeWitnessThreshold, resolveWitnessParameter, validateWitnessParameter } from './witness.js';
 
 const buildMetaFromEntry = (entry: DIDLogEntry): DIDResolutionMeta => {
   const resolvedWitness = resolveWitnessParameter(entry.parameters);

--- a/src/method.ts
+++ b/src/method.ts
@@ -2,7 +2,7 @@ import type { DIDResolutionResult } from 'did-resolver';
 import { DEFAULT_TTL_SECONDS, SCID_PLACEHOLDER } from './constants.js';
 import { prepareDeactivationEntry, prepareGenesisEntry, prepareUpdateEntry } from './core/entries.js';
 import { resolveLog } from './core/resolution.js';
-import { computeWitnessRequirementChecks } from './core/witness-requirements.js';
+import { computeWitnessRequirementChecks, type WitnessCheckResult } from './core/witness-requirements.js';
 import { generateParallelDidWeb } from './did-document.js';
 import type {
   CreateDIDInterface,
@@ -326,34 +326,27 @@ export const verifyWitnessProofs = async (
   witnessProofs: WitnessProofFileEntry[],
   options: VerifyWitnessProofsOptions = {}
 ): Promise<WitnessVerificationResult> => {
-  const requirements = getWitnessRequirements(log);
-  let checkOutcomes: { targetVersionId: string; approvals: number; satisfied: boolean }[] = [];
+  let checkOutcomes: WitnessCheckResult[] = [];
 
   await resolveLog(log, {
     witnessProofs,
     verifier: options.verifier ?? defaultVerifier,
     onWitnessChecksComputed: (checks) => {
-      checkOutcomes = checks.map((check) => ({
-        targetVersionId: check.targetVersionId,
-        approvals: check.approvals,
-        satisfied: check.satisfied,
-      }));
+      checkOutcomes = checks;
     },
   });
 
-  const outcomesByVersionId = new Map(checkOutcomes.map((outcome) => [outcome.targetVersionId, outcome]));
-
-  const annotatedRequirements = requirements.map((requirement) => {
-    const outcome = outcomesByVersionId.get(requirement.versionId);
-    return {
-      ...requirement,
-      approvals: outcome?.approvals ?? 0,
-      satisfied: outcome?.satisfied ?? false,
-    };
-  });
+  const requirements = checkOutcomes.map((check) => ({
+    versionId: check.targetVersionId,
+    versionNumber: check.targetVersionNumber,
+    threshold: normalizeWitnessThreshold(check.witness.threshold),
+    witnesses: deepClone(check.witness.witnesses ?? []),
+    approvals: check.approvals,
+    satisfied: check.satisfied,
+  }));
 
   return {
-    verified: annotatedRequirements.every((requirement) => requirement.satisfied),
-    requirements: annotatedRequirements,
+    verified: requirements.every((requirement) => requirement.satisfied),
+    requirements,
   };
 };

--- a/src/method.ts
+++ b/src/method.ts
@@ -198,10 +198,7 @@ export const resolveDIDFromLog = async (log: DIDLog, options: ResolutionOptions 
 export const updateDID = async (options: UpdateDIDInterface): Promise<UpdateDIDResult> => {
   const log = options.log;
   const lastEntry = log[log.length - 1];
-  // Default to an empty proof array so missing witnessProofs never falls back to network fetch.
-  // Unmet witness requirement surfaces as a thrown error below.
-  const lastMeta = (await resolveLog(log, { verifier: options.verifier, witnessProofs: options.witnessProofs ?? [] }))
-    .meta;
+  const lastMeta = (await resolveLog(log, { verifier: options.verifier, witnessProofs: options.witnessProofs })).meta;
   const currentUpdateKeys = options.updateKeys;
   if (lastMeta.deactivated) {
     throw new Error('Cannot update deactivated DID');
@@ -254,10 +251,7 @@ export const deactivateDID = async (
 ): Promise<{ did: string; doc: DIDDoc; meta: DIDResolutionMeta; log: DIDLog }> => {
   const log = options.log;
   const lastEntry = log[log.length - 1];
-  // Default to an empty proof array so missing witnessProofs never falls back to network fetch.
-  // Unmet witness requirement surfaces as a thrown error below.
-  const lastMeta = (await resolveLog(log, { verifier: options.verifier, witnessProofs: options.witnessProofs ?? [] }))
-    .meta;
+  const lastMeta = (await resolveLog(log, { verifier: options.verifier, witnessProofs: options.witnessProofs })).meta;
   if (lastMeta.deactivated) {
     throw new Error('DID already deactivated');
   }

--- a/src/method.ts
+++ b/src/method.ts
@@ -1,8 +1,8 @@
 import type { DIDResolutionResult } from 'did-resolver';
 import { DEFAULT_TTL_SECONDS, SCID_PLACEHOLDER } from './constants.js';
 import { prepareDeactivationEntry, prepareGenesisEntry, prepareUpdateEntry } from './core/entries.js';
-import { resolveLog } from './core/resolution.js';
-import { computeWitnessRequirementChecks, type WitnessCheckResult } from './core/witness-requirements.js';
+import { resolveLog, resolveLogWithWitnessResults } from './core/resolution.js';
+import { computeWitnessRequirementChecks } from './core/witness-requirements.js';
 import { generateParallelDidWeb } from './did-document.js';
 import type {
   CreateDIDInterface,
@@ -326,14 +326,9 @@ export const verifyWitnessProofs = async (
   witnessProofs: WitnessProofFileEntry[],
   options: VerifyWitnessProofsOptions = {}
 ): Promise<WitnessVerificationResult> => {
-  let checkOutcomes: WitnessCheckResult[] = [];
-
-  await resolveLog(log, {
+  const { witnessChecks: checkOutcomes } = await resolveLogWithWitnessResults(log, {
     witnessProofs,
     verifier: options.verifier ?? defaultVerifier,
-    onWitnessChecksComputed: (checks) => {
-      checkOutcomes = checks;
-    },
   });
 
   const requirements = checkOutcomes.map((check) => ({

--- a/test/cli/e2e.test.ts
+++ b/test/cli/e2e.test.ts
@@ -70,7 +70,7 @@ function createTempVerificationMethod(vm: VerificationMethod): string {
   return tempFile;
 }
 
-describe('CLI End-to-End Tests', () => {
+describe('Controller CLI End-to-End Tests', () => {
   test('Create DID using CLI', async () => {
     const proc = runCli(['create', '--address', 'example.com', '--output', join(TEST_DIR, 'did.jsonl'), '--portable']);
     expect(proc.exitCode).toBe(0);
@@ -258,6 +258,122 @@ describe('CLI End-to-End Tests', () => {
     expect(proc.stdout).toContain('Resolved DID');
     expect(proc.stdout).toContain('DID Document');
     expect(proc.stdout).toContain('Metadata');
+  });
+
+  test('updates a witnessed DID using a local witness file', async () => {
+    const logFile = join(TEST_DIR, 'did-witnessed-update.jsonl');
+    const witnessFile = join(TEST_DIR, 'did-witnessed-update.json');
+    const witnessVmProc = runCli(['generate-vm']);
+    expect(witnessVmProc.exitCode).toBe(0);
+    const witnessVm = JSON.parse(witnessVmProc.stdout) as { did: string; secretKeyMultibase: string };
+
+    const createProc = runCli([
+      'create',
+      '--address',
+      'example.com',
+      '--output',
+      logFile,
+      '--portable',
+      '--witness',
+      witnessVm.did,
+    ]);
+    expect(createProc.exitCode).toBe(0);
+    const log = await readLogFromDisk(logFile);
+    const proofProc = runCli([
+      'generate-witness-proof',
+      '--version-id',
+      log[0].versionId,
+      '--witness-did',
+      witnessVm.did,
+      '--witness-secret',
+      witnessVm.secretKeyMultibase,
+      '--output',
+      witnessFile,
+    ]);
+    expect(proofProc.exitCode).toBe(0);
+
+    const updateProc = runCli(['update', '--log', logFile, '--output', logFile, '--witness-file', witnessFile]);
+    expect(updateProc.exitCode).toBe(0);
+    expect(await readLogFromDisk(logFile)).toHaveLength(2);
+  });
+
+  test('deactivates a witnessed DID using a local witness file', async () => {
+    const logFile = join(TEST_DIR, 'did-witnessed-deactivate.jsonl');
+    const witnessFile = join(TEST_DIR, 'did-witnessed-deactivate.json');
+    const witnessVmProc = runCli(['generate-vm']);
+    expect(witnessVmProc.exitCode).toBe(0);
+    const witnessVm = JSON.parse(witnessVmProc.stdout) as { did: string; secretKeyMultibase: string };
+
+    const createProc = runCli([
+      'create',
+      '--address',
+      'example.com',
+      '--output',
+      logFile,
+      '--portable',
+      '--witness',
+      witnessVm.did,
+    ]);
+    expect(createProc.exitCode).toBe(0);
+    const log = await readLogFromDisk(logFile);
+    const proofProc = runCli([
+      'generate-witness-proof',
+      '--version-id',
+      log[0].versionId,
+      '--witness-did',
+      witnessVm.did,
+      '--witness-secret',
+      witnessVm.secretKeyMultibase,
+      '--output',
+      witnessFile,
+    ]);
+    expect(proofProc.exitCode).toBe(0);
+
+    const deactivateProc = runCli(['deactivate', '--log', logFile, '--output', logFile, '--witness-file', witnessFile]);
+    expect(deactivateProc.exitCode).toBe(0);
+    const deactivatedLog = await readLogFromDisk(logFile);
+    expect(deactivatedLog).toHaveLength(2);
+    expect(deactivatedLog[1].parameters.deactivated).toBe(true);
+  });
+
+  test('Verify witnessed DID proofs using CLI', async () => {
+    const logFile = join(TEST_DIR, 'did-witnessed-verify.jsonl');
+    const witnessFile = join(TEST_DIR, 'did-witnessed-verify.json');
+    const witnessVmProc = runCli(['generate-vm']);
+    expect(witnessVmProc.exitCode).toBe(0);
+    const witnessVm = JSON.parse(witnessVmProc.stdout) as { did: string; secretKeyMultibase: string };
+
+    const createProc = runCli([
+      'create',
+      '--address',
+      'example.com',
+      '--output',
+      logFile,
+      '--portable',
+      '--witness',
+      witnessVm.did,
+    ]);
+    expect(createProc.exitCode).toBe(0);
+
+    const log = await readLogFromDisk(logFile);
+    const proofProc = runCli([
+      'generate-witness-proof',
+      '--version-id',
+      log[0].versionId,
+      '--witness-did',
+      witnessVm.did,
+      '--witness-secret',
+      witnessVm.secretKeyMultibase,
+      '--output',
+      witnessFile,
+    ]);
+    expect(proofProc.exitCode).toBe(0);
+
+    const verifyProc = runCli(['verify-proofs', '--log', logFile, '--witness-file', witnessFile]);
+    expect(verifyProc.exitCode).toBe(0);
+    const result = JSON.parse(verifyProc.stdout) as { verified: boolean; requirements: unknown[] };
+    expect(result.verified).toBe(true);
+    expect(result.requirements).toHaveLength(1);
   });
 });
 

--- a/test/witness.test.ts
+++ b/test/witness.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, test } from 'vitest';
+import { beforeAll, describe, expect, test, vi } from 'vitest';
 import { getWitnessRequirements, verifyWitnessProofs } from '../src';
 import { computeWitnessRequirementChecks } from '../src/core/witness-requirements';
 import type {
@@ -8,7 +8,7 @@ import type {
   Signer,
   VerificationMethod,
 } from '../src/interfaces';
-import { createDID, resolveDIDFromLog, updateDID } from '../src/method';
+import { createDID, deactivateDID, resolveDIDFromLog, updateDID } from '../src/method';
 import { deriveHash } from '../src/utils/crypto';
 import { MultibaseEncoding, multibaseEncode } from '../src/utils/multiformats';
 import { parseDidKeyDid, parseDidKeyVerificationMethod } from '../src/utils/verification-methods';
@@ -692,6 +692,205 @@ describe('Witness Implementation Tests', async () => {
       for (const requirement of result.requirements) {
         expect(requirement.satisfied).toBe(true);
         expect(requirement.approvals).toBe(1);
+      }
+    });
+
+    test('Deactivating a witnessed DID validates the prior log using caller-supplied witnessProofs, and the resulting entry is checked via verifyWitnessProofs', async () => {
+      const witnessDid = `did:key:${witness1.publicKeyMultibase}`;
+      const genesisDid = await createDID({
+        address: 'example.com',
+        signer: createTestSigner(authKey),
+        updateKeys: [authKey.publicKeyMultibase!],
+        verificationMethods: asPublicVerificationMethods(authKey),
+        witness: { threshold: 1, witnesses: [{ id: witnessDid }] },
+        verifier: testImplementation,
+      });
+
+      const genesisVersionId = genesisDid.log[0].versionId;
+      const genesisWitnessProofs = [
+        {
+          versionId: genesisVersionId,
+          proof: [
+            await createWitnessProof(
+              createWitnessSigner(witness1),
+              genesisVersionId,
+              witnessVerificationMethod(witness1)
+            ),
+          ],
+        },
+      ];
+
+      // Deactivate: resolving the prior (witnessed) log must use the caller-supplied
+      // proofs rather than falling back to a network fetch of did-witness.json.
+      const deactivated = await deactivateDID({
+        log: genesisDid.log,
+        signer: createTestSigner(authKey),
+        verifier: testImplementation,
+        witnessProofs: genesisWitnessProofs,
+      });
+
+      expect(deactivated.meta.deactivated).toBe(true);
+      expect(deactivated.log).toHaveLength(2);
+
+      // The still-active genesis configuration also governs the deactivation entry
+      // itself (v2); a proof signing the deactivation entry's own versionId cumulatively
+      // satisfies both the genesis (v1) and deactivation (v2) requirements.
+      const deactivationVersionId = deactivated.log[1].versionId;
+      const cumulativeWitnessProofs = [
+        {
+          versionId: deactivationVersionId,
+          proof: [
+            await createWitnessProof(
+              createWitnessSigner(witness1),
+              deactivationVersionId,
+              witnessVerificationMethod(witness1)
+            ),
+          ],
+        },
+      ];
+
+      const result = await verifyWitnessProofs(deactivated, cumulativeWitnessProofs, { verifier: testImplementation });
+
+      expect(result.verified).toBe(true);
+      expect(result.requirements).toEqual([
+        {
+          versionId: genesisVersionId,
+          versionNumber: 1,
+          threshold: 1,
+          witnesses: [{ id: witnessDid }],
+          approvals: 1,
+          satisfied: true,
+        },
+        {
+          versionId: deactivationVersionId,
+          versionNumber: 2,
+          threshold: 1,
+          witnesses: [{ id: witnessDid }],
+          approvals: 1,
+          satisfied: true,
+        },
+      ]);
+    });
+
+    test('deactivateDID rejects when a witness is required but witnessProofs is omitted, without a network fetch', async () => {
+      const witnessDid = `did:key:${witness1.publicKeyMultibase}`;
+      const genesisDid = await createDID({
+        address: 'example.com',
+        signer: createTestSigner(authKey),
+        updateKeys: [authKey.publicKeyMultibase!],
+        verificationMethods: asPublicVerificationMethods(authKey),
+        witness: { threshold: 1, witnesses: [{ id: witnessDid }] },
+        verifier: testImplementation,
+      });
+
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network fetch should not occur'));
+
+      try {
+        await expect(
+          deactivateDID({
+            log: genesisDid.log,
+            signer: createTestSigner(authKey),
+            verifier: testImplementation,
+          })
+        ).rejects.toThrow();
+
+        expect(fetchSpy).not.toHaveBeenCalled();
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    });
+
+    test('updateDID rejects when a witness is required but witnessProofs is omitted, without a network fetch', async () => {
+      const witnessDid = `did:key:${witness1.publicKeyMultibase}`;
+      const genesisDid = await createDID({
+        address: 'example.com',
+        signer: createTestSigner(authKey),
+        updateKeys: [authKey.publicKeyMultibase!],
+        verificationMethods: asPublicVerificationMethods(authKey),
+        witness: { threshold: 1, witnesses: [{ id: witnessDid }] },
+        verifier: testImplementation,
+      });
+
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network fetch should not occur'));
+
+      try {
+        await expect(
+          updateDID({
+            log: genesisDid.log,
+            signer: createTestSigner(authKey),
+            updateKeys: [authKey.publicKeyMultibase!],
+            verificationMethods: asPublicVerificationMethods(authKey),
+            verifier: testImplementation,
+          })
+        ).rejects.toThrow();
+
+        expect(fetchSpy).not.toHaveBeenCalled();
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    });
+
+    test('updateDID and deactivateDID never fetch witness proofs over the network when witnessProofs is supplied', async () => {
+      const witnessDid = `did:key:${witness1.publicKeyMultibase}`;
+      const genesisDid = await createDID({
+        address: 'example.com',
+        signer: createTestSigner(authKey),
+        updateKeys: [authKey.publicKeyMultibase!],
+        verificationMethods: asPublicVerificationMethods(authKey),
+        witness: { threshold: 1, witnesses: [{ id: witnessDid }] },
+        verifier: testImplementation,
+      });
+
+      const genesisVersionId = genesisDid.log[0].versionId;
+      const genesisWitnessProofs = [
+        {
+          versionId: genesisVersionId,
+          proof: [
+            await createWitnessProof(
+              createWitnessSigner(witness1),
+              genesisVersionId,
+              witnessVerificationMethod(witness1)
+            ),
+          ],
+        },
+      ];
+
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network fetch should not occur'));
+
+      try {
+        const updatedDid = await updateDID({
+          log: genesisDid.log,
+          signer: createTestSigner(authKey),
+          updateKeys: [authKey.publicKeyMultibase!],
+          verificationMethods: asPublicVerificationMethods(authKey),
+          verifier: testImplementation,
+          witnessProofs: genesisWitnessProofs,
+        });
+        expect(fetchSpy).not.toHaveBeenCalled();
+
+        const updatedVersionId = updatedDid.log[1].versionId;
+        const updatedWitnessProofs = [
+          {
+            versionId: updatedVersionId,
+            proof: [
+              await createWitnessProof(
+                createWitnessSigner(witness1),
+                updatedVersionId,
+                witnessVerificationMethod(witness1)
+              ),
+            ],
+          },
+        ];
+
+        await deactivateDID({
+          log: updatedDid.log,
+          signer: createTestSigner(authKey),
+          verifier: testImplementation,
+          witnessProofs: updatedWitnessProofs,
+        });
+        expect(fetchSpy).not.toHaveBeenCalled();
+      } finally {
+        fetchSpy.mockRestore();
       }
     });
   });

--- a/test/witness.test.ts
+++ b/test/witness.test.ts
@@ -1,5 +1,5 @@
 import { beforeAll, describe, expect, test } from 'vitest';
-import { getWitnessRequirements } from '../src';
+import { getWitnessRequirements, verifyWitnessProofs } from '../src';
 import { computeWitnessRequirementChecks } from '../src/core/witness-requirements';
 import type {
   CreateDIDResult,
@@ -526,6 +526,173 @@ describe('Witness Implementation Tests', async () => {
 
       expect(requirements.map((r) => r.versionId)).toEqual(checks.map((c) => c.targetVersionId));
       expect(requirements.map((r) => r.threshold)).toEqual(checks.map((c) => c.witness.threshold));
+    });
+  });
+
+  describe('verifyWitnessProofs', () => {
+    test('Returns verified: true and satisfied requirements when threshold is met', async () => {
+      const witness1SignerFn = createWitnessSigner(witness1);
+      const witness2SignerFn = createWitnessSigner(witness2);
+      const versionId = initialDID.log[0].versionId;
+
+      const witnessProofs = [
+        {
+          versionId,
+          proof: await Promise.all([
+            createWitnessProof(witness1SignerFn, versionId, witnessVerificationMethod(witness1)),
+            createWitnessProof(witness2SignerFn, versionId, witnessVerificationMethod(witness2)),
+          ]),
+        },
+      ];
+
+      const result = await verifyWitnessProofs(initialDID, witnessProofs, { verifier: testImplementation });
+
+      expect(result.verified).toBe(true);
+      expect(result.requirements).toEqual([
+        {
+          versionId,
+          versionNumber: 1,
+          threshold: 2,
+          witnesses: [
+            { id: `did:key:${witness1.publicKeyMultibase}` },
+            { id: `did:key:${witness2.publicKeyMultibase}` },
+          ],
+          approvals: 2,
+          satisfied: true,
+        },
+      ]);
+    });
+
+    test('Returns verified: false with a per-entry approval count when threshold is not met, without throwing', async () => {
+      const witness1SignerFn = createWitnessSigner(witness1);
+      const versionId = initialDID.log[0].versionId;
+
+      const witnessProofs = [
+        {
+          versionId,
+          proof: [await createWitnessProof(witness1SignerFn, versionId, witnessVerificationMethod(witness1))],
+        },
+      ];
+
+      const result = await verifyWitnessProofs(initialDID, witnessProofs, { verifier: testImplementation });
+
+      expect(result.verified).toBe(false);
+      expect(result.requirements).toEqual([
+        {
+          versionId,
+          versionNumber: 1,
+          threshold: 2,
+          witnesses: [
+            { id: `did:key:${witness1.publicKeyMultibase}` },
+            { id: `did:key:${witness2.publicKeyMultibase}` },
+          ],
+          approvals: 1,
+          satisfied: false,
+        },
+      ]);
+    });
+
+    test('Returns verified: true with no requirements when the log has no witness requirement', async () => {
+      const noWitnessDID = await createDID({
+        address: 'example.com',
+        signer: createTestSigner(authKey),
+        updateKeys: [authKey.publicKeyMultibase!],
+        verificationMethods: asPublicVerificationMethods(authKey),
+        verifier: testImplementation,
+      });
+
+      const result = await verifyWitnessProofs(noWitnessDID, [], { verifier: testImplementation });
+
+      expect(result).toEqual({ verified: true, requirements: [] });
+    });
+
+    test('Still throws for non-witness integrity failures, unmodified', async () => {
+      const tamperedLog: DIDLog = JSON.parse(JSON.stringify(initialDID.log));
+      tamperedLog[0].parameters.scid = 'tampered-scid';
+
+      await expect(verifyWitnessProofs({ log: tamperedLog }, [], { verifier: testImplementation })).rejects.toThrow();
+    });
+
+    test('Verifies a proposed chain-tip update using a single cumulative proof for a 3-entry log', async () => {
+      // Simulates the create -> witness -> verify -> publish sequence for a proposed,
+      // not-yet-published update: a single witness proof signing only the latest
+      // (v3) versionId must cumulatively satisfy the inherited witness requirement
+      // on v1, v2, and v3 alike, without any per-version proof history.
+      const witnessDid = `did:key:${witness1.publicKeyMultibase}`;
+      const genesisDid = await createDID({
+        address: 'example.com',
+        signer: createTestSigner(authKey),
+        updateKeys: [authKey.publicKeyMultibase!],
+        verificationMethods: asPublicVerificationMethods(authKey),
+        witness: { threshold: 1, witnesses: [{ id: witnessDid }] },
+        verifier: testImplementation,
+      });
+
+      // v2: published, witnessed by a proof scoped to v1 (its own requirement).
+      const v1WitnessProofs = [
+        {
+          versionId: genesisDid.log[0].versionId,
+          proof: [
+            await createWitnessProof(
+              createWitnessSigner(witness1),
+              genesisDid.log[0].versionId,
+              witnessVerificationMethod(witness1)
+            ),
+          ],
+        },
+      ];
+      const publishedV2 = await updateDID({
+        log: genesisDid.log,
+        signer: createTestSigner(authKey),
+        updateKeys: [authKey.publicKeyMultibase!],
+        verificationMethods: asPublicVerificationMethods(authKey),
+        verifier: testImplementation,
+        witnessProofs: v1WitnessProofs,
+      });
+
+      // v3: a proposed chain tip, not yet witnessed or published anywhere else.
+      // v2 also requires this same (inherited) witness configuration to be re-verified
+      // when resolving the fuller log, so its own cumulative proof is supplied here.
+      const v2WitnessProofs = [
+        {
+          versionId: publishedV2.log[1].versionId,
+          proof: [
+            await createWitnessProof(
+              createWitnessSigner(witness1),
+              publishedV2.log[1].versionId,
+              witnessVerificationMethod(witness1)
+            ),
+          ],
+        },
+      ];
+      const proposedV3 = await updateDID({
+        log: publishedV2.log,
+        signer: createTestSigner(authKey),
+        updateKeys: [authKey.publicKeyMultibase!],
+        verificationMethods: asPublicVerificationMethods(authKey),
+        verifier: testImplementation,
+        witnessProofs: v2WitnessProofs,
+      });
+      expect(proposedV3.log).toHaveLength(3);
+
+      const v3VersionId = proposedV3.log[2].versionId;
+      const cumulativeWitnessProofs = [
+        {
+          versionId: v3VersionId,
+          proof: [
+            await createWitnessProof(createWitnessSigner(witness1), v3VersionId, witnessVerificationMethod(witness1)),
+          ],
+        },
+      ];
+
+      const result = await verifyWitnessProofs(proposedV3, cumulativeWitnessProofs, { verifier: testImplementation });
+
+      expect(result.verified).toBe(true);
+      expect(result.requirements.length).toBeGreaterThanOrEqual(1);
+      for (const requirement of result.requirements) {
+        expect(requirement.satisfied).toBe(true);
+        expect(requirement.approvals).toBe(1);
+      }
     });
   });
 

--- a/test/witness.test.ts
+++ b/test/witness.test.ts
@@ -1,4 +1,6 @@
 import { beforeAll, describe, expect, test } from 'vitest';
+import { getWitnessRequirements } from '../src';
+import { computeWitnessRequirementChecks } from '../src/core/witness-requirements';
 import type {
   CreateDIDResult,
   DataIntegrityProofTemplate,
@@ -137,6 +139,17 @@ describe('Witness Implementation Tests', async () => {
     expect(resolved.didDocumentMetadata?.witness?.threshold).toBe(2);
     expect(updatedDID.log).toHaveLength(2);
     expect(resolved.didDocumentMetadata?.witness?.witnesses).toHaveLength(2);
+
+    // getWitnessRequirements agrees: first activation is governed by the new
+    // configuration on the same (v2) entry.
+    expect(getWitnessRequirements(updatedDID)).toEqual([
+      {
+        versionId: newVersionId,
+        versionNumber: 2,
+        threshold: 2,
+        witnesses: [{ id: `did:key:${witness1.publicKeyMultibase}` }, { id: `did:key:${witness2.publicKeyMultibase}` }],
+      },
+    ]);
   });
 
   test('Resolve DID rejects duplicate witness IDs in witness parameters', async () => {
@@ -410,6 +423,16 @@ describe('Witness Implementation Tests', async () => {
     });
     expect(resolved.didDocumentMetadata?.witness?.witnesses).toHaveLength(1);
     expect(resolved.didDocumentMetadata?.witness?.threshold).toBe(1);
+
+    // getWitnessRequirements agrees: the replacing entry (v2) is governed by the
+    // previous list (witness1 + witness2), not the new one.
+    const requirements = getWitnessRequirements(updatedDID);
+    expect(requirements[1].versionId).toBe(newVersionId);
+    expect(requirements[1].threshold).toBe(2);
+    expect(requirements[1].witnesses).toEqual([
+      { id: `did:key:${witness1.publicKeyMultibase}` },
+      { id: `did:key:${witness2.publicKeyMultibase}` },
+    ]);
   });
 
   test('Disable witnessing by setting witness list to null', async () => {
@@ -444,6 +467,66 @@ describe('Witness Implementation Tests', async () => {
       witnessProofs: [...witnessProofs, { versionId: newVersionId, proof: deactivationProofs }],
     });
     expect(resolved.didDocumentMetadata.witness).toEqual({});
+
+    // getWitnessRequirements agrees: the turn-off entry (v2) is still governed by
+    // the previously active list.
+    const requirements = getWitnessRequirements(updatedDID);
+    expect(requirements[1].versionId).toBe(newVersionId);
+    expect(requirements[1].threshold).toBe(2);
+    expect(requirements[1].witnesses).toEqual([
+      { id: `did:key:${witness1.publicKeyMultibase}` },
+      { id: `did:key:${witness2.publicKeyMultibase}` },
+    ]);
+  });
+
+  describe('getWitnessRequirements', () => {
+    test('Genesis without witnesses returns no requirements', async () => {
+      const noWitnessDID = await createDID({
+        address: 'example.com',
+        signer: createTestSigner(authKey),
+        updateKeys: [authKey.publicKeyMultibase!],
+        verificationMethods: asPublicVerificationMethods(authKey),
+        verifier: testImplementation,
+      });
+
+      expect(getWitnessRequirements(noWitnessDID)).toEqual([]);
+    });
+
+    test('Genesis with witnesses returns versionId, normalized threshold, and witness list', async () => {
+      const requirements = getWitnessRequirements(initialDID);
+
+      expect(requirements).toEqual([
+        {
+          versionId: initialDID.log[0].versionId,
+          versionNumber: 1,
+          threshold: 2,
+          witnesses: [
+            { id: `did:key:${witness1.publicKeyMultibase}` },
+            { id: `did:key:${witness2.publicKeyMultibase}` },
+          ],
+        },
+      ]);
+    });
+
+    test('Returns defensive copies that callers cannot use to mutate internal state', async () => {
+      const requirements = getWitnessRequirements(initialDID);
+      const originalWitnesses = JSON.parse(JSON.stringify(requirements[0].witnesses));
+
+      requirements[0].witnesses.push({ id: 'did:key:zTamperedWitness' });
+      requirements[0].threshold = 999;
+
+      const requirementsAgain = getWitnessRequirements(initialDID);
+      expect(requirementsAgain[0].witnesses).toEqual(originalWitnesses);
+      expect(requirementsAgain[0].threshold).toBe(2);
+    });
+
+    test('Agrees with the resolver-derived requirements for the same log', async () => {
+      const checks = computeWitnessRequirementChecks(initialDID.log);
+      const requirements = getWitnessRequirements(initialDID);
+
+      expect(requirements.map((r) => r.versionId)).toEqual(checks.map((c) => c.targetVersionId));
+      expect(requirements.map((r) => r.threshold)).toEqual(checks.map((c) => c.witness.threshold));
+    });
   });
 
   test('Verify witness proofs from did-witness.json', async () => {
@@ -724,6 +807,24 @@ describe('Witness Implementation Tests', async () => {
     expect(result.didResolutionMetadata.message).toContain(
       `Witness threshold not met for version ${updatedDid.log[1].versionId}`
     );
+
+    // getWitnessRequirements agrees: the inherited config (witnessDid, threshold 1) also
+    // governs v2, not just v1.
+    const requirements = getWitnessRequirements(updatedDid);
+    expect(requirements).toEqual([
+      {
+        versionId: didWithWitness.log[0].versionId,
+        versionNumber: 1,
+        threshold: 1,
+        witnesses: [{ id: witnessDid }],
+      },
+      {
+        versionId: updatedDid.log[1].versionId,
+        versionNumber: 2,
+        threshold: 1,
+        witnesses: [{ id: witnessDid }],
+      },
+    ]);
   });
 
   test('Resolve does not double-count duplicate proofs from the same witness DID', async () => {

--- a/test/witness.test.ts
+++ b/test/witness.test.ts
@@ -809,7 +809,7 @@ describe('Witness Implementation Tests', async () => {
       await expectResolverRequirementsToMatch(deactivated.log, cumulativeWitnessProofs);
     });
 
-    test('deactivateDID rejects when a witness is required but witnessProofs is omitted, without a network fetch', async () => {
+    test('deactivateDID rejects when a witness is required but witnessProofs is explicitly empty', async () => {
       const witnessDid = `did:key:${witness1.publicKeyMultibase}`;
       const genesisDid = await createDID({
         address: 'example.com',
@@ -828,6 +828,7 @@ describe('Witness Implementation Tests', async () => {
             log: genesisDid.log,
             signer: createTestSigner(authKey),
             verifier: testImplementation,
+            witnessProofs: [],
           })
         ).rejects.toThrow();
 
@@ -837,7 +838,7 @@ describe('Witness Implementation Tests', async () => {
       }
     });
 
-    test('updateDID rejects when a witness is required but witnessProofs is omitted, without a network fetch', async () => {
+    test('updateDID rejects when a witness is required but witnessProofs is explicitly empty', async () => {
       const witnessDid = `did:key:${witness1.publicKeyMultibase}`;
       const genesisDid = await createDID({
         address: 'example.com',
@@ -858,10 +859,41 @@ describe('Witness Implementation Tests', async () => {
             updateKeys: [authKey.publicKeyMultibase!],
             verificationMethods: asPublicVerificationMethods(authKey),
             verifier: testImplementation,
+            witnessProofs: [],
           })
         ).rejects.toThrow();
 
         expect(fetchSpy).not.toHaveBeenCalled();
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    });
+
+    test('updateDID fetches witness proofs when witnessProofs is omitted', async () => {
+      const witnessDid = `did:key:${witness1.publicKeyMultibase}`;
+      const genesisDid = await createDID({
+        address: 'example.com',
+        signer: createTestSigner(authKey),
+        updateKeys: [authKey.publicKeyMultibase!],
+        verificationMethods: asPublicVerificationMethods(authKey),
+        witness: { threshold: 1, witnesses: [{ id: witnessDid }] },
+        verifier: testImplementation,
+      });
+
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network fetch observed'));
+
+      try {
+        await expect(
+          updateDID({
+            log: genesisDid.log,
+            signer: createTestSigner(authKey),
+            updateKeys: [authKey.publicKeyMultibase!],
+            verificationMethods: asPublicVerificationMethods(authKey),
+            verifier: testImplementation,
+          })
+        ).rejects.toThrow();
+
+        expect(fetchSpy).toHaveBeenCalledWith('https://example.com/.well-known/did-witness.json');
       } finally {
         fetchSpy.mockRestore();
       }

--- a/test/witness.test.ts
+++ b/test/witness.test.ts
@@ -1,17 +1,17 @@
 import { beforeAll, describe, expect, test, vi } from 'vitest';
-import { getWitnessRequirements, verifyWitnessProofs } from '../src';
-import { computeWitnessRequirementChecks } from '../src/core/witness-requirements';
+import { computeWitnessRequirementChecks } from '../src/core/witness-requirements.js';
+import { getWitnessRequirements, verifyWitnessProofs } from '../src/index.js';
 import type {
   CreateDIDResult,
   DataIntegrityProofTemplate,
   DIDLog,
   Signer,
   VerificationMethod,
-} from '../src/interfaces';
-import { createDID, deactivateDID, resolveDIDFromLog, updateDID } from '../src/method';
-import { deriveHash } from '../src/utils/crypto';
-import { MultibaseEncoding, multibaseEncode } from '../src/utils/multiformats';
-import { parseDidKeyDid, parseDidKeyVerificationMethod } from '../src/utils/verification-methods';
+} from '../src/interfaces.js';
+import { createDID, deactivateDID, resolveDIDFromLog, updateDID } from '../src/method.js';
+import { deriveHash } from '../src/utils/crypto.js';
+import { MultibaseEncoding, multibaseEncode } from '../src/utils/multiformats.js';
+import { parseDidKeyDid, parseDidKeyVerificationMethod } from '../src/utils/verification-methods.js';
 import {
   countWitnessApprovals,
   createWitnessProof,

--- a/test/witness.test.ts
+++ b/test/witness.test.ts
@@ -806,6 +806,7 @@ describe('Witness Implementation Tests', async () => {
           satisfied: true,
         },
       ]);
+      await expectResolverRequirementsToMatch(deactivated.log, cumulativeWitnessProofs);
     });
 
     test('deactivateDID rejects when a witness is required but witnessProofs is omitted, without a network fetch', async () => {
@@ -1225,6 +1226,20 @@ describe('Witness Implementation Tests', async () => {
         versionNumber: 2,
         threshold: 1,
         witnesses: [{ id: witnessDid }],
+      },
+    ]);
+
+    const inheritedVersionId = updatedDid.log[1].versionId;
+    await expectResolverRequirementsToMatch(updatedDid.log, [
+      {
+        versionId: inheritedVersionId,
+        proof: [
+          await createWitnessProof(
+            createWitnessSigner(witness1),
+            inheritedVersionId,
+            witnessVerificationMethod(witness1)
+          ),
+        ],
       },
     ]);
   });

--- a/test/witness.test.ts
+++ b/test/witness.test.ts
@@ -495,6 +495,55 @@ describe('Witness Implementation Tests', async () => {
     ]);
   });
 
+  test('Disable witnessing with an explicit empty witness configuration', async () => {
+    const versionId = initialDID.log[0].versionId;
+    const initialProofs = [
+      {
+        versionId,
+        proof: await Promise.all([
+          createWitnessProof(createWitnessSigner(witness1), versionId, witnessVerificationMethod(witness1)),
+          createWitnessProof(createWitnessSigner(witness2), versionId, witnessVerificationMethod(witness2)),
+        ]),
+      },
+    ];
+
+    const updatedDID = await updateDID({
+      log: initialDID.log,
+      signer: createTestSigner(authKey),
+      updateKeys: [authKey.publicKeyMultibase!],
+      verificationMethods: asPublicVerificationMethods(authKey),
+      witness: {},
+      verifier: testImplementation,
+      witnessProofs: initialProofs,
+    });
+
+    const updatedVersionId = updatedDID.log[1].versionId;
+    const updatedProofs = {
+      versionId: updatedVersionId,
+      proof: await Promise.all([
+        createWitnessProof(createWitnessSigner(witness1), updatedVersionId, witnessVerificationMethod(witness1)),
+        createWitnessProof(createWitnessSigner(witness2), updatedVersionId, witnessVerificationMethod(witness2)),
+      ]),
+    };
+    const allWitnessProofs = [...initialProofs, updatedProofs];
+
+    const resolved = await resolveDIDFromLog(updatedDID.log, {
+      verifier: testImplementation,
+      witnessProofs: allWitnessProofs,
+    });
+    expect(resolved.didDocumentMetadata.witness).toEqual({});
+
+    const requirements = getWitnessRequirements(updatedDID.log);
+    expect(requirements).toHaveLength(2);
+    expect(requirements[1]).toMatchObject({
+      versionId: updatedVersionId,
+      versionNumber: 2,
+      threshold: 2,
+      witnesses: [{ id: `did:key:${witness1.publicKeyMultibase}` }, { id: `did:key:${witness2.publicKeyMultibase}` }],
+    });
+    await expectResolverRequirementsToMatch(updatedDID.log, allWitnessProofs);
+  });
+
   describe('getWitnessRequirements', () => {
     test('Genesis without witnesses returns no requirements', async () => {
       const noWitnessDID = await createDID({
@@ -506,6 +555,26 @@ describe('Witness Implementation Tests', async () => {
       });
 
       expect(getWitnessRequirements(noWitnessDID.log)).toEqual([]);
+    });
+
+    test('Keeps subsequent entries inactive when genesis has no witnesses and the entry omits witnesses', async () => {
+      const noWitnessDID = await createDID({
+        address: 'example.com',
+        signer: createTestSigner(authKey),
+        updateKeys: [authKey.publicKeyMultibase!],
+        verificationMethods: asPublicVerificationMethods(authKey),
+        verifier: testImplementation,
+      });
+      const updatedDID = await updateDID({
+        log: noWitnessDID.log,
+        signer: createTestSigner(authKey),
+        updateKeys: [authKey.publicKeyMultibase!],
+        verificationMethods: asPublicVerificationMethods(authKey),
+        verifier: testImplementation,
+      });
+
+      expect(getWitnessRequirements(updatedDID.log)).toEqual([]);
+      await expectResolverRequirementsToMatch(updatedDID.log, []);
     });
 
     test('Genesis with witnesses returns versionId, normalized threshold, and witness list', async () => {
@@ -522,6 +591,141 @@ describe('Witness Implementation Tests', async () => {
           ],
         },
       ]);
+    });
+
+    test('Reports a witness requirement when witnesses are first activated on an update', async () => {
+      const noWitnessDID = await createDID({
+        address: 'example.com',
+        signer: createTestSigner(authKey),
+        updateKeys: [authKey.publicKeyMultibase!],
+        verificationMethods: asPublicVerificationMethods(authKey),
+        verifier: testImplementation,
+      });
+      const updatedDID = await updateDID({
+        log: noWitnessDID.log,
+        signer: createTestSigner(authKey),
+        updateKeys: [authKey.publicKeyMultibase!],
+        verificationMethods: asPublicVerificationMethods(authKey),
+        witness: {
+          threshold: 1,
+          witnesses: [{ id: `did:key:${witness1.publicKeyMultibase}` }],
+        },
+        verifier: testImplementation,
+      });
+
+      const requirements = getWitnessRequirements(updatedDID.log);
+      expect(requirements).toEqual([
+        {
+          versionId: updatedDID.log[1].versionId,
+          versionNumber: 2,
+          threshold: 1,
+          witnesses: [{ id: `did:key:${witness1.publicKeyMultibase}` }],
+        },
+      ]);
+      await expectResolverRequirementsToMatch(updatedDID.log, [
+        {
+          versionId: updatedDID.log[1].versionId,
+          proof: [
+            await createWitnessProof(
+              createWitnessSigner(witness1),
+              updatedDID.log[1].versionId,
+              witnessVerificationMethod(witness1)
+            ),
+          ],
+        },
+      ]);
+    });
+
+    test('Carries witness requirements forward when a subsequent entry omits witnesses', async () => {
+      const versionId = initialDID.log[0].versionId;
+      const initialProofs = [
+        {
+          versionId,
+          proof: await Promise.all([
+            createWitnessProof(createWitnessSigner(witness1), versionId, witnessVerificationMethod(witness1)),
+            createWitnessProof(createWitnessSigner(witness2), versionId, witnessVerificationMethod(witness2)),
+          ]),
+        },
+      ];
+      const updatedDID = await updateDID({
+        log: initialDID.log,
+        signer: createTestSigner(authKey),
+        updateKeys: [authKey.publicKeyMultibase!],
+        verificationMethods: asPublicVerificationMethods(authKey),
+        verifier: testImplementation,
+        witnessProofs: initialProofs,
+      });
+      const updatedVersionId = updatedDID.log[1].versionId;
+      const updatedProofs = {
+        versionId: updatedVersionId,
+        proof: await Promise.all([
+          createWitnessProof(createWitnessSigner(witness1), updatedVersionId, witnessVerificationMethod(witness1)),
+          createWitnessProof(createWitnessSigner(witness2), updatedVersionId, witnessVerificationMethod(witness2)),
+        ]),
+      };
+
+      expect(getWitnessRequirements(updatedDID.log)).toEqual([
+        {
+          versionId,
+          versionNumber: 1,
+          threshold: 2,
+          witnesses: [
+            { id: `did:key:${witness1.publicKeyMultibase}` },
+            { id: `did:key:${witness2.publicKeyMultibase}` },
+          ],
+        },
+        {
+          versionId: updatedVersionId,
+          versionNumber: 2,
+          threshold: 2,
+          witnesses: [
+            { id: `did:key:${witness1.publicKeyMultibase}` },
+            { id: `did:key:${witness2.publicKeyMultibase}` },
+          ],
+        },
+      ]);
+      await expectResolverRequirementsToMatch(updatedDID.log, [...initialProofs, updatedProofs]);
+    });
+
+    test('Uses the previous witness configuration for a replacement entry', async () => {
+      const versionId = initialDID.log[0].versionId;
+      const initialProofs = [
+        {
+          versionId,
+          proof: await Promise.all([
+            createWitnessProof(createWitnessSigner(witness1), versionId, witnessVerificationMethod(witness1)),
+            createWitnessProof(createWitnessSigner(witness2), versionId, witnessVerificationMethod(witness2)),
+          ]),
+        },
+      ];
+      const updatedDID = await updateDID({
+        log: initialDID.log,
+        signer: createTestSigner(authKey),
+        updateKeys: [authKey.publicKeyMultibase!],
+        verificationMethods: asPublicVerificationMethods(authKey),
+        witness: {
+          threshold: 1,
+          witnesses: [{ id: `did:key:${witness3.publicKeyMultibase}` }],
+        },
+        verifier: testImplementation,
+        witnessProofs: initialProofs,
+      });
+      const updatedVersionId = updatedDID.log[1].versionId;
+      const updatedProofs = {
+        versionId: updatedVersionId,
+        proof: await Promise.all([
+          createWitnessProof(createWitnessSigner(witness1), updatedVersionId, witnessVerificationMethod(witness1)),
+          createWitnessProof(createWitnessSigner(witness2), updatedVersionId, witnessVerificationMethod(witness2)),
+        ]),
+      };
+
+      expect(getWitnessRequirements(updatedDID.log)[1]).toEqual({
+        versionId: updatedVersionId,
+        versionNumber: 2,
+        threshold: 2,
+        witnesses: [{ id: `did:key:${witness1.publicKeyMultibase}` }, { id: `did:key:${witness2.publicKeyMultibase}` }],
+      });
+      await expectResolverRequirementsToMatch(updatedDID.log, [...initialProofs, updatedProofs]);
     });
 
     test('Returns defensive copies that callers cannot use to mutate internal state', async () => {

--- a/test/witness.test.ts
+++ b/test/witness.test.ts
@@ -1,5 +1,4 @@
 import { beforeAll, describe, expect, test, vi } from 'vitest';
-import { computeWitnessRequirementChecks } from '../src/core/witness-requirements.js';
 import { getWitnessRequirements, verifyWitnessProofs } from '../src/index.js';
 import type {
   CreateDIDResult,
@@ -521,11 +520,27 @@ describe('Witness Implementation Tests', async () => {
     });
 
     test('Agrees with the resolver-derived requirements for the same log', async () => {
-      const checks = computeWitnessRequirementChecks(initialDID.log);
       const requirements = getWitnessRequirements(initialDID);
+      const versionId = initialDID.log[0].versionId;
+      const witnessProofs = [
+        {
+          versionId,
+          proof: await Promise.all([
+            createWitnessProof(createWitnessSigner(witness1), versionId, witnessVerificationMethod(witness1)),
+            createWitnessProof(createWitnessSigner(witness2), versionId, witnessVerificationMethod(witness2)),
+          ]),
+        },
+      ];
+      const resolved = await verifyWitnessProofs(initialDID, witnessProofs, { verifier: testImplementation });
 
-      expect(requirements.map((r) => r.versionId)).toEqual(checks.map((c) => c.targetVersionId));
-      expect(requirements.map((r) => r.threshold)).toEqual(checks.map((c) => c.witness.threshold));
+      expect(resolved.verified).toBe(true);
+      expect(resolved.requirements).toEqual(
+        requirements.map((requirement) => ({
+          ...requirement,
+          approvals: 2,
+          satisfied: true,
+        }))
+      );
     });
   });
 

--- a/test/witness.test.ts
+++ b/test/witness.test.ts
@@ -6,6 +6,7 @@ import type {
   DIDLog,
   Signer,
   VerificationMethod,
+  WitnessProofFileEntry,
 } from '../src/interfaces.js';
 import { createDID, deactivateDID, resolveDIDFromLog, updateDID } from '../src/method.js';
 import { deriveHash } from '../src/utils/crypto.js';
@@ -42,6 +43,16 @@ describe('Witness Implementation Tests', async () => {
 
   const witnessVerificationMethod = (vm: VerificationMethod) =>
     `did:key:${vm.publicKeyMultibase}#${vm.publicKeyMultibase}`;
+
+  const expectResolverRequirementsToMatch = async (log: DIDLog, witnessProofs: WitnessProofFileEntry[]) => {
+    const expected = getWitnessRequirements(log);
+    const result = await verifyWitnessProofs(log, witnessProofs, { verifier: testImplementation });
+
+    expect(result.verified).toBe(true);
+    expect(
+      result.requirements.map(({ approvals: _approvals, satisfied: _satisfied, ...requirement }) => requirement)
+    ).toEqual(expected);
+  };
 
   test('Create DID with witness threshold', async () => {
     initialDID = await createDID({
@@ -149,6 +160,7 @@ describe('Witness Implementation Tests', async () => {
         witnesses: [{ id: `did:key:${witness1.publicKeyMultibase}` }, { id: `did:key:${witness2.publicKeyMultibase}` }],
       },
     ]);
+    await expectResolverRequirementsToMatch(updatedDID.log, witnessProofs);
   });
 
   test('Resolve DID rejects duplicate witness IDs in witness parameters', async () => {
@@ -432,6 +444,7 @@ describe('Witness Implementation Tests', async () => {
       { id: `did:key:${witness1.publicKeyMultibase}` },
       { id: `did:key:${witness2.publicKeyMultibase}` },
     ]);
+    await expectResolverRequirementsToMatch(updatedDID.log, [...witnessProofs, ...newWitnessProofs]);
   });
 
   test('Disable witnessing by setting witness list to null', async () => {
@@ -475,6 +488,10 @@ describe('Witness Implementation Tests', async () => {
     expect(requirements[1].witnesses).toEqual([
       { id: `did:key:${witness1.publicKeyMultibase}` },
       { id: `did:key:${witness2.publicKeyMultibase}` },
+    ]);
+    await expectResolverRequirementsToMatch(updatedDID.log, [
+      ...witnessProofs,
+      { versionId: newVersionId, proof: deactivationProofs },
     ]);
   });
 

--- a/test/witness.test.ts
+++ b/test/witness.test.ts
@@ -141,7 +141,7 @@ describe('Witness Implementation Tests', async () => {
 
     // getWitnessRequirements agrees: first activation is governed by the new
     // configuration on the same (v2) entry.
-    expect(getWitnessRequirements(updatedDID)).toEqual([
+    expect(getWitnessRequirements(updatedDID.log)).toEqual([
       {
         versionId: newVersionId,
         versionNumber: 2,
@@ -425,7 +425,7 @@ describe('Witness Implementation Tests', async () => {
 
     // getWitnessRequirements agrees: the replacing entry (v2) is governed by the
     // previous list (witness1 + witness2), not the new one.
-    const requirements = getWitnessRequirements(updatedDID);
+    const requirements = getWitnessRequirements(updatedDID.log);
     expect(requirements[1].versionId).toBe(newVersionId);
     expect(requirements[1].threshold).toBe(2);
     expect(requirements[1].witnesses).toEqual([
@@ -469,7 +469,7 @@ describe('Witness Implementation Tests', async () => {
 
     // getWitnessRequirements agrees: the turn-off entry (v2) is still governed by
     // the previously active list.
-    const requirements = getWitnessRequirements(updatedDID);
+    const requirements = getWitnessRequirements(updatedDID.log);
     expect(requirements[1].versionId).toBe(newVersionId);
     expect(requirements[1].threshold).toBe(2);
     expect(requirements[1].witnesses).toEqual([
@@ -488,11 +488,11 @@ describe('Witness Implementation Tests', async () => {
         verifier: testImplementation,
       });
 
-      expect(getWitnessRequirements(noWitnessDID)).toEqual([]);
+      expect(getWitnessRequirements(noWitnessDID.log)).toEqual([]);
     });
 
     test('Genesis with witnesses returns versionId, normalized threshold, and witness list', async () => {
-      const requirements = getWitnessRequirements(initialDID);
+      const requirements = getWitnessRequirements(initialDID.log);
 
       expect(requirements).toEqual([
         {
@@ -508,19 +508,19 @@ describe('Witness Implementation Tests', async () => {
     });
 
     test('Returns defensive copies that callers cannot use to mutate internal state', async () => {
-      const requirements = getWitnessRequirements(initialDID);
+      const requirements = getWitnessRequirements(initialDID.log);
       const originalWitnesses = JSON.parse(JSON.stringify(requirements[0].witnesses));
 
       requirements[0].witnesses.push({ id: 'did:key:zTamperedWitness' });
       requirements[0].threshold = 999;
 
-      const requirementsAgain = getWitnessRequirements(initialDID);
+      const requirementsAgain = getWitnessRequirements(initialDID.log);
       expect(requirementsAgain[0].witnesses).toEqual(originalWitnesses);
       expect(requirementsAgain[0].threshold).toBe(2);
     });
 
     test('Agrees with the resolver-derived requirements for the same log', async () => {
-      const requirements = getWitnessRequirements(initialDID);
+      const requirements = getWitnessRequirements(initialDID.log);
       const versionId = initialDID.log[0].versionId;
       const witnessProofs = [
         {
@@ -531,7 +531,7 @@ describe('Witness Implementation Tests', async () => {
           ]),
         },
       ];
-      const resolved = await verifyWitnessProofs(initialDID, witnessProofs, { verifier: testImplementation });
+      const resolved = await verifyWitnessProofs(initialDID.log, witnessProofs, { verifier: testImplementation });
 
       expect(resolved.verified).toBe(true);
       expect(resolved.requirements).toEqual(
@@ -560,7 +560,7 @@ describe('Witness Implementation Tests', async () => {
         },
       ];
 
-      const result = await verifyWitnessProofs(initialDID, witnessProofs, { verifier: testImplementation });
+      const result = await verifyWitnessProofs(initialDID.log, witnessProofs, { verifier: testImplementation });
 
       expect(result.verified).toBe(true);
       expect(result.requirements).toEqual([
@@ -589,7 +589,7 @@ describe('Witness Implementation Tests', async () => {
         },
       ];
 
-      const result = await verifyWitnessProofs(initialDID, witnessProofs, { verifier: testImplementation });
+      const result = await verifyWitnessProofs(initialDID.log, witnessProofs, { verifier: testImplementation });
 
       expect(result.verified).toBe(false);
       expect(result.requirements).toEqual([
@@ -616,7 +616,7 @@ describe('Witness Implementation Tests', async () => {
         verifier: testImplementation,
       });
 
-      const result = await verifyWitnessProofs(noWitnessDID, [], { verifier: testImplementation });
+      const result = await verifyWitnessProofs(noWitnessDID.log, [], { verifier: testImplementation });
 
       expect(result).toEqual({ verified: true, requirements: [] });
     });
@@ -625,7 +625,7 @@ describe('Witness Implementation Tests', async () => {
       const tamperedLog: DIDLog = JSON.parse(JSON.stringify(initialDID.log));
       tamperedLog[0].parameters.scid = 'tampered-scid';
 
-      await expect(verifyWitnessProofs({ log: tamperedLog }, [], { verifier: testImplementation })).rejects.toThrow();
+      await expect(verifyWitnessProofs(tamperedLog, [], { verifier: testImplementation })).rejects.toThrow();
     });
 
     test('Verifies a proposed chain-tip update using a single cumulative proof for a 3-entry log', async () => {
@@ -700,7 +700,9 @@ describe('Witness Implementation Tests', async () => {
         },
       ];
 
-      const result = await verifyWitnessProofs(proposedV3, cumulativeWitnessProofs, { verifier: testImplementation });
+      const result = await verifyWitnessProofs(proposedV3.log, cumulativeWitnessProofs, {
+        verifier: testImplementation,
+      });
 
       expect(result.verified).toBe(true);
       expect(result.requirements.length).toBeGreaterThanOrEqual(1);
@@ -764,7 +766,9 @@ describe('Witness Implementation Tests', async () => {
         },
       ];
 
-      const result = await verifyWitnessProofs(deactivated, cumulativeWitnessProofs, { verifier: testImplementation });
+      const result = await verifyWitnessProofs(deactivated.log, cumulativeWitnessProofs, {
+        verifier: testImplementation,
+      });
 
       expect(result.verified).toBe(true);
       expect(result.requirements).toEqual([
@@ -1191,7 +1195,7 @@ describe('Witness Implementation Tests', async () => {
 
     // getWitnessRequirements agrees: the inherited config (witnessDid, threshold 1) also
     // governs v2, not just v1.
-    const requirements = getWitnessRequirements(updatedDid);
+    const requirements = getWitnessRequirements(updatedDid.log);
     expect(requirements).toEqual([
       {
         versionId: didWithWitness.log[0].versionId,


### PR DESCRIPTION
Enabling `Controller` <-> `Witness` agent interactions requires 2 new convenience API methods to be exposed for `controller` operations

* `getWitnessRequirements` enables a `controller` to determine exactly which proofs to obtain for a proposed log chain tip before publishing `did-witness.json` and then `did.jsonl`.

* `verifyWitnessProofs` enables a `controller` to verify returned witness proofs against their did log to ensure validity and threshold without network fetch. All other verification failures (hash chain, SCID, controller proof, etc.) still throw.

Both exported from package root with corresponding types

Other changes:

* `updateDID` and `deactivateDID` now do not fetch witness proofs when `witnessProofs` is omitted, they pass `[]` instead, avoiding network fetch and causing an unmet requirement to fail immediately and deterministically.
* callers must explicitly supply `witnessProofs` when updating/deactivating a DID with an active witness requirement.
* Witness requirement derivation is extracted from the resolver into a shared core module, so resolution and the new public APIs apply the same transition rules.
* `resolveDID` and `resolveDIDFromLog` retain their normal deterministic witness-file fetch behaviour when proofs are omitted.

Tests cover valid, missing, invalid, duplicate, and cumulative witness proofs, transition cases and the deactivation rule