### PR TITLE
fix(resolver): guard against localhost HTTP downgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ Method-specific metadata (`scid`, `updateKeys`, `nextKeyHashes`, `prerotation`, 
 - `createDID(options: CreateDIDInterface): Promise<{did: string, doc: any, meta: DIDResolutionMeta, log: DIDLog, webDoc?: DIDDoc}>`
   Creates a new DID. Always produces a v1.0 log.
   Accepts `address` (`host`, `host:port`, `https://...`, or `did:webvh:...`) or legacy `domain`.
-  Resolver URL mapping uses `http://localhost` for local testing and `https://` for non-local hosts.
+  Resolver URL mapping always uses `https://`, including for `localhost` and identifiers with `localhost` in a hostname or path. For local testing without HTTPS, use `resolveDIDFromLog` with an in-memory log.
   If `alsoKnownAsWeb: true` is supplied, the result also includes `webDoc`, the parallel `did:web` DID document to publish as `did.json`.
 
 - `updateDID(options: UpdateDIDInterface): Promise<{did: string, doc: any, meta: DIDResolutionMeta, log: DIDLog, webDoc?: DIDDoc}>`

--- a/test/resolve-http.test.ts
+++ b/test/resolve-http.test.ts
@@ -76,6 +76,28 @@ describe('resolveDID over HTTPS', () => {
     expect(result.didResolutionMetadata.contentType).toBe('application/did+ld+json');
   });
 
+  test.each([
+    ['localhost.example.com', [], 'https://localhost.example.com/.well-known/did.jsonl'],
+    ['example.com', ['localhost'], 'https://example.com/localhost/did.jsonl'],
+    ['localhost:8000', [], 'https://localhost:8000/.well-known/did.jsonl'],
+  ])('resolves %s with paths %j over HTTPS', async (address, paths, expectedUrl) => {
+    const created = await createDID({
+      address,
+      paths,
+      signer: createTestSigner(authKey),
+      updateKeys: [authKey.publicKeyMultibase!],
+      verificationMethods: asPublicVerificationMethods(authKey),
+      verifier,
+    });
+    const fetchMock = stubFetchResponse(toJsonl(created.log));
+
+    const result = await resolveDID(created.did, { verifier });
+
+    expect(fetchMock).toHaveBeenCalledExactlyOnceWith(expectedUrl);
+    expect(result.didDocument?.id).toBe(created.did);
+    expect(result.didResolutionMetadata.error).toBeUndefined();
+  });
+
   test('ignores DID_VERIFICATION_METHODS in the runtime environment', async () => {
     const previous = process.env.DID_VERIFICATION_METHODS;
     process.env.DID_VERIFICATION_METHODS = 'invalid-runtime-value';

--- a/test/resolve.test.ts
+++ b/test/resolve.test.ts
@@ -9,6 +9,24 @@ import {
 } from '../src/utils.js';
 
 describe('Resolver URL derivation', () => {
+  test.each([
+    ['localhost', 'localhost', '/.well-known'],
+    ['localhost%3A8000', 'localhost:8000', '/.well-known'],
+    ['localhost.example.com', 'localhost.example.com', '/.well-known'],
+    ['my-localhost.example.com', 'my-localhost.example.com', '/.well-known'],
+    ['cdn-localhost.example', 'cdn-localhost.example', '/.well-known'],
+    ['localhost.example.com%3A8443', 'localhost.example.com:8443', '/.well-known'],
+    ['example.com:localhost', 'example.com/localhost', ''],
+    ['example.com:api:localhost:issuer', 'example.com/api/localhost/issuer', ''],
+    ['example.com%3A8443:localhost', 'example.com:8443/localhost', ''],
+    ['%6Cocalhost.example.com', 'localhost.example.com', '/.well-known'],
+  ])('Keeps HTTPS when localhost appears in %s', (address, location, logDirectory) => {
+    const did = `did:webvh:scid:${address}`;
+
+    expect(getBaseUrl(did)).toBe(`https://${location}`);
+    expect(buildDidLogUrl(did)).toBe(`https://${location}${logDirectory}/did.jsonl`);
+  });
+
   test('Uses https for localhost DID host', () => {
     const did = 'did:webvh:scid:localhost%3A8000:test:path';
     expect(getBaseUrl(did)).toBe('https://localhost:8000/test/path');


### PR DESCRIPTION
The `localhost` substring downgrade reported in 2.7.4 is already removed on `main` by 8ebada3d5f90eda24f14c337ef2d3a714f9602ff, which requires HTTPS even for localhost. This PR protects that behavior with regression coverage and corrects the README's obsolete HTTP exception.

Coverage includes the reported public hostnames and path segments, encoded hosts and ports, and complete resolution with assertions on the URL passed to `fetch`. Local testing without HTTPS is documented using `resolveDIDFromLog`.

Fixes #185.

Validation: all 457 tests pass, along with Biome CI, TypeScript checking, and the build. Temporarily restoring the substring-based downgrade makes all 13 added cases fail; after restoring the implementation, all 43 tests in the affected files pass.
